### PR TITLE
chore: clarify shellcheck guidance for repo_root expansion

### DIFF
--- a/scripts/sync-templates.sh
+++ b/scripts/sync-templates.sh
@@ -115,7 +115,7 @@ copy_into_metarepo_from_repo(){
       [[ -z "$f" ]] && continue
 
       # Pfad relativ zum Repo-Root bestimmen
-      # (Pattern intentionally unquoted to satisfy ShellCheck SC2295.)
+      # ShellCheck SC2295: repo_root must stay unquoted inside the parameter expansion.
       local rel_f="${f#${repo_root}}"
       [[ -z "$rel_f" || "$rel_f" == "$f" ]] && continue
 


### PR DESCRIPTION
## Summary
- clarify the comment explaining why `repo_root` must remain unquoted inside the `${f#...}` expansion so that ShellCheck SC2295 stays green

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e4d3f61638832cb9ef1fcc19052a60