### PR TITLE
Align hauski references with migration guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,9 +4,9 @@
 Metarepo dient als zentraler, lernender Meta-Layer. Es spiegelt **kanonische Templates** (Workflows, Justfile, Docs, WGX-Profile) in Sub-Repos und **zieht Verbesserungen** aus Sub-Repos zurück (dialektisches Lernen).
 
 ## Repos
-- GitHub User: `alexdermohr`
-- Alle Repos öffentlich, **außer** `vault-gewebe` (privat).
-- Primäre Kinder (Beispiele): `weltgewebe`, `hauski-audio`, `semantAH`, `wgx`, `hauski`, `metarepo`.
+- GitHub Organisation: `heimgewebe`
+- Alle Repos öffentlich, **außer** `vault-gewebe` (privat bei `alexdermohr`).
+- Primäre Kinder (Beispiele): `weltgewebe`, `hauski`, `hauski-audio`, `semantAH`, `wgx`, `metarepo`.
 
 ## Rollen
 - **Metarepo**: Quelle der Wahrheit für Templates unter `templates/**`.

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 # metarepo
 
-**Docs:** siehe [docs/README.md](docs/README.md) · WGX-Master-Doku: https://github.com/alexdermohr/wgx
+**Docs:** siehe [docs/README.md](docs/README.md) · WGX-Master-Doku: https://github.com/heimgewebe/wgx
 
-Zentrale Steuerzentrale (Meta-Layer) für alle Repos von **alexdermohr**.
+Zentrale Steuerzentrale (Meta-Layer) für alle Repos von **heimgewebe**.
 Enthält:
 - **WGX-Master**: Referenzdoku + `.wgx/profile.yml`-Template
 - **Fleet-Orchestrierung**: `scripts/wgx` (up | list | run | doctor | validate | smoke)
@@ -15,7 +15,7 @@ Enthält:
 > Secrets für den Heavy-Workflow: `ASK_ENDPOINT_URL` z. B. `https://host/ask?q=hi&k=3&ns=default`, `METRICS_SNAPSHOT_URL` z. B. `https://host/metrics`.
 
 ## Repos (Quelle)
-Siehe `repos.yml`. Standard: alle öffentlichen Repos unter `alexdermohr`, **außer** `vault-gewebe` (privat).
+Siehe `repos.yml`. Standard: alle öffentlichen Repos unter `heimgewebe`, **außer** `vault-gewebe` (privat bei `alexdermohr`).
 
 ## Quickstart
 1. `just list` – Repos anzeigen

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # metarepo · Docs-Index (Tower)
 Diese Dokumente beschreiben **Fleet/Themen** des metarepo (Inventar, Verteilung, CI-Reusables, Drift).
-Für **WGX (Engine)** siehe: https://github.com/alexdermohr/wgx
+Für **WGX (Engine)** siehe: https://github.com/heimgewebe/wgx
 
 ## Inhalte
 - [Fleet-Operations](./fleet.md)

--- a/docs/ci-reusables.md
+++ b/docs/ci-reusables.md
@@ -2,7 +2,7 @@
 
 Das metarepo stellt wiederverwendbare GitHub-Actions-Workflows bereit,
 die Sub-Repos direkt referenzieren. Sie bilden die Fleet-Standards ab und
-verweisen bei Bedarf auf die WGX-Engine im [WGX-Repository](https://github.com/alexdermohr/wgx).
+verweisen bei Bedarf auf die WGX-Engine im [WGX-Repository](https://github.com/heimgewebe/wgx).
 
 ## Verfügbare Workflows (`templates/.github/workflows/`)
 - `wgx-guard.yml` – überprüft das Vorhandensein des WGX-Profils (`.wgx/profile.yml`).
@@ -20,7 +20,7 @@ on:
 
 jobs:
   guard:
-    uses: alexdermohr/metarepo/.github/workflows/wgx-guard.yml@main
+    uses: heimgewebe/metarepo/.github/workflows/wgx-guard.yml@main
 ```
 
 Zusätzliche Beispiel-Einbindung für den Smoke-Workflow:
@@ -28,7 +28,7 @@ Zusätzliche Beispiel-Einbindung für den Smoke-Workflow:
 ```yaml
 jobs:
   smoke:
-    uses: alexdermohr/metarepo/.github/workflows/wgx-smoke.yml@main
+    uses: heimgewebe/metarepo/.github/workflows/wgx-smoke.yml@main
     with:
       run_tests: true
 ```

--- a/docs/fleet.md
+++ b/docs/fleet.md
@@ -1,8 +1,8 @@
 # Fleet-Operations im metarepo
 
-Das **metarepo** ist die Flotten-Leitstelle für alle Repositories unter `alexdermohr`.
+Das **metarepo** ist die Flotten-Leitstelle für alle Repositories unter `heimgewebe`.
 Es hält das Inventar (`repos.yml`), verteilt Templates/CI-Reusables und stößt WGX-Läufe an.
-Die kanonische WGX-Dokumentation bleibt im [WGX-Repository](https://github.com/alexdermohr/wgx).
+Die kanonische WGX-Dokumentation bleibt im [WGX-Repository](https://github.com/heimgewebe/wgx).
 
 ## Verantwortungsabgrenzung
 - **metarepo**

--- a/docs/repos.yml.md
+++ b/docs/repos.yml.md
@@ -10,15 +10,18 @@ mode: static
 
 # GitHub-Owner/Organisation der Fleet
 github:
-  owner: alexdermohr
+  owner: heimgewebe
 
 # Statische Fleet-Liste (genutzt, wenn mode: static)
 repos:
   - name: weltgewebe
-    url: https://github.com/alexdermohr/weltgewebe
+    url: https://github.com/heimgewebe/weltgewebe
+    default_branch: main
+  - name: hauski
+    url: https://github.com/heimgewebe/hausKI
     default_branch: main
   - name: hauski-audio
-    url: https://github.com/alexdermohr/hauski-audio
+    url: https://github.com/heimgewebe/hauski-audio
     default_branch: main
     depends_on:
       - hauski
@@ -26,10 +29,10 @@ repos:
 static:
   include:
     - name: semantAH
-      url: https://github.com/alexdermohr/semantAH
+      url: https://github.com/heimgewebe/semantAH
       default_branch: main
     - name: wgx
-      url: https://github.com/alexdermohr/wgx
+      url: https://github.com/heimgewebe/wgx
       default_branch: main
 ```
 
@@ -42,8 +45,8 @@ static:
 - `static.include`: Ergänzende Repos, z. B. wenn `repos` leer bleiben soll. Aufbau identisch zu `repos`.
 
 ## Standard-Policy
-- Fleet umfasst alle **öffentlichen** Repos unter `alexdermohr`.
-- Ausnahme: `vault-gewebe` bleibt aus Datenschutzgründen ausgeschlossen.
+- Fleet umfasst alle **öffentlichen** Repos unter `heimgewebe`.
+- Ausnahme: `vault-gewebe` bleibt aus Datenschutzgründen ausgeschlossen (liegt weiter bei `alexdermohr`).
 
 ## Praxis-Tipps
 - Für einmalige Pushes `scripts/sync-templates.sh --repos-from repos.yml --pattern "templates/.github/workflows/*.yml"`.

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -26,4 +26,4 @@ Setze immer `--dry-run`, wenn du neue Muster ausprobierst.
 - Nutze Pull-Lernen, um Verbesserungen zurückzuholen.
 - Bei harten Abweichungen neue Fleet-Regel definieren (z. B. repo-spezifische Ausnahme im Ziel-Repo dokumentieren).
 
-> 🔗 Deep-Dive zu WGX-spezifischen Settings siehe [WGX-Doku](https://github.com/alexdermohr/wgx).
+> 🔗 Deep-Dive zu WGX-spezifischen Settings siehe [WGX-Doku](https://github.com/heimgewebe/wgx).

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -4,7 +4,7 @@ Kurzer Spickzettel für die häufigsten Stolpersteine rund um Fleet-Sync & WGX.
 
 ## 1. `wgx` nicht im PATH
 - Symptom: CI-Job bricht mit `command not found: wgx` ab.
-- Fix: Installationsschritte aus der [WGX-Doku](https://github.com/alexdermohr/wgx) in den Workflow einbauen (z. B. Setup-Script
+- Fix: Installationsschritte aus der [WGX-Doku](https://github.com/heimgewebe/wgx) in den Workflow einbauen (z. B. Setup-Script
   vor den Guard-Checks ausführen).
 
 ## 2. CI ohne `uv`

--- a/docs/wgx-stub.md
+++ b/docs/wgx-stub.md
@@ -2,7 +2,7 @@
 
 Das metarepo liefert nur **Verweise** auf die kanonische WGX-Dokumentation.
 Alle inhaltlichen Details (Policies, CLI-Referenz, Troubleshooting) liegen im
-[WGX-Repository](https://github.com/alexdermohr/wgx).
+[WGX-Repository](https://github.com/heimgewebe/wgx).
 
 ## Zweck des Stubs
 - Einheitliche Platzhalter-Datei (`docs/wgx-konzept.md`) in allen Sub-Repos.
@@ -15,7 +15,7 @@ Sub-Repos sollen sie **nicht** eigenständig erweitern, sondern auf neue Inhalte
 
 ```markdown
 # WGX – Einstieg
-Mehr dazu: https://github.com/alexdermohr/wgx
+Mehr dazu: https://github.com/heimgewebe/wgx
 ```
 
 ## Änderungen am Stub

--- a/repos.yml
+++ b/repos.yml
@@ -2,28 +2,28 @@
 mode: static
 
 github:
-  owner: alexdermohr
+  owner: heimgewebe
 
 repos:
   - name: weltgewebe
-    url: https://github.com/alexdermohr/weltgewebe
+    url: https://github.com/heimgewebe/weltgewebe
     default_branch: main
   - name: hauski
-    url: https://github.com/alexdermohr/hauski
+    url: https://github.com/heimgewebe/hausKI
     default_branch: main
   - name: hauski-audio
-    url: https://github.com/alexdermohr/hauski-audio
+    url: https://github.com/heimgewebe/hauski-audio
     default_branch: main
     depends_on:
       - hauski
   - name: semantAH
-    url: https://github.com/alexdermohr/semantAH
+    url: https://github.com/heimgewebe/semantAH
     default_branch: main
   - name: wgx
-    url: https://github.com/alexdermohr/wgx
+    url: https://github.com/heimgewebe/wgx
     default_branch: main
   - name: tools
-    url: https://github.com/alexdermohr/tools
+    url: https://github.com/heimgewebe/tools
     default_branch: main
 
 # exclude:

--- a/scripts/sync-templates.sh
+++ b/scripts/sync-templates.sh
@@ -9,7 +9,7 @@ yellow(){ printf "\e[33m%s\e[0m\n" "$*"; }
 log()   { printf "%s\n" "$*" >&2; }
 
 usage(){
-  local default_owner="${GITHUB_OWNER:-alexdermohr}"
+  local default_owner="${GITHUB_OWNER:-heimgewebe}"
   cat <<USG
 Usage:
   $0 --pull-from <repo-name>  --pattern "<glob>" [--pattern "..."] [--dry-run]
@@ -30,7 +30,7 @@ USG
 REPO_FROM=""; REPO_TO=""
 REPOS_FROM_FILE=""
 PATTERNS=()
-OWNER="${GITHUB_OWNER:-alexdermohr}"
+OWNER="${GITHUB_OWNER:-heimgewebe}"
 DRYRUN=0
 
 while [[ $# -gt 0 ]]; do

--- a/scripts/wgx-doctor
+++ b/scripts/wgx-doctor
@@ -5,7 +5,7 @@ usage(){ echo "Usage: $0 --repo <name> [--patterns \"glob1,glob2\"]"; }
 
 REPO=""
 PATTERNS="templates/.github/workflows/*.yml,templates/Justfile,templates/docs/**,templates/.wgx/profile.yml"
-OWNER="${GITHUB_OWNER:-alexdermohr}"
+OWNER="${GITHUB_OWNER:-heimgewebe}"
 
 while [[ $# -gt 0 ]]; do
   case "$1" in

--- a/templates/docs/wgx-konzept.md
+++ b/templates/docs/wgx-konzept.md
@@ -1,2 +1,2 @@
 # WGX – Einstieg
-Mehr dazu: https://github.com/alexdermohr/wgx
+Mehr dazu: https://github.com/heimgewebe/wgx


### PR DESCRIPTION
## Summary
- keep the primary repo list in AGENTS.md referencing the canonical hauski slug while retaining the new heimgewebe namespace
- update the repos.yml documentation sample so the entry name and dependency refer to hauski while URLs use the renamed hausKI path
- adjust repos.yml to mirror the documented naming so downstream tooling continues to resolve the hauski repository

## Testing
- no tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e4cb75e86c832cb56d93f88f370a96