### PR TITLE
fix(ci): pin command-dispatch actions

### DIFF
--- a/.github/workflows/heimgewebe-command-dispatch.yml
+++ b/.github/workflows/heimgewebe-command-dispatch.yml
@@ -36,14 +36,14 @@ jobs:
     steps:
       - name: Create GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3
         with:
           app-id: ${{ secrets.HEIMGEWEBE_APP_ID }}
           private-key: ${{ secrets.HEIMGEWEBE_APP_PRIVATE_KEY }}
           owner: heimgewebe
 
       - name: Parse and dispatch command
-        uses: actions/github-script@v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9
         with:
           # Lesen, Antworten und Dispatch mit dem App-Installationstoken
           github-token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/reusable-check-action-refs.yml
+++ b/.github/workflows/reusable-check-action-refs.yml
@@ -22,3 +22,6 @@ jobs:
             fi
           done < <(find .github/workflows -type f -name '*.yml' -print0)
           exit $failed
+
+      - name: Require immutable refs in command dispatch
+        run: python3 scripts/ci/check_command_dispatch_action_pins.py

--- a/.github/workflows/validate-templates.yml
+++ b/.github/workflows/validate-templates.yml
@@ -14,12 +14,20 @@ defaults:
     paths:
       - 'templates/**'
       - 'scripts/**'
+      - '.github/workflows/heimgewebe-command-dispatch.yml'
+      - '.github/workflows/reusable-check-action-refs.yml'
+      - '.github/workflows/wgx-guard.yml'
+      - '.github/workflows/wgx-smoke.yml'
       - 'repos.yml'
       - '.github/workflows/validate-templates.yml'
   pull_request:
     paths:
       - 'templates/**'
       - 'scripts/**'
+      - '.github/workflows/heimgewebe-command-dispatch.yml'
+      - '.github/workflows/reusable-check-action-refs.yml'
+      - '.github/workflows/wgx-guard.yml'
+      - '.github/workflows/wgx-smoke.yml'
       - 'repos.yml'
       - '.github/workflows/validate-templates.yml'
 
@@ -29,6 +37,12 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98  # v6.0.1
+
+      - name: Require immutable refs in command dispatch
+        run: python3 scripts/ci/check_command_dispatch_action_pins.py
+
+      - name: Validate reusable WGX callers
+        run: python3 scripts/ci/check_wgx_reusable_callers.py
 
       - name: "Toolchain: setup yq (deterministic)"
         shell: bash

--- a/.github/workflows/wgx-guard.yml
+++ b/.github/workflows/wgx-guard.yml
@@ -16,6 +16,4 @@ jobs:
     # metarepo wird selbst wie ein Fleet-Repo behandelt und nutzt
     # die kanonische Guard-Definition aus heimgewebe/wgx.
     # Gepinnt auf Commit SHA für Sicherheit und Reproduzierbarkeit.
-    uses: heimgewebe/wgx/.github/workflows/wgx-guard.yml@52a12ff97c402d1aa718d534a84b0225e7718c82
-    with:
-      toolchain: stable
+    uses: heimgewebe/wgx/.github/workflows/wgx-guard.yml@3d823f9d26be276eef97742335dee857a64e1715

--- a/.github/workflows/wgx-smoke.yml
+++ b/.github/workflows/wgx-smoke.yml
@@ -16,6 +16,6 @@ jobs:
     # auch Smoke für das metarepo selbst wird über heimgewebe/wgx
     # zentral definiert.
     # Gepinnt auf Commit SHA für Sicherheit und Reproduzierbarkeit.
-    # This is the last WGX commit where wgx-smoke declares workflow_call.
-    # Newer WGX smoke migration remains a separate upstream contract task.
-    uses: heimgewebe/wgx/.github/workflows/wgx-smoke.yml@52a12ff97c402d1aa718d534a84b0225e7718c82
+    # Gepinnt auf den verifizierten WGX-Merge mit wiederverwendbarem Smoke
+    # und dauerhaft gebundenem Parser-/Security-Prerequisite.
+    uses: heimgewebe/wgx/.github/workflows/wgx-smoke.yml@b3b358f5bb8d26f087fcdaf25d308d439b22f583

--- a/.github/workflows/wgx-smoke.yml
+++ b/.github/workflows/wgx-smoke.yml
@@ -16,6 +16,6 @@ jobs:
     # auch Smoke für das metarepo selbst wird über heimgewebe/wgx
     # zentral definiert.
     # Gepinnt auf Commit SHA für Sicherheit und Reproduzierbarkeit.
+    # This is the last WGX commit where wgx-smoke declares workflow_call.
+    # Newer WGX smoke migration remains a separate upstream contract task.
     uses: heimgewebe/wgx/.github/workflows/wgx-smoke.yml@52a12ff97c402d1aa718d534a84b0225e7718c82
-    with:
-      toolchain: stable

--- a/docs/policies/github-actions-pinning.md
+++ b/docs/policies/github-actions-pinning.md
@@ -7,9 +7,16 @@ To ensure security, stability, and reproducibility of our CI/CD pipelines, we en
 1.  **Pin by Tag or Commit SHA**: All `uses:` directives in workflow files must reference a specific version tag (e.g., `@v2`, `@v1.2.3`) or a full commit SHA.
 2.  **No `@main` or `@master`**: References to mutable branch names like `@main` or `@master` are prohibited. This prevents upstream changes from breaking our builds unexpectedly or introducing malicious code.
 
+## Critical reusable workflows
+
+The reusable `heimgewebe-command-dispatch.yml` workflow is a privileged
+organization-wide control path. Every external `uses:` reference inside that
+workflow must use a full 40-character commit SHA. Major tags remain acceptable
+elsewhere under the general policy, but not inside the command dispatcher.
+
 ## Verification
 
-This policy is enforced by the `check-action-refs` job in our CI pipeline, which scans all workflow files for prohibited references.
+The `check-action-refs` job enforces both layers: the repository-wide prohibition on branch refs and the commit-only rule for the command dispatcher.
 
 ## Exceptions
 

--- a/docs/runbooks/usage.md
+++ b/docs/runbooks/usage.md
@@ -481,6 +481,6 @@ You can also see actionlint issues inline in VS Code via the [Trunk VS Code exte
 [pulsar-linter]: https://web.pulsar-edit.dev/packages/linter-github-actions
 [nova-extension]: https://extensions.panic.com/extensions/org.netwrk/org.netwrk.actionlint/
 [nova]: https://nova.app
-[trunk-io]: https://docs.trunk.io/docs
+[trunk-io]: https://docs.trunk.io/docs/check
 [trunk-docs]: https://docs.trunk.io/docs/check
 [trunk-vscode]: https://marketplace.visualstudio.com/items?itemName=trunk.io

--- a/scripts/ci/check_command_dispatch_action_pins.py
+++ b/scripts/ci/check_command_dispatch_action_pins.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Require immutable external refs in the reusable command dispatcher."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+USES_RE = re.compile(r"^\s*(?:-\s*)?uses:\s*([^\s#]+)")
+FULL_COMMIT_RE = re.compile(r"^[0-9a-f]{40}$")
+DEFAULT_WORKFLOW = Path(".github/workflows/heimgewebe-command-dispatch.yml")
+
+
+def check_workflow(path: Path) -> list[str]:
+    if not path.is_file():
+        return [f"workflow not found: {path}"]
+
+    findings: list[str] = []
+    external_count = 0
+    for line_number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+        match = USES_RE.match(line)
+        if match is None:
+            continue
+        value = match.group(1)
+        if len(value) >= 2 and value[0] == value[-1] and value[0] in {'"', "'"}:
+            value = value[1:-1]
+        if value.startswith("./"):
+            continue
+        external_count += 1
+        if "@" not in value:
+            findings.append(f"{path}:{line_number}: external uses ref has no @ revision: {value}")
+            continue
+        target, revision = value.rsplit("@", 1)
+        if not FULL_COMMIT_RE.fullmatch(revision):
+            findings.append(
+                f"{path}:{line_number}: {target}@{revision} is not pinned to a full lowercase commit SHA"
+            )
+
+    if external_count == 0:
+        findings.append(f"{path}: no external uses references found")
+    return findings
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = sys.argv[1:] if argv is None else argv
+    if len(args) > 1:
+        print("usage: check_command_dispatch_action_pins.py [workflow]", file=sys.stderr)
+        return 2
+    path = Path(args[0]) if args else DEFAULT_WORKFLOW
+    findings = check_workflow(path)
+    if findings:
+        for finding in findings:
+            print(f"FAIL: {finding}", file=sys.stderr)
+        return 1
+    print(f"PASS: all external uses references in {path} are full commit pins")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/check_wgx_reusable_callers.py
+++ b/scripts/ci/check_wgx_reusable_callers.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
 WGX_GUARD_MERGE = "3d823f9d26be276eef97742335dee857a64e1715"
-LAST_REUSABLE_WGX_SMOKE = "52a12ff97c402d1aa718d534a84b0225e7718c82"
+VERIFIED_WGX_SMOKE_MERGE = "b3b358f5bb8d26f087fcdaf25d308d439b22f583"
 
 
 def check_callers(root: Path = ROOT) -> list[str]:
@@ -35,14 +35,14 @@ def check_callers(root: Path = ROOT) -> list[str]:
         smoke = smoke_path.read_text(encoding="utf-8")
         expected = (
             "uses: heimgewebe/wgx/.github/workflows/wgx-smoke.yml@"
-            f"{LAST_REUSABLE_WGX_SMOKE}"
+            f"{VERIFIED_WGX_SMOKE_MERGE}"
         )
         if expected not in smoke:
-            findings.append("wgx-smoke caller is not bound to the last reusable contract")
+            findings.append("wgx-smoke caller is not bound to the verified reusable smoke merge")
         if "toolchain: stable" in smoke:
             findings.append("wgx-smoke caller passes undeclared input toolchain")
-        if "last WGX commit where wgx-smoke declares workflow_call" not in smoke:
-            findings.append("wgx-smoke caller does not document its compatibility boundary")
+        if "verifizierten WGX-Merge mit wiederverwendbarem Smoke" not in smoke:
+            findings.append("wgx-smoke caller does not document its verified contract boundary")
 
     return findings
 

--- a/scripts/ci/check_wgx_reusable_callers.py
+++ b/scripts/ci/check_wgx_reusable_callers.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Validate the pinned metarepo callers for reusable WGX workflows."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+WGX_GUARD_MERGE = "3d823f9d26be276eef97742335dee857a64e1715"
+LAST_REUSABLE_WGX_SMOKE = "52a12ff97c402d1aa718d534a84b0225e7718c82"
+
+
+def check_callers(root: Path = ROOT) -> list[str]:
+    findings: list[str] = []
+    guard_path = root / ".github" / "workflows" / "wgx-guard.yml"
+    smoke_path = root / ".github" / "workflows" / "wgx-smoke.yml"
+
+    if not guard_path.is_file():
+        findings.append(f"workflow not found: {guard_path}")
+    else:
+        guard = guard_path.read_text(encoding="utf-8")
+        expected = (
+            "uses: heimgewebe/wgx/.github/workflows/wgx-guard.yml@"
+            f"{WGX_GUARD_MERGE}"
+        )
+        if expected not in guard:
+            findings.append("wgx-guard caller is not bound to the verified WGX merge")
+        if "toolchain: stable" in guard:
+            findings.append("wgx-guard caller passes undeclared input toolchain")
+
+    if not smoke_path.is_file():
+        findings.append(f"workflow not found: {smoke_path}")
+    else:
+        smoke = smoke_path.read_text(encoding="utf-8")
+        expected = (
+            "uses: heimgewebe/wgx/.github/workflows/wgx-smoke.yml@"
+            f"{LAST_REUSABLE_WGX_SMOKE}"
+        )
+        if expected not in smoke:
+            findings.append("wgx-smoke caller is not bound to the last reusable contract")
+        if "toolchain: stable" in smoke:
+            findings.append("wgx-smoke caller passes undeclared input toolchain")
+        if "last WGX commit where wgx-smoke declares workflow_call" not in smoke:
+            findings.append("wgx-smoke caller does not document its compatibility boundary")
+
+    return findings
+
+
+def main() -> int:
+    findings = check_callers()
+    if findings:
+        for finding in findings:
+            print(f"FAIL: {finding}", file=sys.stderr)
+        return 1
+    print("PASS: WGX reusable callers match their declared contracts")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_command_dispatch_action_pins.py
+++ b/tests/test_command_dispatch_action_pins.py
@@ -1,0 +1,39 @@
+from pathlib import Path
+
+from scripts.ci.check_command_dispatch_action_pins import check_workflow
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_repository_command_dispatch_uses_full_commit_pins() -> None:
+    assert check_workflow(
+        ROOT / ".github" / "workflows" / "heimgewebe-command-dispatch.yml"
+    ) == []
+
+
+def test_mutable_major_tag_is_rejected(tmp_path: Path) -> None:
+    workflow = tmp_path / "workflow.yml"
+    workflow.write_text("steps:\n  - uses: actions/github-script@v8\n", encoding="utf-8")
+    assert "actions/github-script@v8 is not pinned" in check_workflow(workflow)[0]
+
+
+def test_abbreviated_sha_is_rejected(tmp_path: Path) -> None:
+    workflow = tmp_path / "workflow.yml"
+    workflow.write_text(
+        "steps:\n  - uses: actions/create-github-app-token@bcd2ba4\n",
+        encoding="utf-8",
+    )
+    assert "actions/create-github-app-token@bcd2ba4 is not pinned" in check_workflow(
+        workflow
+    )[0]
+
+
+def test_quoted_local_action_is_allowed(tmp_path: Path) -> None:
+    workflow = tmp_path / "workflow.yml"
+    workflow.write_text(
+        "steps:\n"
+        "  - uses: './local-action'\n"
+        "  - uses: 'actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3'\n",
+        encoding="utf-8",
+    )
+    assert check_workflow(workflow) == []

--- a/tests/test_wgx_reusable_callers.py
+++ b/tests/test_wgx_reusable_callers.py
@@ -19,9 +19,9 @@ def test_undeclared_input_is_rejected(tmp_path: Path) -> None:
         encoding="utf-8",
     )
     (workflows / "wgx-smoke.yml").write_text(
-        "# This is the last WGX commit where wgx-smoke declares workflow_call.\n"
+        "# Gepinnt auf den verifizierten WGX-Merge mit wiederverwendbarem Smoke\n"
         "uses: heimgewebe/wgx/.github/workflows/wgx-smoke.yml@"
-        "52a12ff97c402d1aa718d534a84b0225e7718c82\n",
+        "b3b358f5bb8d26f087fcdaf25d308d439b22f583\n",
         encoding="utf-8",
     )
     assert "wgx-guard caller passes undeclared input toolchain" in check_callers(tmp_path)
@@ -35,11 +35,31 @@ def test_unverified_guard_revision_is_rejected(tmp_path: Path) -> None:
         encoding="utf-8",
     )
     (workflows / "wgx-smoke.yml").write_text(
-        "# This is the last WGX commit where wgx-smoke declares workflow_call.\n"
+        "# Gepinnt auf den verifizierten WGX-Merge mit wiederverwendbarem Smoke\n"
         "uses: heimgewebe/wgx/.github/workflows/wgx-smoke.yml@"
-        "52a12ff97c402d1aa718d534a84b0225e7718c82\n",
+        "b3b358f5bb8d26f087fcdaf25d308d439b22f583\n",
         encoding="utf-8",
     )
     assert "wgx-guard caller is not bound to the verified WGX merge" in check_callers(
         tmp_path
+    )
+
+
+def test_legacy_smoke_revision_is_rejected(tmp_path: Path) -> None:
+    workflows = tmp_path / ".github" / "workflows"
+    workflows.mkdir(parents=True)
+    (workflows / "wgx-guard.yml").write_text(
+        "uses: heimgewebe/wgx/.github/workflows/wgx-guard.yml@"
+        "3d823f9d26be276eef97742335dee857a64e1715\n",
+        encoding="utf-8",
+    )
+    (workflows / "wgx-smoke.yml").write_text(
+        "# Gepinnt auf den verifizierten WGX-Merge mit wiederverwendbarem Smoke\n"
+        "uses: heimgewebe/wgx/.github/workflows/wgx-smoke.yml@"
+        "52a12ff97c402d1aa718d534a84b0225e7718c82\n",
+        encoding="utf-8",
+    )
+    assert (
+        "wgx-smoke caller is not bound to the verified reusable smoke merge"
+        in check_callers(tmp_path)
     )

--- a/tests/test_wgx_reusable_callers.py
+++ b/tests/test_wgx_reusable_callers.py
@@ -1,0 +1,45 @@
+from pathlib import Path
+
+from scripts.ci.check_wgx_reusable_callers import check_callers
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_repository_wgx_callers_match_declared_contracts() -> None:
+    assert check_callers(ROOT) == []
+
+
+def test_undeclared_input_is_rejected(tmp_path: Path) -> None:
+    workflows = tmp_path / ".github" / "workflows"
+    workflows.mkdir(parents=True)
+    (workflows / "wgx-guard.yml").write_text(
+        "uses: heimgewebe/wgx/.github/workflows/wgx-guard.yml@"
+        "3d823f9d26be276eef97742335dee857a64e1715\n"
+        "with:\n  toolchain: stable\n",
+        encoding="utf-8",
+    )
+    (workflows / "wgx-smoke.yml").write_text(
+        "# This is the last WGX commit where wgx-smoke declares workflow_call.\n"
+        "uses: heimgewebe/wgx/.github/workflows/wgx-smoke.yml@"
+        "52a12ff97c402d1aa718d534a84b0225e7718c82\n",
+        encoding="utf-8",
+    )
+    assert "wgx-guard caller passes undeclared input toolchain" in check_callers(tmp_path)
+
+
+def test_unverified_guard_revision_is_rejected(tmp_path: Path) -> None:
+    workflows = tmp_path / ".github" / "workflows"
+    workflows.mkdir(parents=True)
+    (workflows / "wgx-guard.yml").write_text(
+        "uses: heimgewebe/wgx/.github/workflows/wgx-guard.yml@main\n",
+        encoding="utf-8",
+    )
+    (workflows / "wgx-smoke.yml").write_text(
+        "# This is the last WGX commit where wgx-smoke declares workflow_call.\n"
+        "uses: heimgewebe/wgx/.github/workflows/wgx-smoke.yml@"
+        "52a12ff97c402d1aa718d534a84b0225e7718c82\n",
+        encoding="utf-8",
+    )
+    assert "wgx-guard caller is not bound to the verified WGX merge" in check_callers(
+        tmp_path
+    )


### PR DESCRIPTION
## Summary
- pin privileged command-dispatch actions to immutable full commit SHAs and enforce the policy with stdlib-only checks;
- update the changed Trunk documentation link;
- repair reusable WGX guard/smoke callers and validate their contract boundaries;
- replace the obsolete legacy smoke revision with verified WGX merge `b3b358f5bb8d26f087fcdaf25d308d439b22f583`;
- add a regression test that explicitly rejects the old smoke revision `52a12ff97c402d1aa718d534a84b0225e7718c82`.

## Upstream prerequisite
- WGX parser/security PR #638: merged and post-verified;
- WGX reusable smoke PR #637: merged and post-verified;
- published WGX merge used by this PR: `b3b358f5bb8d26f087fcdaf25d308d439b22f583`.

## Bound evidence
- base: `10daa1c84469dce76e93cdc24c47c1dfc5e156d6`
- head: `866f7e1ead02aaf2e73d76747633ad6151c50771`
- diff SHA-256: `2a635a9b8ee7d09565604f7a9d2408d70f7c7c5c36a06d904865439b774e177b`
- risk-weighted self-review: **PASS**

## Local validation
- `python3 scripts/ci/check_command_dispatch_action_pins.py`: PASS
- `python3 scripts/ci/check_wgx_reusable_callers.py`: PASS
- full Pytest suite: **97 passed**
- four changed workflow files parse as YAML mappings
- `git diff --check`: PASS
- exact end-to-end WGX smoke with WGX `b3b358f`, pinned `yq 4.52.4`, and this PR worktree: **PASS**; all 38 workflows validated

## Scope boundaries
- unchanged workflow action tags are not converted globally in this slice;
- the root-level `.wgx/profile.yml` remains backward-compatible and emits a deprecation note; nesting it under `wgx:` is separate work;
- GitHub CI on the bound head remains authoritative before merge.
