### PR TITLE
fix(wgx-guard): indent inline python block

### DIFF
--- a/.github/workflows/wgx-guard.yml
+++ b/.github/workflows/wgx-guard.yml
@@ -38,24 +38,24 @@ jobs:
       - name: Run schema-lite check
         run: |
           python - <<'PY'
-import sys, yaml, pathlib
-p = pathlib.Path(".wgx/profile.yml")
-data = yaml.safe_load(p.read_text(encoding="utf-8"))
-required_top = ["version","env_priority","tooling","tasks"]
-missing = [k for k in required_top if k not in data]
-if missing:
-    print(f"::error::missing keys: {missing}")
-    sys.exit(1)
-envp = data["env_priority"]
-if not isinstance(envp, list) or not envp:
-    print("::error::env_priority must be a non-empty list")
-    sys.exit(1)
-for t in ["up","lint","test","build","smoke"]:
-    if t not in data["tasks"]:
-        print(f"::error::task '{t}' missing")
-        sys.exit(1)
-print("schema-lite ok")
-PY
+          import sys, yaml, pathlib
+          p = pathlib.Path(".wgx/profile.yml")
+          data = yaml.safe_load(p.read_text(encoding="utf-8"))
+          required_top = ["version","env_priority","tooling","tasks"]
+          missing = [k for k in required_top if k not in data]
+          if missing:
+              print(f"::error::missing keys: {missing}")
+              sys.exit(1)
+          envp = data["env_priority"]
+          if not isinstance(envp, list) or not envp:
+              print("::error::env_priority must be a non-empty list")
+              sys.exit(1)
+          for t in ["up","lint","test","build","smoke"]:
+              if t not in data["tasks"]:
+                  print(f"::error::task '{t}' missing")
+                  sys.exit(1)
+          print("schema-lite ok")
+          PY
 
       - name: (Optional) UV bootstrap (pyproject present)
         if: ${{ hashFiles('pyproject.toml') != '' }}


### PR DESCRIPTION
## Summary
- fix the indentation of the inline Python script in the schema-lite check step so it is part of the `run` block

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e16678469c832cad4716863ddf24d3