### PR TITLE
deps(actions): refresh core workflow actions

### DIFF
--- a/.github/workflows/adr-lint.yml
+++ b/.github/workflows/adr-lint.yml
@@ -24,7 +24,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Run ADR lint script
         run: |

--- a/.github/workflows/agent-mode-guard.yml
+++ b/.github/workflows/agent-mode-guard.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Show environment
         run: |

--- a/.github/workflows/agents-ci.yml
+++ b/.github/workflows/agents-ci.yml
@@ -24,13 +24,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v6  # v4 (major tag)
+      - uses: actions/checkout@v7  # v7 (major tag)
       - name: Setup Python
         uses: actions/setup-python@v6  # v5 (major tag)
         with:
           python-version: "3.11"
       - name: Cache uv
-        uses: actions/cache@v5  # v4 (major tag)
+        uses: actions/cache@v6  # v6 (major tag)
         with:
           path: |
             ~/.cache/uv

--- a/.github/workflows/ai-context-guard.yml
+++ b/.github/workflows/ai-context-guard.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup Python
         uses: actions/setup-python@v6
@@ -44,7 +44,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup Python
         uses: actions/setup-python@v6

--- a/.github/workflows/ci-shellcheck.yml
+++ b/.github/workflows/ci-shellcheck.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Install ShellCheck
         run: sudo apt-get update -yqq && sudo apt-get install -yqq shellcheck

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
       CARGO_INCREMENTAL: 0
     steps:
       - name: Checkout repository
-        uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98  # v6.0.1
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -191,7 +191,7 @@ jobs:
 
       - name: Cache Cargo artifacts
         if: ${{ hashFiles('**/Cargo.toml') != '' }}
-        uses: actions/cache@v5  # v4 (major tag)
+        uses: actions/cache@v6  # v6 (major tag)
         with:
           path: |
             ~/.cargo/registry
@@ -217,7 +217,7 @@ jobs:
 
       - name: Cache uv package cache
         if: ${{ hashFiles('**/pyproject.toml') != '' }}
-        uses: actions/cache@v5  # v4 (major tag)
+        uses: actions/cache@v6  # v6 (major tag)
         with:
           # OS-spezifische uv-Cachepfade
           path: |
@@ -234,7 +234,7 @@ jobs:
 
       - name: Cache uv virtual environment (requirements)
         if: ${{ hashFiles('**/requirements*.txt') != '' }}
-        uses: actions/cache@v5  # v4 (major tag)
+        uses: actions/cache@v6  # v6 (major tag)
         with:
           path: .venv
           key: ${{ runner.os }}-${{ runner.arch }}-uv-venv-${{ env.UV_VERSION }}-${{ env.PYTHON_VERSION }}-${{ hashFiles('**/requirements*.txt') }}
@@ -246,7 +246,7 @@ jobs:
 
       - name: Cache uv virtual environment (pyproject)
         if: ${{ hashFiles('**/pyproject.toml') != '' && hashFiles('**/requirements*.txt') == '' }}
-        uses: actions/cache@v5  # v4 (major tag)
+        uses: actions/cache@v6  # v6 (major tag)
         with:
           path: .venv
           key: ${{ runner.os }}-${{ runner.arch }}-uv-venv-${{ env.UV_VERSION }}-${{ env.PYTHON_VERSION }}-${{ hashFiles('**/pyproject.toml', '**/uv.lock', '**/poetry.lock') }}
@@ -350,7 +350,7 @@ jobs:
 
       - name: Cache lychee URL state
         if: runner.os == 'Linux' && hashFiles('.lychee.toml') != ''
-        uses: actions/cache@v5  # v4 (major tag)
+        uses: actions/cache@v6  # v6 (major tag)
         with:
           path: ~/.cache/lychee
           key: ${{ runner.os }}-lychee-${{ hashFiles('.lychee.toml', 'README.md', 'docs/**/*.md') }}
@@ -359,7 +359,7 @@ jobs:
 
       - name: Link check with Lychee (Linux)
         if: runner.os == 'Linux' && hashFiles('.lychee.toml') != ''
-        uses: lycheeverse/lychee-action@v2.8.0
+        uses: lycheeverse/lychee-action@v2.9.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           LYCHEE_CACHE_DIR: ~/.cache/lychee
@@ -487,7 +487,7 @@ jobs:
 
       - name: (web) Cache Playwright browsers
         if: ${{ steps.webvars.outputs.enabled == 'true' }}
-        uses: actions/cache@v5  # v4 (major tag)
+        uses: actions/cache@v6  # v6 (major tag)
         with:
           path: ~/.cache/ms-playwright
           # Version ist in devDependency gepinnt (@playwright/test 1.55.1)

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -29,7 +29,7 @@ jobs:
       actions: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
 

--- a/.github/workflows/contracts-index-guard.yml
+++ b/.github/workflows/contracts-index-guard.yml
@@ -23,7 +23,7 @@ jobs:
       run:
         shell: bash --noprofile --norc -euo pipefail {0}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Check contracts index
         run: |
           bash ./scripts/check-contracts-index.sh

--- a/.github/workflows/contracts-validate.yml
+++ b/.github/workflows/contracts-validate.yml
@@ -44,7 +44,7 @@ jobs:
       GH_PUSH_BEFORE: ${{ github.event.before }}
       PROTECTED_REGEX: '^(contracts|fixtures)/'
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -119,7 +119,7 @@ jobs:
     needs: [guard]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
 

--- a/.github/workflows/docs-linkcheck.yml
+++ b/.github/workflows/docs-linkcheck.yml
@@ -21,16 +21,16 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v6  # v4 (major tag)
+      - uses: actions/checkout@v7  # v7 (major tag)
       - name: Cache lychee URL state
-        uses: actions/cache@v5  # v4 (major tag)
+        uses: actions/cache@v6  # v6 (major tag)
         with:
           path: ~/.cache/lychee
           key: ${{ runner.os }}-lychee-${{ hashFiles('.lychee.toml', 'README.md', 'docs/**/*.md') }}
           restore-keys: |
             ${{ runner.os }}-lychee-
       - name: Check documentation links (uses .lychee.toml)
-        uses: lycheeverse/lychee-action@v2.8.0
+        uses: lycheeverse/lychee-action@v2.9.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           LYCHEE_CACHE_DIR: ~/.cache/lychee

--- a/.github/workflows/epistemic-guard.yml
+++ b/.github/workflows/epistemic-guard.yml
@@ -9,7 +9,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Run WGX epistemic guard
         uses: heimgewebe/wgx/.github/workflows/wgx-guard.yml@52a12ff97c402d1aa718d534a84b0225e7718c82
         with:

--- a/.github/workflows/fleet-doctor.yml
+++ b/.github/workflows/fleet-doctor.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Setup Python
         uses: actions/setup-python@v6
         with:

--- a/.github/workflows/fleet-drift-check.yml
+++ b/.github/workflows/fleet-drift-check.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Setup Python
         uses: actions/setup-python@v6
         with:

--- a/.github/workflows/fleet-generated-check.yml
+++ b/.github/workflows/fleet-generated-check.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Setup Python
         uses: actions/setup-python@v6
         with:

--- a/.github/workflows/heavy.yml
+++ b/.github/workflows/heavy.yml
@@ -22,7 +22,7 @@ jobs:
       ASK_ENDPOINT_URL: ${{ secrets.ASK_ENDPOINT_URL }}
       METRICS_SNAPSHOT_URL: ${{ secrets.METRICS_SNAPSHOT_URL }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Query /ask endpoint (optional)
         if: ${{ env.ASK_ENDPOINT_URL != '' && env.AGENT_MODE == '' }}

--- a/.github/workflows/impact-check.yml
+++ b/.github/workflows/impact-check.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Detect changes (contracts + manifest)
         id: changed

--- a/.github/workflows/integrity-sources-release.yml
+++ b/.github/workflows/integrity-sources-release.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98 # v6.0.1
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up Python
         uses: actions/setup-python@4f41a90a1f38628c7ccc608d05fbafe701bc20ae # v6.2.0

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -30,7 +30,7 @@ jobs:
     timeout-minutes: 20
     steps:
       # Für Core-Actions nutzen wir stabile Major-Tags statt SHAs, um 404-Risiken zu vermeiden.
-      - uses: actions/checkout@v6  # v4 (major tag)
+      - uses: actions/checkout@v7  # v7 (major tag)
       - name: Install lychee
         run: |
           chmod +x scripts/tools/lychee-pin.sh
@@ -39,7 +39,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Cache lychee URL state
-        uses: actions/cache@v5  # v4 (major tag)
+        uses: actions/cache@v6  # v6 (major tag)
         with:
           path: ~/.cache/lychee
           key: ${{ runner.os }}-lychee-${{ hashFiles('.lychee.toml', 'README.md', 'docs/**/*.md', 'contracts/**/*.md') }}

--- a/.github/workflows/metarepo-analyze.yml
+++ b/.github/workflows/metarepo-analyze.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Setup Python
         uses: actions/setup-python@v6

--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -27,7 +27,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Ensure Node for ajv-cli
         uses: actions/setup-node@v6

--- a/.github/workflows/net-probe.yml
+++ b/.github/workflows/net-probe.yml
@@ -25,7 +25,7 @@ jobs:
     timeout-minutes: 7
     if: ${{ vars.AGENT_MODE == '' }}
     steps:
-      - uses: actions/checkout@v6  # v4 (major tag)
+      - uses: actions/checkout@v7  # v7 (major tag)
 
       - name: Check outbound HTTPS access (GitHub, PyPI, crates.io)
         run: |

--- a/.github/workflows/org-assets.yml
+++ b/.github/workflows/org-assets.yml
@@ -34,13 +34,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v6  # v4 (major tag)
+      - uses: actions/checkout@v7  # v7 (major tag)
         with:
           fetch-depth: 0
       - uses: actions/setup-python@v6  # v5 (major tag)
         with:
           python-version: '3.11'
-      - uses: actions/cache@v5  # v4 (major tag)
+      - uses: actions/cache@v6  # v6 (major tag)
         with:
           path: |
             ~/.cache/uv

--- a/.github/workflows/organismus-readme-guard.yml
+++ b/.github/workflows/organismus-readme-guard.yml
@@ -31,7 +31,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Ensure README links to Heimgewebe-Organismus
         run: |

--- a/.github/workflows/readiness.yml
+++ b/.github/workflows/readiness.yml
@@ -13,7 +13,7 @@ jobs:
   readiness:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: actions/setup-python@v6
         with:
           python-version: '3.x'

--- a/.github/workflows/render-diagrams.yml
+++ b/.github/workflows/render-diagrams.yml
@@ -23,7 +23,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/reusable-check-action-refs.yml
+++ b/.github/workflows/reusable-check-action-refs.yml
@@ -8,7 +8,7 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Scan workflow refs
         run: |
           shopt -s nullglob

--- a/.github/workflows/reusable-ci.yml
+++ b/.github/workflows/reusable-ci.yml
@@ -28,7 +28,7 @@ jobs:
     timeout-minutes: 40
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup Just
         run: |

--- a/.github/workflows/reusable-validate-jsonl.yml
+++ b/.github/workflows/reusable-validate-jsonl.yml
@@ -50,7 +50,7 @@ jobs:
     timeout-minutes: 40
     steps:
       - name: Checkout caller repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup Node
         uses: actions/setup-node@v6

--- a/.github/workflows/reusable-validate-observatory.yml
+++ b/.github/workflows/reusable-validate-observatory.yml
@@ -37,7 +37,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
       - name: Setup Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6

--- a/.github/workflows/reusable-wgx-metrics.yml
+++ b/.github/workflows/reusable-wgx-metrics.yml
@@ -12,7 +12,7 @@ jobs:
   metrics:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Try just wgx metrics snapshot
         run: |
           set -euo pipefail

--- a/.github/workflows/toolchain-guard.yml
+++ b/.github/workflows/toolchain-guard.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Setup Node (for ajv-cli)
         uses: actions/setup-node@v6

--- a/.github/workflows/validate-templates.yml
+++ b/.github/workflows/validate-templates.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98  # v6.0.1
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
       - name: Require immutable refs in command dispatch
         run: python3 scripts/ci/check_command_dispatch_action_pins.py

--- a/.github/workflows/wgx-metrics.yml
+++ b/.github/workflows/wgx-metrics.yml
@@ -62,7 +62,7 @@ jobs:
       METRICS_POST_URL: ${{ secrets.post_url || inputs.post_url }}
       METRICS_POST_TOKEN: ${{ secrets.post_token }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Setup Node
         uses: actions/setup-node@v6


### PR DESCRIPTION
## Summary
- update Checkout to v7 across all workflows
- update Cache to v6 across all workflows
- update Lychee Action to v2.9.0
- preserve full-SHA pins at privileged or already immutable sites
- correct only the stale version comments on the changed lines

This current-main consolidation supersedes #637, #639 and #644. PR #635 is already satisfied on main by the full-SHA GitHub Script v9 pin and is not duplicated here.

## Validation
- 38 workflows parsed
- checksum-verified Actionlint passed
- command-dispatch and observatory full-SHA ratchets passed
- 5 targeted policy tests passed
- full suite: 98 passed
- diff SHA-256: `875f4f0a5b89b022c2a5798817ae60ff8be3024e2baaf6f59e35c224f2be4184`
