### PR TITLE
fix(ci): pin observatory reusable actions

### DIFF
--- a/.github/workflows/reusable-check-action-refs.yml
+++ b/.github/workflows/reusable-check-action-refs.yml
@@ -25,3 +25,6 @@ jobs:
 
       - name: Require immutable refs in command dispatch
         run: python3 scripts/ci/check_command_dispatch_action_pins.py
+
+      - name: Require immutable refs in reusable observatory validation
+        run: python3 scripts/ci/check_command_dispatch_action_pins.py .github/workflows/reusable-validate-observatory.yml

--- a/.github/workflows/reusable-validate-observatory.yml
+++ b/.github/workflows/reusable-validate-observatory.yml
@@ -37,10 +37,10 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
 
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6
 
       - name: Install ajv-cli
         if: ${{ env.AGENT_MODE == '' }}

--- a/.github/workflows/validate-templates.yml
+++ b/.github/workflows/validate-templates.yml
@@ -41,6 +41,9 @@ jobs:
       - name: Require immutable refs in command dispatch
         run: python3 scripts/ci/check_command_dispatch_action_pins.py
 
+      - name: Require immutable refs in reusable observatory validation
+        run: python3 scripts/ci/check_command_dispatch_action_pins.py .github/workflows/reusable-validate-observatory.yml
+
       - name: Validate reusable WGX callers
         run: python3 scripts/ci/check_wgx_reusable_callers.py
 

--- a/tests/test_command_dispatch_action_pins.py
+++ b/tests/test_command_dispatch_action_pins.py
@@ -11,6 +11,12 @@ def test_repository_command_dispatch_uses_full_commit_pins() -> None:
     ) == []
 
 
+def test_repository_observatory_reusable_uses_full_commit_pins() -> None:
+    assert check_workflow(
+        ROOT / ".github" / "workflows" / "reusable-validate-observatory.yml"
+    ) == []
+
+
 def test_mutable_major_tag_is_rejected(tmp_path: Path) -> None:
     workflow = tmp_path / "workflow.yml"
     workflow.write_text("steps:\n  - uses: actions/github-script@v8\n", encoding="utf-8")


### PR DESCRIPTION
## Kontext

Lenskit ruft über WGX den wiederverwendbaren metarepo-Workflow `reusable-validate-observatory.yml` auf. Der äußere Workflow war commitgepinnt, enthielt intern aber noch `actions/checkout@v6` und `actions/setup-node@v6`.

## Änderung

- beide internen Actions auf vollständige Commit-SHAs pinnen
- den vorhandenen Pin-Prüfer in `validate-templates` und `reusable-check-action-refs` auch auf den Observatory-Workflow anwenden
- Repository-Negativtest für diesen Workflow ergänzen

## Prüfung

- `ALLOW_NET=1 just validate` — grün
- 88 Python-Tests — grün
- Shell-Regressionstests — grün
- YAML-Validierung — grün
- Actionlint — grün
- fokussierter Pin-Checker — grün

## Review-Grenze

Der PR schließt nur die beiden von WGX transitiv erreichten beweglichen Action-Tags. Er behauptet keine vollständige metarepo-weite Action-Pin-Bereinigung und keine Schadcodefreiheit der gepinnten Commits.
