### PR TITLE
fix: clarify repo root stripping comment

### DIFF
--- a/scripts/sync-templates.sh
+++ b/scripts/sync-templates.sh
@@ -115,7 +115,7 @@ copy_into_metarepo_from_repo(){
       [[ -z "$f" ]] && continue
 
       # Pfad relativ zum Repo-Root bestimmen
-      # (Pattern intentionally unquoted to satisfy ShellCheck SC2295.)
+      # Strip the repo root prefix (pattern intentionally unquoted per ShellCheck SC2295).
       local rel_f="${f#${repo_root}}"
       [[ -z "$rel_f" || "$rel_f" == "$f" ]] && continue
 


### PR DESCRIPTION
## Summary
- clarify the inline comment around repo-root prefix stripping to highlight the ShellCheck-compliant parameter expansion

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e4d363fca8832c8d1d0a890f828e44