### PR TITLE
fix(contracts): restore policy proposal required fields

### DIFF
--- a/.github/workflows/contracts-validate.yml
+++ b/.github/workflows/contracts-validate.yml
@@ -12,11 +12,15 @@ concurrency:
   workflow_dispatch: {}
   push:
     paths:
+      - "scripts/check-contract-json.py"
+      - "scripts/validate-contracts.sh"
       - "contracts/**"
       - "fixtures/**"
       - ".github/workflows/contracts-validate.yml"
   pull_request:
     paths:
+      - "scripts/check-contract-json.py"
+      - "scripts/validate-contracts.sh"
       - "contracts/**"
       - "fixtures/**"
       - ".github/workflows/contracts-validate.yml"
@@ -118,6 +122,9 @@ jobs:
       - uses: actions/checkout@v6
         with:
           persist-credentials: false
+
+      - name: Reject duplicate JSON keys and non-finite numbers
+        run: python3 scripts/check-contract-json.py contracts
 
       - name: Ensure Node available
         uses: actions/setup-node@v6

--- a/contracts/policy.weight_adjustment.v1.schema.json
+++ b/contracts/policy.weight_adjustment.v1.schema.json
@@ -35,7 +35,7 @@
             "properties": {
               "kind": { "const": "absolute" },
               "value": { "type": "number", "description": "New absolute value." },
-              "unit": { 
+              "unit": {
                 "type": "string",
                 "enum": ["weight", "probability", "score", "factor"],
                 "description": "Optional unit for absolute values (e.g., 'weight', 'probability', 'score', 'factor')."
@@ -50,10 +50,10 @@
             "properties": {
               "kind": { "const": "relative" },
               "value": { "type": "number", "minimum": -5.0, "maximum": 5.0, "description": "Relative multiplier or percentage change." },
-              "unit": { 
-                "type": "string", 
+              "unit": {
+                "type": "string",
                 "enum": ["percent", "factor"],
-                "description": "Unit required for relative changes to clarify semantics. Must be either 'percent' or 'factor'." 
+                "description": "Unit required for relative changes to clarify semantics. Must be either 'percent' or 'factor'."
               }
             },
             "required": ["kind", "value", "unit"],
@@ -115,7 +115,6 @@
       ]
     }
   },
-  "required": ["deltas"],
   "additionalProperties": false,
   "allOf": [
     {

--- a/scripts/check-contract-json.py
+++ b/scripts/check-contract-json.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Reject duplicate keys and non-finite numbers in contract JSON files."""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+def _reject_constant(value: str) -> None:
+    raise ValueError(f"non-finite JSON number {value}")
+
+
+def _object_without_duplicates(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    value: dict[str, Any] = {}
+    for key, item in pairs:
+        if key in value:
+            raise ValueError(f"duplicate JSON key {key!r}")
+        value[key] = item
+    return value
+
+
+def _files(paths: list[Path]) -> list[Path]:
+    files: set[Path] = set()
+    for path in paths:
+        if path.is_dir():
+            files.update(candidate for candidate in path.rglob("*.json") if candidate.is_file())
+        elif path.is_file():
+            files.add(path)
+        else:
+            raise ValueError(f"path does not exist: {path}")
+    return sorted(files)
+
+
+def check(paths: list[Path]) -> list[str]:
+    errors: list[str] = []
+    for path in _files(paths):
+        try:
+            json.loads(
+                path.read_text(encoding="utf-8"),
+                object_pairs_hook=_object_without_duplicates,
+                parse_constant=_reject_constant,
+            )
+        except (OSError, UnicodeError, json.JSONDecodeError, ValueError) as exc:
+            errors.append(f"{path}: {exc}")
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("paths", nargs="+", type=Path)
+    args = parser.parse_args()
+    errors = check(args.paths)
+    if errors:
+        for error in errors:
+            print(error)
+        return 1
+    print(f"contract JSON strict parse: valid ({len(_files(args.paths))} files)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate-contracts.sh
+++ b/scripts/validate-contracts.sh
@@ -10,6 +10,12 @@ if ! command -v npm > /dev/null 2>&1; then
   exit 1
 fi
 
+if ! command -v python3 > /dev/null 2>&1; then
+  echo "::error::python3 is required to strictly parse contract JSON"
+  exit 1
+fi
+python3 scripts/check-contract-json.py contracts
+
 # --- Optimization: Setup local AJV ---
 echo "::group::Setup Validator"
 # Robust mktemp for Linux/macOS/BSD

--- a/tests/test_contracts_semantics.py
+++ b/tests/test_contracts_semantics.py
@@ -6,6 +6,8 @@ their fixtures, ensuring semantic rules are enforced.
 import json
 import pytest
 import math
+import subprocess
+import sys
 from pathlib import Path
 from jsonschema import validate, ValidationError
 
@@ -118,3 +120,47 @@ def test_policy_weight_adjustment_rejects_non_finite_delta_value(non_finite_valu
     
     with pytest.raises(ValidationError, match=r".*non-finite.*"):
         validate_finite_numbers(instance)
+
+
+def test_policy_weight_adjustment_requires_all_top_level_fields():
+    schema = load_schema(SCHEMA_MAP["policy.weight_adjustment"])
+    valid = {
+        "version": "v1",
+        "basis_policy": "grabowski-routing-v0",
+        "ts": "2026-07-11T00:00:00Z",
+        "deltas": {
+            "route.direct_patch.weight": {
+                "kind": "relative",
+                "value": -0.1,
+                "unit": "factor",
+            }
+        },
+        "confidence": 0.7,
+        "evidence": {"decisions_analyzed": 10},
+    }
+    validate(instance=valid, schema=schema)
+    for required_field in (
+        "version",
+        "basis_policy",
+        "ts",
+        "deltas",
+        "confidence",
+        "evidence",
+    ):
+        invalid = dict(valid)
+        invalid.pop(required_field)
+        with pytest.raises(ValidationError):
+            validate(instance=invalid, schema=schema)
+
+
+def test_contract_json_guard_rejects_duplicate_keys(tmp_path):
+    duplicate = tmp_path / "duplicate.json"
+    duplicate.write_text('{"required":["a"],"required":["b"]}', encoding="utf-8")
+    completed = subprocess.run(
+        [sys.executable, "scripts/check-contract-json.py", str(duplicate)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode == 1
+    assert "duplicate JSON key 'required'" in completed.stdout


### PR DESCRIPTION
## Summary

- remove the duplicate top-level `required` key that silently weakened `policy.weight_adjustment.v1` to require only `deltas`
- restore enforcement of `version`, `basis_policy`, `ts`, `deltas`, `confidence`, and `evidence`
- reject duplicate JSON keys and non-finite JSON numbers before AJV compilation
- run the strict guard in local contract validation and the contracts GitHub workflow
- add regression tests for every required proposal field and for duplicate-key rejection

## Why

The duplicate key was valid enough for normal JSON parsers to accept, but the later key overwrote the earlier required-field list. Heimlern T003 discovered this while strictly loading the canonical schema; relying on the old contract would have made `schema-valid proposal` an overclaim.

## Validation

- 89 pytest tests passed
- Ruff: pass
- strict parse: 91 contract JSON files valid
- AJV compile/examples: pass
- actionlint: pass
- shell syntax/shellcheck: pass
- duplicate-key negative probe: rejected as expected
- `git diff --check`: pass