### PR TITLE
fix: normalize repo root trimming in sync script

### DIFF
--- a/scripts/sync-templates.sh
+++ b/scripts/sync-templates.sh
@@ -76,7 +76,8 @@ clone_repo(){
 copy_into_metarepo_from_repo(){
   local name="$1"
   local src=""
-  local repo_root="${TMPDIR}/${name}/"
+  local repo_root="${TMPDIR}/${name}"
+  repo_root="${repo_root%/}/"
 
   for p in "${PATTERNS[@]}"; do
     case "$p" in


### PR DESCRIPTION
## Summary
- normalize the repo root prefix handling before trimming file paths in sync-templates.sh
- keep the ShellCheck-compliant parameter expansion when computing relative paths

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e29e4599d4832ca9c7bf652f635fb8