### PR TITLE
Fix template sync prefix trimming

### DIFF
--- a/scripts/sync-templates.sh
+++ b/scripts/sync-templates.sh
@@ -77,7 +77,7 @@ copy_into_metarepo_from_repo(){
   local name="$1"
   local src=""
   local -a files=()
-  local repo_root="${TMPDIR}/${name}/"
+  local repo_root="${TMPDIR}/${name}"
   for p in "${PATTERNS[@]}"; do
     case "$p" in
       templates/*) src="${p#templates/}" ;;
@@ -96,7 +96,7 @@ copy_into_metarepo_from_repo(){
 
     for f in "${files[@]}"; do
       # Remove TMPDIR/$name/ prefix for destination path
-      rel_f="${f#${repo_root}}"
+      rel_f="${f#${repo_root}/}"
       [[ -z "$rel_f" || "$rel_f" == "$f" ]] && continue
       dest="$PWD/templates/$rel_f"
       if ((DRYRUN==1)); then


### PR DESCRIPTION
## Summary
- ensure the template sync script strips the repository root without nested quoting that breaks ShellCheck

## Testing
- not run (shellcheck unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e29cd41944832c89d061e71e37a79e