### PR TITLE
Fix shebang placement in sync-templates script

### DIFF
--- a/scripts/sync-templates.sh
+++ b/scripts/sync-templates.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# c2b: scripts/sync-templates.sh (ideal)
 set -euo pipefail
 shopt -s globstar nullglob
 


### PR DESCRIPTION
## Summary
- ensure scripts/sync-templates.sh starts with the shebang followed by the c2b mapping comment to satisfy ShellCheck

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e29f28a00c832cb655d1fd869e90a6