### PR TITLE
Fix repo_config pytest import path

### DIFF
--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,1 @@
+"""Utility scripts package for metarepo."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,9 @@
+"""Pytest configuration for metarepo tests."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))


### PR DESCRIPTION
## Summary
- add a package initializer so `scripts` can be imported during tests
- ensure pytest adds the repository root to `sys.path` for module resolution

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e52adf9fb8832c96285eaf45d50d77