### PR TITLE
contracts: Consumerregister an Evidenz binden

### DIFF
--- a/.github/workflows/contracts-validate.yml
+++ b/.github/workflows/contracts-validate.yml
@@ -14,6 +14,10 @@ concurrency:
     paths:
       - "scripts/check-contract-json.py"
       - "scripts/validate-contracts.sh"
+      - "scripts/contracts/**"
+      - "tests/test_contract_consumers_registry.py"
+      - "pyproject.toml"
+      - "uv.lock"
       - "contracts/**"
       - "fixtures/**"
       - ".github/workflows/contracts-validate.yml"
@@ -21,6 +25,10 @@ concurrency:
     paths:
       - "scripts/check-contract-json.py"
       - "scripts/validate-contracts.sh"
+      - "scripts/contracts/**"
+      - "tests/test_contract_consumers_registry.py"
+      - "pyproject.toml"
+      - "uv.lock"
       - "contracts/**"
       - "fixtures/**"
       - ".github/workflows/contracts-validate.yml"
@@ -122,6 +130,20 @@ jobs:
       - uses: actions/checkout@v7
         with:
           persist-credentials: false
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        with:
+          enable-cache: true
+
+      - name: Install locked Python dependencies
+        run: uv sync --locked --no-install-project
+
+      - name: Validate producer and consumer evidence
+        run: uv run python scripts/contracts/validate_consumers.py
+
+      - name: Test producer and consumer evidence guard
+        run: uv run pytest -q tests/test_contract_consumers_registry.py
 
       - name: Reject duplicate JSON keys and non-finite numbers
         run: python3 scripts/check-contract-json.py contracts

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -1,96 +1,32 @@
-# Heimgewebe Contracts
+# Shared Contracts
 
-This directory contains the canonical JSON Schema definitions for the Heimgewebe fleet. These contracts are the **Single Source of Truth (SSOT)** for all data exchange between services.
+Metarepo owns the shared schema files stored below `contracts/`. Those files are the canonical byte definitions for the contracts they publish. Metarepo does **not** own the runtime state, delivery success or semantic correctness of producing and consuming systems.
 
-## Canonical URIs
+## Machine-readable governance
 
-The canonical base URI for all schemas is `https://schemas.heimgewebe.org/`. While this domain may not be operational for hosting, it serves as the stable identifier for validation and referencing.
+- `consumers.yaml` is the backward-compatible registry of known contracts, lifecycle state, replacement targets and reviewed producer/consumer claims.
+- `consumer-evidence.v1.json` binds those claims to exact default-branch commits, repository paths, line references and, for verified mirrors, byte hashes.
+- `scripts/contracts/validate_consumers.py` checks both files fail-closed.
 
-## Migration to Draft 2020-12
+Lifecycle values:
 
-All new contracts **MUST** use JSON Schema Draft 2020-12. Legacy contracts using older drafts (e.g. Draft 07) remain valid until explicitly migrated.
+- `active`: the schema is maintained as a current shared contract.
+- `compatibility`: the contract remains for a bounded migration or compatibility surface.
+- `historical`: the entry is retained for audit and must not be used as evidence of an active route.
 
-## Usage Guidelines
+Claim status values:
 
-**DO NOT** copy or embed these schemas into your service's source code directly. Doing so leads to drift and validation errors.
+- `verified`: the exact audited repository commit contains path evidence; mirror claims additionally require byte identity.
+- `unverified`: the relationship remains a review target and is not established as current.
+- `compatibility`: only a bounded compatibility relationship is asserted.
+- `historical`: the relationship is retained solely as historical evidence.
 
-### Correct Usage
-
-1.  **NPM Package**: Use the `@heimgewebe/contracts` package if your service is node-based.
-    *   **Note**: `metarepo/contracts` is the **SSOT** (canonical source). The `@heimgewebe/contracts` package is a **distribution artifact** built from this source.
-    *   **Publishing**: The package manifest in this directory exists for local validation and structure definition. Actual publishing to a registry is handled by the CI/Release pipeline (e.g. from a separate build step).
-    *   Install via your package manager (e.g., `pnpm`, `npm`):
-    ```bash
-    npm install @heimgewebe/contracts
-    ```
-    Import schemas from `node_modules/@heimgewebe/contracts/contracts/...` or use the helper:
-    ```js
-    const { contractsPath } = require('@heimgewebe/contracts');
-    const schemaPath = path.join(contractsPath, 'chronik/event.batch.v1.schema.json');
-    ```
-
-2.  **Vendoring (Automated)**: If you must vendor (e.g., non-JS services), use a script to download the specific version from the `metarepo` release artifacts.
-    *   **Strict Rule**: Vendoring **MUST** be automated and pinned (e.g., via Release Tag or Commit SHA + SHA256 verification). Do NOT blindly fetch from `main`.
-    *   Manual copying is prohibited to prevent semantic drift.
-
-3.  **Reference**: Use absolute canonical URIs (e.g., `https://schemas.heimgewebe.org/...`) when referencing schemas in `consumers.yaml` or other contracts.
-    *   `schema_ref` in events/artifacts **MUST** match the canonical `$id` of the referenced schema (e.g., the artifact schema or event schema).
-
-## Governance Metadata
-
-Governance metadata files are **NOT** JSON Schemas and are excluded from schema validation.
-
-*   `contracts/meta/`: Detailed governance definitions.
-*   `contracts/consumers.yaml`: Registry of contract consumption (producers/consumers).
-
-## Structure
-
-*   `events/`: Event envelopes and specific event type definitions.
-*   `plexer/`: Contracts related to the Plexer routing service.
-*   `heimlern/`: Contracts for Heimlern ingestion and state.
-*   `chronik/`: Contracts for Chronik event storage and batch retrieval.
-*   `integrity/`: Contracts for system integrity reporting.
-*   `knowledge/`: Contracts for the Knowledge Observatory.
+A `verified` claim proves repository coupling at the audited commit. It does not prove live runtime use, runtime health, delivery success, semantic correctness or future compatibility. The current evidence set covers the repositories already declared in `consumers.yaml`; it does not claim complete organization-wide discovery.
 
 ## Validation
 
-All schemas must be valid JSON Schema Draft 2020-12. Changes are validated via CI using `ajv-cli`.
-
-## Conventions
-
-- **SHA-256 (Canonical Form)**: `sha256:<64-hex-chars>`. Pattern: `^sha256:[a-f0-9]{64}$`.
-  (Ingress may accept relaxed formats; see Normalization Policy below.)
-
-## Schema Versioning Policy
-
-We apply **SemVer principles** (Semantic Versioning) but only encode **MAJOR** versions in filenames (e.g., `event.v1.schema.json`).
-
--   **Major Versions (Breaking)**: Require a new file (e.g., `v2`).
-    -   Migration Path: **Version Bump**. Consumers must explicitly upgrade.
--   **Minor/Patch Versions (Compatible)**: Applied in-place to the existing `v1` file.
-    -   Migration Path: **Fleet Cutover**. Consumers automatically receive new optional fields or relaxed constraints.
-
-## Normalization Policy
-
-**Policy:** *Lenient on ingest, strict on store.*
-
-To ensure robustness across the fleet while maintaining canonical persistence:
-
-1.  **Ingest (v1 Schemas)**
-    -   **`sha` is optional.**
-    -   **Lenient Pattern**: Inputs MAY include or omit the `sha256:` prefix and MAY use uppercase or mixed-case hex.
-    -   Consumers **MUST NOT** fail validation if `sha` is missing or strictly formatted in v1.
-
-2.  **Store / Persistence**
-    -   **Canonical Form**: `sha256:<lowercase-hex>`.
-    -   **Responsibility**: The consuming service (Store/Archivist) **MUST** normalize values before persistence.
-    -   Examples in this repository **MUST** use the canonical form.
-
-## Event Payload Policy
-
-To ensure long-term traceability:
-
--   **`sha` (Content Identity)**: SHOULD be present.
--   **`schema_ref` (Semantic Identity)**: SHOULD be present (Pattern: `https://schemas.heimgewebe.org/...`).
-    -   `schema_ref` identifies the validating schema, not the producer implementation.
--   **Consumer Behavior**: Consumers **MAY** warn if these fields are missing, but **MUST NOT** reject valid v1 events.
+```bash
+uv run python scripts/contracts/validate_consumers.py
+uv run pytest -q tests/test_contract_consumers_registry.py
+scripts/validate-contracts.sh
+```

--- a/contracts/consumer-evidence.v1.json
+++ b/contracts/consumer-evidence.v1.json
@@ -1,0 +1,1876 @@
+{
+  "schemaVersion": 1,
+  "kind": "metarepo_contract_consumer_evidence",
+  "observedAt": "2026-07-14T21:35:14+02:00",
+  "source": {
+    "repository": "heimgewebe/metarepo",
+    "commit": "894657cef6734ecaf64813e83fc0433212d8fd5d",
+    "auditJob": "grabowski-job-f8d92a1aa443",
+    "auditFinalizationReceiptSha256": "b4543d1156de83b0e97c48aca780bb2e55085316e05c35f997ae91d6eaa9fd64",
+    "method": "shallow_default_branch_clone_plus_fixed_string_repository_scan"
+  },
+  "scope": {
+    "repositories": [
+      {
+        "repository": "heimgewebe/aussensensor",
+        "commit": "f9c75995b61ee841321420789e8e6b6374384a2a",
+        "defaultBranch": "main"
+      },
+      {
+        "repository": "heimgewebe/chronik",
+        "commit": "2fc65efe06cd23baa2a2bdef39f5f099c8a5540b",
+        "defaultBranch": "main"
+      },
+      {
+        "repository": "heimgewebe/hausKI",
+        "commit": "2b2e4496613c856993e028e360e76abea70c7028",
+        "defaultBranch": "main"
+      },
+      {
+        "repository": "heimgewebe/heim-pc",
+        "commit": "140e84bc28d3b208a51e2edb1cb27c5946c38d49",
+        "defaultBranch": "main"
+      },
+      {
+        "repository": "heimgewebe/heimgeist",
+        "commit": "2d657297e9875cf0ec12932b3391fc4c0d8a246a",
+        "defaultBranch": "main"
+      },
+      {
+        "repository": "heimgewebe/heimlern",
+        "commit": "8dbebea6b253f9d2f41514a15d34e5166602e792",
+        "defaultBranch": "main"
+      },
+      {
+        "repository": "heimgewebe/leitstand",
+        "commit": "a5df64b478f998973be7ba4ac2936d1d12ba3ed1",
+        "defaultBranch": "main"
+      },
+      {
+        "repository": "heimgewebe/mitschreiber",
+        "commit": "3680bb7e14079c4b8ec3d0758605f7023ee11097",
+        "defaultBranch": "main"
+      },
+      {
+        "repository": "heimgewebe/plexer",
+        "commit": "e1099df6ccf1763c7e235d844ff09b2728b24601",
+        "defaultBranch": "main"
+      },
+      {
+        "repository": "heimgewebe/semantAH",
+        "commit": "c306e89105605778a382aa12c231f727c221cc74",
+        "defaultBranch": "main"
+      },
+      {
+        "repository": "heimgewebe/wgx",
+        "commit": "2f2aa2225838be1d029697348d9aa989ce7e62f9",
+        "defaultBranch": "main"
+      }
+    ],
+    "completeForDeclaredRepositories": true,
+    "completeForOrganization": false,
+    "githubCodeSearchComplete": false,
+    "githubCodeSearchLimitation": "The separate code-search quota was exhausted after ten exploratory queries; final evidence comes from eleven exact shallow main clones."
+  },
+  "contracts": [
+    {
+      "id": "event_backbone/aussen.event",
+      "schema": "contracts/aussen.event.schema.json",
+      "schemaExists": true,
+      "schemaSha256": "2410e7ccd2a94271d6b292d4e8df5a4190a111376f26ae509901c8995a888f37",
+      "lifecycle": "active",
+      "replacement": null
+    },
+    {
+      "id": "event_backbone/event.line",
+      "schema": "contracts/event.line.schema.json",
+      "schemaExists": true,
+      "schemaSha256": "9e26e15ed569383edfd743b5f3fab81fd389f7fea4ea1b423c6be16b1423b891",
+      "lifecycle": "active",
+      "replacement": null
+    },
+    {
+      "id": "event_backbone/heimgeist.insight",
+      "schema": "contracts/events/heimgeist.insight.v1.schema.json",
+      "schemaExists": true,
+      "schemaSha256": "2281ad813f4638c9a1db15dfd1fc92037c0650d968b240ad1a1dbf8885af5b39",
+      "lifecycle": "active",
+      "replacement": null
+    },
+    {
+      "id": "fixtures/chronik-fixtures",
+      "schema": "contracts/chronik-fixtures.schema.json",
+      "schemaExists": false,
+      "schemaSha256": null,
+      "lifecycle": "historical",
+      "replacement": null
+    },
+    {
+      "id": "metrics/fleet.health",
+      "schema": "contracts/fleet.health.schema.json",
+      "schemaExists": true,
+      "schemaSha256": "e743c67d043a7729ad6ca8887d80be033c444a4e67b56dced03826a0bb0869d5",
+      "lifecycle": "active",
+      "replacement": null
+    },
+    {
+      "id": "integrity/summary",
+      "schema": "contracts/integrity.summary.schema.json",
+      "schemaExists": true,
+      "schemaSha256": "4a347da189ada968f102b484bf69ce34fef4a492c6866b1e2dbeb0d80ebeb842",
+      "lifecycle": "active",
+      "replacement": null
+    },
+    {
+      "id": "knowledge/insights.daily",
+      "schema": "contracts/insights.daily.schema.json",
+      "schemaExists": true,
+      "schemaSha256": "f3610f837a16b26ba74141fe2701bde2875e178bf81259c98583e12fc53e449c",
+      "lifecycle": "active",
+      "replacement": null
+    },
+    {
+      "id": "knowledge/insights.daily.published",
+      "schema": "contracts/events/insights.daily.published.v1.schema.json",
+      "schemaExists": true,
+      "schemaSha256": "72dcb6515b1c74d6951e8794fa3cdaaf192eb142082acbf466109c1b37a0d635",
+      "lifecycle": "compatibility",
+      "replacement": "knowledge/insights.daily.published.v1"
+    },
+    {
+      "id": "knowledge/insights.daily.published.v1",
+      "schema": "contracts/events/insights.daily.published.v1.schema.json",
+      "schemaExists": true,
+      "schemaSha256": "72dcb6515b1c74d6951e8794fa3cdaaf192eb142082acbf466109c1b37a0d635",
+      "lifecycle": "active",
+      "replacement": null
+    },
+    {
+      "id": "knowledge/observatory",
+      "schema": "contracts/knowledge.observatory.schema.json",
+      "schemaExists": true,
+      "schemaSha256": "8da4fe8f04a010f957f9ba1769d444991eaf2ddb378c8f696cd6d026e7c9d153",
+      "lifecycle": "active",
+      "replacement": null
+    },
+    {
+      "id": "knowledge/knowledge.observatory.published.v1",
+      "schema": "contracts/events/knowledge.observatory.published.v1.schema.json",
+      "schemaExists": true,
+      "schemaSha256": "ff70e502fc9b1488d96ee68918f01db7e77447315f9eb535ea8c004b23d194ff",
+      "lifecycle": "active",
+      "replacement": null
+    },
+    {
+      "id": "os_context/state",
+      "schema": "contracts/os.context.state.schema.json",
+      "schemaExists": true,
+      "schemaSha256": "4eaf7bef863aeee699f6c2688da56c472945f8a9fdce7639852bc9f9127217e5",
+      "lifecycle": "active",
+      "replacement": null
+    },
+    {
+      "id": "os_context/text.embed",
+      "schema": "contracts/os.context.text.embed.schema.json",
+      "schemaExists": true,
+      "schemaSha256": "a38400d04ab1428905743c15a966acaa7aec8072e66cb9df8133e1b6a0889ff3",
+      "lifecycle": "active",
+      "replacement": null
+    },
+    {
+      "id": "policy/decision",
+      "schema": "contracts/policy.decision.schema.json",
+      "schemaExists": true,
+      "schemaSha256": "2de890b578285100f57839d6fe7f8dd43326fa9c1c7c84759dd5a3604c025bce",
+      "lifecycle": "historical",
+      "replacement": null
+    },
+    {
+      "id": "policy/feedback",
+      "schema": "contracts/policy.feedback.schema.json",
+      "schemaExists": true,
+      "schemaSha256": "b718aedfb33d00330602cdb5fe1168693c0137df87f6afcf4e0bf33d8b0821b3",
+      "lifecycle": "historical",
+      "replacement": null
+    },
+    {
+      "id": "policy/snapshot",
+      "schema": "contracts/policy.snapshot.schema.json",
+      "schemaExists": true,
+      "schemaSha256": "6a51ba574f9d0575b8c6298eda4b08a6f483035502a2d5511f5f8fb831e5fbe7",
+      "lifecycle": "historical",
+      "replacement": null
+    },
+    {
+      "id": "policy/heimlern.ingest.state.v1",
+      "schema": "contracts/heimlern.ingest.state.schema.json",
+      "schemaExists": true,
+      "schemaSha256": "accd33e387f954d2dfc2e96b96e2941847e275830c01fe8142fc44618b2c089f",
+      "lifecycle": "historical",
+      "replacement": null
+    },
+    {
+      "id": "heim-pc/state.index",
+      "schema": "contracts/heim-pc/state/heim-pc.state.index.schema.json",
+      "schemaExists": true,
+      "schemaSha256": "69eeb45661c9f1a893ad4fa655b4fa997ea59e2655c623e5b9b7464bf15a4193",
+      "lifecycle": "historical",
+      "replacement": null
+    },
+    {
+      "id": "heim-pc/state.repos",
+      "schema": "contracts/heim-pc/state/heim-pc.state.repos.schema.json",
+      "schemaExists": true,
+      "schemaSha256": "c7b72cdb428335fdb9bf5ee7ca36ec1a012fb01685cf5ff6d8175ab7198989b7",
+      "lifecycle": "historical",
+      "replacement": null
+    },
+    {
+      "id": "heim-pc/state.uncertainties",
+      "schema": "contracts/heim-pc/state/heim-pc.state.uncertainties.schema.json",
+      "schemaExists": true,
+      "schemaSha256": "d27806094c53d725f77f994d4cb8d95cef30b57e43753501aa664573b6a6cd68",
+      "lifecycle": "historical",
+      "replacement": null
+    },
+    {
+      "id": "heim-pc/state.insights",
+      "schema": "contracts/heim-pc/state/heim-pc.state.insights.schema.json",
+      "schemaExists": true,
+      "schemaSha256": "69776f3d636b1ba367835231f492453e0bf76a9c39d6a62799f25c6dd05d42d3",
+      "lifecycle": "historical",
+      "replacement": null
+    },
+    {
+      "id": "heim-pc/state.drift",
+      "schema": "contracts/heim-pc/state/heim-pc.state.drift.schema.json",
+      "schemaExists": true,
+      "schemaSha256": "9f0cdb52bf886ec84cf022a4759076d6f2c8ba829b47e1de9def0276f0efd2fd",
+      "lifecycle": "historical",
+      "replacement": null
+    },
+    {
+      "id": "heim-pc/config.zones",
+      "schema": "contracts/heim-pc/config/zones.schema.json",
+      "schemaExists": true,
+      "schemaSha256": "8eb66dc4a82d863fb62d1b4023e7216ffd5ad584445016f8567e3e767797fcd8",
+      "lifecycle": "compatibility",
+      "replacement": null
+    }
+  ],
+  "claims": [
+    {
+      "id": "event_backbone/aussen.event::producer::aussensensor",
+      "contract": "event_backbone/aussen.event",
+      "role": "producer",
+      "repository": "heimgewebe/aussensensor",
+      "commit": "f9c75995b61ee841321420789e8e6b6374384a2a",
+      "status": "verified",
+      "mode": null,
+      "files": [
+        ".github/workflows/contracts-drift.yml",
+        ".github/workflows/fixtures-validate.yml",
+        ".github/workflows/validate-aussen-fixtures.yml",
+        ".github/workflows/validate-aussen.yml"
+      ],
+      "evidence": [
+        {
+          "path": ".github/workflows/contracts-drift.yml",
+          "line": 21,
+          "kind": "ci_reference"
+        },
+        {
+          "path": ".github/workflows/fixtures-validate.yml",
+          "line": 31,
+          "kind": "ci_reference"
+        },
+        {
+          "path": ".github/workflows/validate-aussen-fixtures.yml",
+          "line": 64,
+          "kind": "ci_reference"
+        },
+        {
+          "path": ".github/workflows/validate-aussen.yml",
+          "line": 23,
+          "kind": "ci_reference"
+        }
+      ],
+      "note": "Current default-branch files reference the exact schema basename; this proves repository coupling, not live production.",
+      "doesNotEstablish": [
+        "runtime_use",
+        "runtime_health",
+        "semantic_correctness",
+        "future_compatibility"
+      ]
+    },
+    {
+      "id": "event_backbone/aussen.event::consumer::aussensensor",
+      "contract": "event_backbone/aussen.event",
+      "role": "consumer",
+      "repository": "heimgewebe/aussensensor",
+      "commit": "f9c75995b61ee841321420789e8e6b6374384a2a",
+      "status": "verified",
+      "mode": "mirror",
+      "files": [
+        "contracts/aussen.event.schema.json"
+      ],
+      "evidence": [
+        {
+          "path": ".github/workflows/contracts-drift.yml",
+          "line": 21,
+          "kind": "ci_reference"
+        },
+        {
+          "path": ".github/workflows/fixtures-validate.yml",
+          "line": 31,
+          "kind": "ci_reference"
+        },
+        {
+          "path": ".github/workflows/validate-aussen-fixtures.yml",
+          "line": 64,
+          "kind": "ci_reference"
+        },
+        {
+          "path": ".github/workflows/validate-aussen.yml",
+          "line": 23,
+          "kind": "ci_reference"
+        }
+      ],
+      "note": "Current default-branch files reference the exact schema basename; this proves repository coupling, not runtime use.",
+      "doesNotEstablish": [
+        "runtime_use",
+        "runtime_health",
+        "semantic_correctness",
+        "future_compatibility"
+      ],
+      "mirrorChecks": [
+        {
+          "path": "contracts/aussen.event.schema.json",
+          "exists": true,
+          "sha256": "2410e7ccd2a94271d6b292d4e8df5a4190a111376f26ae509901c8995a888f37",
+          "matches_canonical": true
+        }
+      ]
+    },
+    {
+      "id": "event_backbone/aussen.event::consumer::chronik",
+      "contract": "event_backbone/aussen.event",
+      "role": "consumer",
+      "repository": "heimgewebe/chronik",
+      "commit": "2fc65efe06cd23baa2a2bdef39f5f099c8a5540b",
+      "status": "verified",
+      "mode": "reference-only",
+      "files": [
+        ".github/workflows/validate-aussen-fixtures.yml",
+        ".github/workflows/validate-aussen.yml",
+        ".ai-context.yml",
+        "README.md"
+      ],
+      "evidence": [
+        {
+          "path": ".github/workflows/validate-aussen-fixtures.yml",
+          "line": 18,
+          "kind": "ci_reference"
+        },
+        {
+          "path": ".github/workflows/validate-aussen.yml",
+          "line": 23,
+          "kind": "ci_reference"
+        },
+        {
+          "path": ".ai-context.yml",
+          "line": 54,
+          "kind": "documentation_or_data_reference"
+        },
+        {
+          "path": "README.md",
+          "line": 21,
+          "kind": "documentation_or_data_reference"
+        }
+      ],
+      "note": "Current default-branch files reference the exact schema basename; this proves repository coupling, not runtime use.",
+      "doesNotEstablish": [
+        "runtime_use",
+        "runtime_health",
+        "semantic_correctness",
+        "future_compatibility"
+      ]
+    },
+    {
+      "id": "event_backbone/event.line::producer::chronik",
+      "contract": "event_backbone/event.line",
+      "role": "producer",
+      "repository": "heimgewebe/chronik",
+      "commit": "2fc65efe06cd23baa2a2bdef39f5f099c8a5540b",
+      "status": "unverified",
+      "mode": null,
+      "files": [
+        "README.md",
+        "docs/event-contracts.md"
+      ],
+      "evidence": [
+        {
+          "path": "README.md",
+          "line": 22,
+          "kind": "documentation_or_data_reference"
+        },
+        {
+          "path": "docs/event-contracts.md",
+          "line": 11,
+          "kind": "documentation_or_data_reference"
+        }
+      ],
+      "note": "The producer relationship remains a review target and is not established by current repository evidence.",
+      "doesNotEstablish": [
+        "runtime_use",
+        "runtime_health",
+        "semantic_correctness",
+        "future_compatibility"
+      ]
+    },
+    {
+      "id": "event_backbone/event.line::consumer::chronik",
+      "contract": "event_backbone/event.line",
+      "role": "consumer",
+      "repository": "heimgewebe/chronik",
+      "commit": "2fc65efe06cd23baa2a2bdef39f5f099c8a5540b",
+      "status": "verified",
+      "mode": "reference-only",
+      "files": [
+        "README.md",
+        "docs/event-contracts.md"
+      ],
+      "evidence": [
+        {
+          "path": "README.md",
+          "line": 22,
+          "kind": "documentation_or_data_reference"
+        },
+        {
+          "path": "docs/event-contracts.md",
+          "line": 11,
+          "kind": "documentation_or_data_reference"
+        }
+      ],
+      "note": "Current default-branch files reference the exact schema basename; this proves repository coupling, not runtime use.",
+      "doesNotEstablish": [
+        "runtime_use",
+        "runtime_health",
+        "semantic_correctness",
+        "future_compatibility"
+      ]
+    },
+    {
+      "id": "event_backbone/heimgeist.insight::producer::heimgeist",
+      "contract": "event_backbone/heimgeist.insight",
+      "role": "producer",
+      "repository": "heimgewebe/heimgeist",
+      "commit": "2d657297e9875cf0ec12932b3391fc4c0d8a246a",
+      "status": "unverified",
+      "mode": null,
+      "files": [
+        "docs/specs/heimgeist-insight-v1.md"
+      ],
+      "evidence": [
+        {
+          "path": "docs/specs/heimgeist-insight-v1.md",
+          "line": 3,
+          "kind": "documentation_or_data_reference"
+        }
+      ],
+      "note": "The producer relationship remains a review target and is not established by current repository evidence.",
+      "doesNotEstablish": [
+        "runtime_use",
+        "runtime_health",
+        "semantic_correctness",
+        "future_compatibility"
+      ]
+    },
+    {
+      "id": "event_backbone/heimgeist.insight::consumer::chronik",
+      "contract": "event_backbone/heimgeist.insight",
+      "role": "consumer",
+      "repository": "heimgewebe/chronik",
+      "commit": "2fc65efe06cd23baa2a2bdef39f5f099c8a5540b",
+      "status": "verified",
+      "mode": "reference-only",
+      "files": [
+        "validation.py",
+        "docs/heimgeist_spec.md"
+      ],
+      "evidence": [
+        {
+          "path": "validation.py",
+          "line": 94,
+          "kind": "executable_or_test_reference"
+        },
+        {
+          "path": "docs/heimgeist_spec.md",
+          "line": 3,
+          "kind": "documentation_or_data_reference"
+        }
+      ],
+      "note": "Current default-branch files reference the exact schema basename; this proves repository coupling, not runtime use.",
+      "doesNotEstablish": [
+        "runtime_use",
+        "runtime_health",
+        "semantic_correctness",
+        "future_compatibility"
+      ]
+    },
+    {
+      "id": "event_backbone/heimgeist.insight::consumer::semantAH",
+      "contract": "event_backbone/heimgeist.insight",
+      "role": "consumer",
+      "repository": "heimgewebe/semantAH",
+      "commit": "c306e89105605778a382aa12c231f727c221cc74",
+      "status": "unverified",
+      "mode": "reference-only",
+      "files": [],
+      "evidence": [],
+      "note": "No exact reference to the schema basename was found in the audited default-branch commit.",
+      "doesNotEstablish": [
+        "runtime_use",
+        "runtime_health",
+        "semantic_correctness",
+        "future_compatibility"
+      ]
+    },
+    {
+      "id": "event_backbone/heimgeist.insight::consumer::leitstand",
+      "contract": "event_backbone/heimgeist.insight",
+      "role": "consumer",
+      "repository": "heimgewebe/leitstand",
+      "commit": "a5df64b478f998973be7ba4ac2936d1d12ba3ed1",
+      "status": "unverified",
+      "mode": "reference-only",
+      "files": [],
+      "evidence": [],
+      "note": "No exact reference to the schema basename was found in the audited default-branch commit.",
+      "doesNotEstablish": [
+        "runtime_use",
+        "runtime_health",
+        "semantic_correctness",
+        "future_compatibility"
+      ]
+    },
+    {
+      "id": "fixtures/chronik-fixtures::consumer::chronik",
+      "contract": "fixtures/chronik-fixtures",
+      "role": "consumer",
+      "repository": "heimgewebe/chronik",
+      "commit": "2fc65efe06cd23baa2a2bdef39f5f099c8a5540b",
+      "status": "historical",
+      "mode": "reference-only",
+      "files": [
+        "README.md",
+        "docs/event-contracts.md"
+      ],
+      "evidence": [
+        {
+          "path": "README.md",
+          "line": 23,
+          "kind": "documentation_or_data_reference"
+        },
+        {
+          "path": "docs/event-contracts.md",
+          "line": 12,
+          "kind": "documentation_or_data_reference"
+        }
+      ],
+      "note": "The contract or its only implementation is historical; this claim is retained for audit, not active routing.",
+      "doesNotEstablish": [
+        "runtime_use",
+        "runtime_health",
+        "semantic_correctness",
+        "future_compatibility"
+      ]
+    },
+    {
+      "id": "metrics/fleet.health::producer::wgx",
+      "contract": "metrics/fleet.health",
+      "role": "producer",
+      "repository": "heimgewebe/wgx",
+      "commit": "2f2aa2225838be1d029697348d9aa989ce7e62f9",
+      "status": "unverified",
+      "mode": null,
+      "files": [],
+      "evidence": [],
+      "note": "The producer relationship remains a review target and is not established by current repository evidence.",
+      "doesNotEstablish": [
+        "runtime_use",
+        "runtime_health",
+        "semantic_correctness",
+        "future_compatibility"
+      ]
+    },
+    {
+      "id": "metrics/fleet.health::consumer::wgx",
+      "contract": "metrics/fleet.health",
+      "role": "consumer",
+      "repository": "heimgewebe/wgx",
+      "commit": "2f2aa2225838be1d029697348d9aa989ce7e62f9",
+      "status": "unverified",
+      "mode": "reference-only",
+      "files": [],
+      "evidence": [],
+      "note": "No exact reference to the schema basename was found in the audited default-branch commit.",
+      "doesNotEstablish": [
+        "runtime_use",
+        "runtime_health",
+        "semantic_correctness",
+        "future_compatibility"
+      ]
+    },
+    {
+      "id": "metrics/fleet.health::consumer::leitstand",
+      "contract": "metrics/fleet.health",
+      "role": "consumer",
+      "repository": "heimgewebe/leitstand",
+      "commit": "a5df64b478f998973be7ba4ac2936d1d12ba3ed1",
+      "status": "verified",
+      "mode": "reference-only",
+      "files": [
+        "README.md",
+        "docs/blueprints/leitstand_visualization.md",
+        "docs/data-flow.md"
+      ],
+      "evidence": [
+        {
+          "path": "README.md",
+          "line": 246,
+          "kind": "documentation_or_data_reference"
+        },
+        {
+          "path": "docs/blueprints/leitstand_visualization.md",
+          "line": 219,
+          "kind": "documentation_or_data_reference"
+        },
+        {
+          "path": "docs/data-flow.md",
+          "line": 32,
+          "kind": "documentation_or_data_reference"
+        }
+      ],
+      "note": "Current default-branch files reference the exact schema basename; this proves repository coupling, not runtime use.",
+      "doesNotEstablish": [
+        "runtime_use",
+        "runtime_health",
+        "semantic_correctness",
+        "future_compatibility"
+      ]
+    },
+    {
+      "id": "integrity/summary::producer::semantAH",
+      "contract": "integrity/summary",
+      "role": "producer",
+      "repository": "heimgewebe/semantAH",
+      "commit": "c306e89105605778a382aa12c231f727c221cc74",
+      "status": "unverified",
+      "mode": null,
+      "files": [],
+      "evidence": [],
+      "note": "The producer relationship remains a review target and is not established by current repository evidence.",
+      "doesNotEstablish": [
+        "runtime_use",
+        "runtime_health",
+        "semantic_correctness",
+        "future_compatibility"
+      ]
+    },
+    {
+      "id": "integrity/summary::consumer::leitstand",
+      "contract": "integrity/summary",
+      "role": "consumer",
+      "repository": "heimgewebe/leitstand",
+      "commit": "a5df64b478f998973be7ba4ac2936d1d12ba3ed1",
+      "status": "unverified",
+      "mode": "reference-only",
+      "files": [],
+      "evidence": [],
+      "note": "No exact reference to the schema basename was found in the audited default-branch commit.",
+      "doesNotEstablish": [
+        "runtime_use",
+        "runtime_health",
+        "semantic_correctness",
+        "future_compatibility"
+      ]
+    },
+    {
+      "id": "integrity/summary::consumer::wgx",
+      "contract": "integrity/summary",
+      "role": "consumer",
+      "repository": "heimgewebe/wgx",
+      "commit": "2f2aa2225838be1d029697348d9aa989ce7e62f9",
+      "status": "unverified",
+      "mode": "reference-only",
+      "files": [],
+      "evidence": [],
+      "note": "No exact reference to the schema basename was found in the audited default-branch commit.",
+      "doesNotEstablish": [
+        "runtime_use",
+        "runtime_health",
+        "semantic_correctness",
+        "future_compatibility"
+      ]
+    },
+    {
+      "id": "knowledge/insights.daily::producer::semantAH",
+      "contract": "knowledge/insights.daily",
+      "role": "producer",
+      "repository": "heimgewebe/semantAH",
+      "commit": "c306e89105605778a382aa12c231f727c221cc74",
+      "status": "verified",
+      "mode": null,
+      "files": [
+        ".github/workflows/insights-daily-drift.yml",
+        ".github/workflows/publish-insights-daily.yml",
+        "scripts/diff_daily_insights.py",
+        "scripts/export_daily_insights.py"
+      ],
+      "evidence": [
+        {
+          "path": ".github/workflows/insights-daily-drift.yml",
+          "line": 61,
+          "kind": "ci_reference"
+        },
+        {
+          "path": ".github/workflows/publish-insights-daily.yml",
+          "line": 11,
+          "kind": "ci_reference"
+        },
+        {
+          "path": "scripts/diff_daily_insights.py",
+          "line": 47,
+          "kind": "executable_or_test_reference"
+        },
+        {
+          "path": "scripts/export_daily_insights.py",
+          "line": 9,
+          "kind": "executable_or_test_reference"
+        }
+      ],
+      "note": "Current default-branch files reference the exact schema basename; this proves repository coupling, not live production.",
+      "doesNotEstablish": [
+        "runtime_use",
+        "runtime_health",
+        "semantic_correctness",
+        "future_compatibility"
+      ]
+    },
+    {
+      "id": "knowledge/insights.daily::consumer::semantAH",
+      "contract": "knowledge/insights.daily",
+      "role": "consumer",
+      "repository": "heimgewebe/semantAH",
+      "commit": "c306e89105605778a382aa12c231f727c221cc74",
+      "status": "verified",
+      "mode": "reference-only",
+      "files": [
+        ".github/workflows/insights-daily-drift.yml",
+        ".github/workflows/publish-insights-daily.yml",
+        "scripts/diff_daily_insights.py",
+        "scripts/export_daily_insights.py"
+      ],
+      "evidence": [
+        {
+          "path": ".github/workflows/insights-daily-drift.yml",
+          "line": 61,
+          "kind": "ci_reference"
+        },
+        {
+          "path": ".github/workflows/publish-insights-daily.yml",
+          "line": 11,
+          "kind": "ci_reference"
+        },
+        {
+          "path": "scripts/diff_daily_insights.py",
+          "line": 47,
+          "kind": "executable_or_test_reference"
+        },
+        {
+          "path": "scripts/export_daily_insights.py",
+          "line": 9,
+          "kind": "executable_or_test_reference"
+        }
+      ],
+      "note": "Current default-branch files reference the exact schema basename; this proves repository coupling, not runtime use.",
+      "doesNotEstablish": [
+        "runtime_use",
+        "runtime_health",
+        "semantic_correctness",
+        "future_compatibility"
+      ]
+    },
+    {
+      "id": "knowledge/insights.daily::consumer::chronik",
+      "contract": "knowledge/insights.daily",
+      "role": "consumer",
+      "repository": "heimgewebe/chronik",
+      "commit": "2fc65efe06cd23baa2a2bdef39f5f099c8a5540b",
+      "status": "verified",
+      "mode": "reference-only",
+      "files": [
+        "validation.py",
+        "docs/insights.daily.schema.json"
+      ],
+      "evidence": [
+        {
+          "path": "validation.py",
+          "line": 83,
+          "kind": "executable_or_test_reference"
+        },
+        {
+          "path": "docs/insights.daily.schema.json",
+          "line": 3,
+          "kind": "documentation_or_data_reference"
+        }
+      ],
+      "note": "Current default-branch files reference the exact schema basename; this proves repository coupling, not runtime use.",
+      "doesNotEstablish": [
+        "runtime_use",
+        "runtime_health",
+        "semantic_correctness",
+        "future_compatibility"
+      ]
+    },
+    {
+      "id": "knowledge/insights.daily::consumer::leitstand",
+      "contract": "knowledge/insights.daily",
+      "role": "consumer",
+      "repository": "heimgewebe/leitstand",
+      "commit": "a5df64b478f998973be7ba4ac2936d1d12ba3ed1",
+      "status": "verified",
+      "mode": "reference-only",
+      "files": [
+        "README.md",
+        "docs/blueprints/leitstand_visualization.md",
+        "docs/data-flow.md"
+      ],
+      "evidence": [
+        {
+          "path": "README.md",
+          "line": 247,
+          "kind": "documentation_or_data_reference"
+        },
+        {
+          "path": "docs/blueprints/leitstand_visualization.md",
+          "line": 282,
+          "kind": "documentation_or_data_reference"
+        },
+        {
+          "path": "docs/data-flow.md",
+          "line": 46,
+          "kind": "documentation_or_data_reference"
+        }
+      ],
+      "note": "Current default-branch files reference the exact schema basename; this proves repository coupling, not runtime use.",
+      "doesNotEstablish": [
+        "runtime_use",
+        "runtime_health",
+        "semantic_correctness",
+        "future_compatibility"
+      ]
+    },
+    {
+      "id": "knowledge/insights.daily.published::producer::semantAH",
+      "contract": "knowledge/insights.daily.published",
+      "role": "producer",
+      "repository": "heimgewebe/semantAH",
+      "commit": "c306e89105605778a382aa12c231f727c221cc74",
+      "status": "compatibility",
+      "mode": null,
+      "files": [],
+      "evidence": [],
+      "note": "The repository retains a compatibility or migration reference; active production is not established.",
+      "doesNotEstablish": [
+        "runtime_use",
+        "runtime_health",
+        "semantic_correctness",
+        "future_compatibility"
+      ]
+    },
+    {
+      "id": "knowledge/insights.daily.published.v1::producer::semantAH",
+      "contract": "knowledge/insights.daily.published.v1",
+      "role": "producer",
+      "repository": "heimgewebe/semantAH",
+      "commit": "c306e89105605778a382aa12c231f727c221cc74",
+      "status": "unverified",
+      "mode": null,
+      "files": [],
+      "evidence": [],
+      "note": "The producer relationship remains a review target and is not established by current repository evidence.",
+      "doesNotEstablish": [
+        "runtime_use",
+        "runtime_health",
+        "semantic_correctness",
+        "future_compatibility"
+      ]
+    },
+    {
+      "id": "knowledge/insights.daily.published.v1::consumer::plexer",
+      "contract": "knowledge/insights.daily.published.v1",
+      "role": "consumer",
+      "repository": "heimgewebe/plexer",
+      "commit": "e1099df6ccf1763c7e235d844ff09b2728b24601",
+      "status": "unverified",
+      "mode": "notification-only",
+      "files": [],
+      "evidence": [],
+      "note": "No exact reference to the schema basename was found in the audited default-branch commit.",
+      "doesNotEstablish": [
+        "runtime_use",
+        "runtime_health",
+        "semantic_correctness",
+        "future_compatibility"
+      ]
+    },
+    {
+      "id": "knowledge/insights.daily.published.v1::consumer::chronik",
+      "contract": "knowledge/insights.daily.published.v1",
+      "role": "consumer",
+      "repository": "heimgewebe/chronik",
+      "commit": "2fc65efe06cd23baa2a2bdef39f5f099c8a5540b",
+      "status": "unverified",
+      "mode": "reference-only",
+      "files": [],
+      "evidence": [],
+      "note": "No exact reference to the schema basename was found in the audited default-branch commit.",
+      "doesNotEstablish": [
+        "runtime_use",
+        "runtime_health",
+        "semantic_correctness",
+        "future_compatibility"
+      ]
+    },
+    {
+      "id": "knowledge/insights.daily.published.v1::consumer::leitstand",
+      "contract": "knowledge/insights.daily.published.v1",
+      "role": "consumer",
+      "repository": "heimgewebe/leitstand",
+      "commit": "a5df64b478f998973be7ba4ac2936d1d12ba3ed1",
+      "status": "unverified",
+      "mode": "reference-only",
+      "files": [],
+      "evidence": [],
+      "note": "No exact reference to the schema basename was found in the audited default-branch commit.",
+      "doesNotEstablish": [
+        "runtime_use",
+        "runtime_health",
+        "semantic_correctness",
+        "future_compatibility"
+      ]
+    },
+    {
+      "id": "knowledge/insights.daily.published.v1::consumer::hausKI",
+      "contract": "knowledge/insights.daily.published.v1",
+      "role": "consumer",
+      "repository": "heimgewebe/hausKI",
+      "commit": "2b2e4496613c856993e028e360e76abea70c7028",
+      "status": "unverified",
+      "mode": "reference-only",
+      "files": [],
+      "evidence": [],
+      "note": "No exact reference to the schema basename was found in the audited default-branch commit.",
+      "doesNotEstablish": [
+        "runtime_use",
+        "runtime_health",
+        "semantic_correctness",
+        "future_compatibility"
+      ]
+    },
+    {
+      "id": "knowledge/observatory::producer::semantAH",
+      "contract": "knowledge/observatory",
+      "role": "producer",
+      "repository": "heimgewebe/semantAH",
+      "commit": "c306e89105605778a382aa12c231f727c221cc74",
+      "status": "verified",
+      "mode": null,
+      "files": [
+        ".github/workflows/contracts-sync-guard.yml",
+        ".github/workflows/knowledge-observatory-drift.yml",
+        ".github/workflows/publish-knowledge-observatory.yml",
+        "scripts/observatory_diff.py"
+      ],
+      "evidence": [
+        {
+          "path": ".github/workflows/contracts-sync-guard.yml",
+          "line": 44,
+          "kind": "ci_reference"
+        },
+        {
+          "path": ".github/workflows/knowledge-observatory-drift.yml",
+          "line": 123,
+          "kind": "ci_reference"
+        },
+        {
+          "path": ".github/workflows/publish-knowledge-observatory.yml",
+          "line": 11,
+          "kind": "ci_reference"
+        },
+        {
+          "path": "scripts/observatory_diff.py",
+          "line": 51,
+          "kind": "executable_or_test_reference"
+        }
+      ],
+      "note": "Current default-branch files reference the exact schema basename; this proves repository coupling, not live production.",
+      "doesNotEstablish": [
+        "runtime_use",
+        "runtime_health",
+        "semantic_correctness",
+        "future_compatibility"
+      ]
+    },
+    {
+      "id": "knowledge/observatory::consumer::leitstand",
+      "contract": "knowledge/observatory",
+      "role": "consumer",
+      "repository": "heimgewebe/leitstand",
+      "commit": "a5df64b478f998973be7ba4ac2936d1d12ba3ed1",
+      "status": "verified",
+      "mode": "reference-only",
+      "files": [
+        "scripts/vendor-contracts.mjs",
+        "vendor/contracts/_pin.json",
+        "vendor/contracts/knowledge/observatory.schema.json"
+      ],
+      "evidence": [
+        {
+          "path": "scripts/vendor-contracts.mjs",
+          "line": 14,
+          "kind": "executable_or_test_reference"
+        },
+        {
+          "path": "vendor/contracts/_pin.json",
+          "line": 5,
+          "kind": "documentation_or_data_reference"
+        },
+        {
+          "path": "vendor/contracts/knowledge/observatory.schema.json",
+          "line": 3,
+          "kind": "documentation_or_data_reference"
+        }
+      ],
+      "note": "Current default-branch files reference the exact schema basename; this proves repository coupling, not runtime use.",
+      "doesNotEstablish": [
+        "runtime_use",
+        "runtime_health",
+        "semantic_correctness",
+        "future_compatibility"
+      ]
+    },
+    {
+      "id": "knowledge/observatory::consumer::hausKI",
+      "contract": "knowledge/observatory",
+      "role": "consumer",
+      "repository": "heimgewebe/hausKI",
+      "commit": "2b2e4496613c856993e028e360e76abea70c7028",
+      "status": "unverified",
+      "mode": "reference-only",
+      "files": [],
+      "evidence": [],
+      "note": "No exact reference to the schema basename was found in the audited default-branch commit.",
+      "doesNotEstablish": [
+        "runtime_use",
+        "runtime_health",
+        "semantic_correctness",
+        "future_compatibility"
+      ]
+    },
+    {
+      "id": "knowledge/observatory::consumer::heimlern",
+      "contract": "knowledge/observatory",
+      "role": "consumer",
+      "repository": "heimgewebe/heimlern",
+      "commit": "8dbebea6b253f9d2f41514a15d34e5166602e792",
+      "status": "unverified",
+      "mode": "reference-only",
+      "files": [],
+      "evidence": [],
+      "note": "No exact reference to the schema basename was found in the audited default-branch commit.",
+      "doesNotEstablish": [
+        "runtime_use",
+        "runtime_health",
+        "semantic_correctness",
+        "future_compatibility"
+      ]
+    },
+    {
+      "id": "knowledge/knowledge.observatory.published.v1::producer::semantAH",
+      "contract": "knowledge/knowledge.observatory.published.v1",
+      "role": "producer",
+      "repository": "heimgewebe/semantAH",
+      "commit": "c306e89105605778a382aa12c231f727c221cc74",
+      "status": "unverified",
+      "mode": null,
+      "files": [],
+      "evidence": [],
+      "note": "The producer relationship remains a review target and is not established by current repository evidence.",
+      "doesNotEstablish": [
+        "runtime_use",
+        "runtime_health",
+        "semantic_correctness",
+        "future_compatibility"
+      ]
+    },
+    {
+      "id": "knowledge/knowledge.observatory.published.v1::consumer::leitstand",
+      "contract": "knowledge/knowledge.observatory.published.v1",
+      "role": "consumer",
+      "repository": "heimgewebe/leitstand",
+      "commit": "a5df64b478f998973be7ba4ac2936d1d12ba3ed1",
+      "status": "unverified",
+      "mode": "reference-only",
+      "files": [],
+      "evidence": [],
+      "note": "No exact reference to the schema basename was found in the audited default-branch commit.",
+      "doesNotEstablish": [
+        "runtime_use",
+        "runtime_health",
+        "semantic_correctness",
+        "future_compatibility"
+      ]
+    },
+    {
+      "id": "knowledge/knowledge.observatory.published.v1::consumer::hausKI",
+      "contract": "knowledge/knowledge.observatory.published.v1",
+      "role": "consumer",
+      "repository": "heimgewebe/hausKI",
+      "commit": "2b2e4496613c856993e028e360e76abea70c7028",
+      "status": "verified",
+      "mode": "reference-only",
+      "files": [
+        "crates/core/src/events.rs",
+        "crates/core/src/events_tests.rs"
+      ],
+      "evidence": [
+        {
+          "path": "crates/core/src/events.rs",
+          "line": 297,
+          "kind": "executable_or_test_reference"
+        },
+        {
+          "path": "crates/core/src/events_tests.rs",
+          "line": 312,
+          "kind": "executable_or_test_reference"
+        }
+      ],
+      "note": "Current default-branch files reference the exact schema basename; this proves repository coupling, not runtime use.",
+      "doesNotEstablish": [
+        "runtime_use",
+        "runtime_health",
+        "semantic_correctness",
+        "future_compatibility"
+      ]
+    },
+    {
+      "id": "knowledge/knowledge.observatory.published.v1::consumer::plexer",
+      "contract": "knowledge/knowledge.observatory.published.v1",
+      "role": "consumer",
+      "repository": "heimgewebe/plexer",
+      "commit": "e1099df6ccf1763c7e235d844ff09b2728b24601",
+      "status": "unverified",
+      "mode": "notification-only",
+      "files": [],
+      "evidence": [],
+      "note": "No exact reference to the schema basename was found in the audited default-branch commit.",
+      "doesNotEstablish": [
+        "runtime_use",
+        "runtime_health",
+        "semantic_correctness",
+        "future_compatibility"
+      ]
+    },
+    {
+      "id": "os_context/state::consumer::mitschreiber",
+      "contract": "os_context/state",
+      "role": "consumer",
+      "repository": "heimgewebe/mitschreiber",
+      "commit": "3680bb7e14079c4b8ec3d0758605f7023ee11097",
+      "status": "verified",
+      "mode": "reference-only",
+      "files": [
+        ".github/workflows/validate.yml",
+        "docs/ci.md",
+        "docs/contracts.md",
+        "renovate.json"
+      ],
+      "evidence": [
+        {
+          "path": ".github/workflows/validate.yml",
+          "line": 38,
+          "kind": "ci_reference"
+        },
+        {
+          "path": "docs/ci.md",
+          "line": 29,
+          "kind": "documentation_or_data_reference"
+        },
+        {
+          "path": "docs/contracts.md",
+          "line": 7,
+          "kind": "documentation_or_data_reference"
+        },
+        {
+          "path": "renovate.json",
+          "line": 132,
+          "kind": "documentation_or_data_reference"
+        }
+      ],
+      "note": "Current default-branch files reference the exact schema basename; this proves repository coupling, not runtime use.",
+      "doesNotEstablish": [
+        "runtime_use",
+        "runtime_health",
+        "semantic_correctness",
+        "future_compatibility"
+      ]
+    },
+    {
+      "id": "os_context/text.embed::consumer::semantAH",
+      "contract": "os_context/text.embed",
+      "role": "consumer",
+      "repository": "heimgewebe/semantAH",
+      "commit": "c306e89105605778a382aa12c231f727c221cc74",
+      "status": "verified",
+      "mode": "reference-only",
+      "files": [
+        "crates/indexd/src/api.rs",
+        "scripts/observatory_mvp.py",
+        "IMPLEMENTATION_SUMMARY.md",
+        "contracts/os.context.text.embed.schema.json"
+      ],
+      "evidence": [
+        {
+          "path": "crates/indexd/src/api.rs",
+          "line": 290,
+          "kind": "executable_or_test_reference"
+        },
+        {
+          "path": "scripts/observatory_mvp.py",
+          "line": 155,
+          "kind": "executable_or_test_reference"
+        },
+        {
+          "path": "IMPLEMENTATION_SUMMARY.md",
+          "line": 12,
+          "kind": "documentation_or_data_reference"
+        },
+        {
+          "path": "contracts/os.context.text.embed.schema.json",
+          "line": 3,
+          "kind": "documentation_or_data_reference"
+        }
+      ],
+      "note": "Current default-branch files reference the exact schema basename; this proves repository coupling, not runtime use.",
+      "doesNotEstablish": [
+        "runtime_use",
+        "runtime_health",
+        "semantic_correctness",
+        "future_compatibility"
+      ]
+    },
+    {
+      "id": "policy/decision::producer::heimlern",
+      "contract": "policy/decision",
+      "role": "producer",
+      "repository": "heimgewebe/heimlern",
+      "commit": "8dbebea6b253f9d2f41514a15d34e5166602e792",
+      "status": "historical",
+      "mode": null,
+      "files": [
+        ".github/workflows/validate-policy-decisions.yml",
+        "scripts/validate_json.py",
+        "README.md",
+        "contracts/README.md"
+      ],
+      "evidence": [
+        {
+          "path": ".github/workflows/validate-policy-decisions.yml",
+          "line": 29,
+          "kind": "ci_reference"
+        },
+        {
+          "path": "scripts/validate_json.py",
+          "line": 75,
+          "kind": "executable_or_test_reference"
+        },
+        {
+          "path": "README.md",
+          "line": 94,
+          "kind": "documentation_or_data_reference"
+        },
+        {
+          "path": "contracts/README.md",
+          "line": 19,
+          "kind": "documentation_or_data_reference"
+        }
+      ],
+      "note": "The repository explicitly declares a historical-only role.",
+      "doesNotEstablish": [
+        "runtime_use",
+        "runtime_health",
+        "semantic_correctness",
+        "future_compatibility"
+      ]
+    },
+    {
+      "id": "policy/decision::consumer::heimlern",
+      "contract": "policy/decision",
+      "role": "consumer",
+      "repository": "heimgewebe/heimlern",
+      "commit": "8dbebea6b253f9d2f41514a15d34e5166602e792",
+      "status": "historical",
+      "mode": "reference-only",
+      "files": [
+        ".github/workflows/validate-policy-decisions.yml",
+        "scripts/validate_json.py",
+        "README.md",
+        "contracts/README.md"
+      ],
+      "evidence": [
+        {
+          "path": ".github/workflows/validate-policy-decisions.yml",
+          "line": 29,
+          "kind": "ci_reference"
+        },
+        {
+          "path": "scripts/validate_json.py",
+          "line": 75,
+          "kind": "executable_or_test_reference"
+        },
+        {
+          "path": "README.md",
+          "line": 94,
+          "kind": "documentation_or_data_reference"
+        },
+        {
+          "path": "contracts/README.md",
+          "line": 19,
+          "kind": "documentation_or_data_reference"
+        }
+      ],
+      "note": "The contract or its only implementation is historical; this claim is retained for audit, not active routing.",
+      "doesNotEstablish": [
+        "runtime_use",
+        "runtime_health",
+        "semantic_correctness",
+        "future_compatibility"
+      ]
+    },
+    {
+      "id": "policy/decision::consumer::hausKI",
+      "contract": "policy/decision",
+      "role": "consumer",
+      "repository": "heimgewebe/hausKI",
+      "commit": "2b2e4496613c856993e028e360e76abea70c7028",
+      "status": "historical",
+      "mode": "reference-only",
+      "files": [],
+      "evidence": [],
+      "note": "The contract or its only implementation is historical; this claim is retained for audit, not active routing.",
+      "doesNotEstablish": [
+        "runtime_use",
+        "runtime_health",
+        "semantic_correctness",
+        "future_compatibility"
+      ]
+    },
+    {
+      "id": "policy/feedback::producer::heimlern",
+      "contract": "policy/feedback",
+      "role": "producer",
+      "repository": "heimgewebe/heimlern",
+      "commit": "8dbebea6b253f9d2f41514a15d34e5166602e792",
+      "status": "historical",
+      "mode": null,
+      "files": [
+        ".github/workflows/rust.yml",
+        ".github/workflows/validate-feedback-schema.yml",
+        "scripts/validate_json.py",
+        "tests/validate_feedback_schema.py"
+      ],
+      "evidence": [
+        {
+          "path": ".github/workflows/rust.yml",
+          "line": 64,
+          "kind": "ci_reference"
+        },
+        {
+          "path": ".github/workflows/validate-feedback-schema.yml",
+          "line": 7,
+          "kind": "ci_reference"
+        },
+        {
+          "path": "scripts/validate_json.py",
+          "line": 77,
+          "kind": "executable_or_test_reference"
+        },
+        {
+          "path": "tests/validate_feedback_schema.py",
+          "line": 14,
+          "kind": "executable_or_test_reference"
+        }
+      ],
+      "note": "The repository explicitly declares a historical-only role.",
+      "doesNotEstablish": [
+        "runtime_use",
+        "runtime_health",
+        "semantic_correctness",
+        "future_compatibility"
+      ]
+    },
+    {
+      "id": "policy/feedback::consumer::heimlern",
+      "contract": "policy/feedback",
+      "role": "consumer",
+      "repository": "heimgewebe/heimlern",
+      "commit": "8dbebea6b253f9d2f41514a15d34e5166602e792",
+      "status": "historical",
+      "mode": "reference-only",
+      "files": [
+        ".github/workflows/rust.yml",
+        ".github/workflows/validate-feedback-schema.yml",
+        "scripts/validate_json.py",
+        "tests/validate_feedback_schema.py"
+      ],
+      "evidence": [
+        {
+          "path": ".github/workflows/rust.yml",
+          "line": 64,
+          "kind": "ci_reference"
+        },
+        {
+          "path": ".github/workflows/validate-feedback-schema.yml",
+          "line": 7,
+          "kind": "ci_reference"
+        },
+        {
+          "path": "scripts/validate_json.py",
+          "line": 77,
+          "kind": "executable_or_test_reference"
+        },
+        {
+          "path": "tests/validate_feedback_schema.py",
+          "line": 14,
+          "kind": "executable_or_test_reference"
+        }
+      ],
+      "note": "The contract or its only implementation is historical; this claim is retained for audit, not active routing.",
+      "doesNotEstablish": [
+        "runtime_use",
+        "runtime_health",
+        "semantic_correctness",
+        "future_compatibility"
+      ]
+    },
+    {
+      "id": "policy/snapshot::producer::heimlern",
+      "contract": "policy/snapshot",
+      "role": "producer",
+      "repository": "heimgewebe/heimlern",
+      "commit": "8dbebea6b253f9d2f41514a15d34e5166602e792",
+      "status": "historical",
+      "mode": null,
+      "files": [
+        "crates/heimlern-bandits/README.md",
+        "crates/heimlern-bandits/src/lib.rs",
+        "scripts/validate_json.py",
+        "Justfile"
+      ],
+      "evidence": [
+        {
+          "path": "crates/heimlern-bandits/README.md",
+          "line": 5,
+          "kind": "executable_or_test_reference"
+        },
+        {
+          "path": "crates/heimlern-bandits/src/lib.rs",
+          "line": 53,
+          "kind": "executable_or_test_reference"
+        },
+        {
+          "path": "scripts/validate_json.py",
+          "line": 6,
+          "kind": "executable_or_test_reference"
+        },
+        {
+          "path": "Justfile",
+          "line": 25,
+          "kind": "documentation_or_data_reference"
+        }
+      ],
+      "note": "The repository explicitly declares a historical-only role.",
+      "doesNotEstablish": [
+        "runtime_use",
+        "runtime_health",
+        "semantic_correctness",
+        "future_compatibility"
+      ]
+    },
+    {
+      "id": "policy/snapshot::consumer::heimlern",
+      "contract": "policy/snapshot",
+      "role": "consumer",
+      "repository": "heimgewebe/heimlern",
+      "commit": "8dbebea6b253f9d2f41514a15d34e5166602e792",
+      "status": "historical",
+      "mode": "reference-only",
+      "files": [
+        "crates/heimlern-bandits/README.md",
+        "crates/heimlern-bandits/src/lib.rs",
+        "scripts/validate_json.py",
+        "Justfile"
+      ],
+      "evidence": [
+        {
+          "path": "crates/heimlern-bandits/README.md",
+          "line": 5,
+          "kind": "executable_or_test_reference"
+        },
+        {
+          "path": "crates/heimlern-bandits/src/lib.rs",
+          "line": 53,
+          "kind": "executable_or_test_reference"
+        },
+        {
+          "path": "scripts/validate_json.py",
+          "line": 6,
+          "kind": "executable_or_test_reference"
+        },
+        {
+          "path": "Justfile",
+          "line": 25,
+          "kind": "documentation_or_data_reference"
+        }
+      ],
+      "note": "The contract or its only implementation is historical; this claim is retained for audit, not active routing.",
+      "doesNotEstablish": [
+        "runtime_use",
+        "runtime_health",
+        "semantic_correctness",
+        "future_compatibility"
+      ]
+    },
+    {
+      "id": "policy/heimlern.ingest.state.v1::producer::heimlern",
+      "contract": "policy/heimlern.ingest.state.v1",
+      "role": "producer",
+      "repository": "heimgewebe/heimlern",
+      "commit": "8dbebea6b253f9d2f41514a15d34e5166602e792",
+      "status": "historical",
+      "mode": null,
+      "files": [],
+      "evidence": [],
+      "note": "The repository explicitly declares a historical-only role.",
+      "doesNotEstablish": [
+        "runtime_use",
+        "runtime_health",
+        "semantic_correctness",
+        "future_compatibility"
+      ]
+    },
+    {
+      "id": "policy/heimlern.ingest.state.v1::consumer::heimlern",
+      "contract": "policy/heimlern.ingest.state.v1",
+      "role": "consumer",
+      "repository": "heimgewebe/heimlern",
+      "commit": "8dbebea6b253f9d2f41514a15d34e5166602e792",
+      "status": "historical",
+      "mode": "mirror",
+      "files": [],
+      "evidence": [],
+      "note": "The contract or its only implementation is historical; this claim is retained for audit, not active routing.",
+      "doesNotEstablish": [
+        "runtime_use",
+        "runtime_health",
+        "semantic_correctness",
+        "future_compatibility"
+      ],
+      "mirrorChecks": []
+    },
+    {
+      "id": "policy/heimlern.ingest.state.v1::consumer::leitstand",
+      "contract": "policy/heimlern.ingest.state.v1",
+      "role": "consumer",
+      "repository": "heimgewebe/leitstand",
+      "commit": "a5df64b478f998973be7ba4ac2936d1d12ba3ed1",
+      "status": "historical",
+      "mode": "reference-only",
+      "files": [],
+      "evidence": [],
+      "note": "The contract or its only implementation is historical; this claim is retained for audit, not active routing.",
+      "doesNotEstablish": [
+        "runtime_use",
+        "runtime_health",
+        "semantic_correctness",
+        "future_compatibility"
+      ]
+    },
+    {
+      "id": "policy/heimlern.ingest.state.v1::consumer::heimgeist",
+      "contract": "policy/heimlern.ingest.state.v1",
+      "role": "consumer",
+      "repository": "heimgewebe/heimgeist",
+      "commit": "2d657297e9875cf0ec12932b3391fc4c0d8a246a",
+      "status": "historical",
+      "mode": "reference-only",
+      "files": [],
+      "evidence": [],
+      "note": "The contract or its only implementation is historical; this claim is retained for audit, not active routing.",
+      "doesNotEstablish": [
+        "runtime_use",
+        "runtime_health",
+        "semantic_correctness",
+        "future_compatibility"
+      ]
+    },
+    {
+      "id": "heim-pc/state.index::producer::heim-pc",
+      "contract": "heim-pc/state.index",
+      "role": "producer",
+      "repository": "heimgewebe/heim-pc",
+      "commit": "140e84bc28d3b208a51e2edb1cb27c5946c38d49",
+      "status": "historical",
+      "mode": null,
+      "files": [],
+      "evidence": [],
+      "note": "The repository explicitly declares a historical-only role.",
+      "doesNotEstablish": [
+        "runtime_use",
+        "runtime_health",
+        "semantic_correctness",
+        "future_compatibility"
+      ]
+    },
+    {
+      "id": "heim-pc/state.index::consumer::heim-pc",
+      "contract": "heim-pc/state.index",
+      "role": "consumer",
+      "repository": "heimgewebe/heim-pc",
+      "commit": "140e84bc28d3b208a51e2edb1cb27c5946c38d49",
+      "status": "historical",
+      "mode": "mirror",
+      "files": [],
+      "evidence": [],
+      "note": "The contract or its only implementation is historical; this claim is retained for audit, not active routing.",
+      "doesNotEstablish": [
+        "runtime_use",
+        "runtime_health",
+        "semantic_correctness",
+        "future_compatibility"
+      ],
+      "mirrorChecks": []
+    },
+    {
+      "id": "heim-pc/state.repos::producer::heim-pc",
+      "contract": "heim-pc/state.repos",
+      "role": "producer",
+      "repository": "heimgewebe/heim-pc",
+      "commit": "140e84bc28d3b208a51e2edb1cb27c5946c38d49",
+      "status": "historical",
+      "mode": null,
+      "files": [],
+      "evidence": [],
+      "note": "The repository explicitly declares a historical-only role.",
+      "doesNotEstablish": [
+        "runtime_use",
+        "runtime_health",
+        "semantic_correctness",
+        "future_compatibility"
+      ]
+    },
+    {
+      "id": "heim-pc/state.repos::consumer::heim-pc",
+      "contract": "heim-pc/state.repos",
+      "role": "consumer",
+      "repository": "heimgewebe/heim-pc",
+      "commit": "140e84bc28d3b208a51e2edb1cb27c5946c38d49",
+      "status": "historical",
+      "mode": "mirror",
+      "files": [],
+      "evidence": [],
+      "note": "The contract or its only implementation is historical; this claim is retained for audit, not active routing.",
+      "doesNotEstablish": [
+        "runtime_use",
+        "runtime_health",
+        "semantic_correctness",
+        "future_compatibility"
+      ],
+      "mirrorChecks": []
+    },
+    {
+      "id": "heim-pc/state.uncertainties::producer::heim-pc",
+      "contract": "heim-pc/state.uncertainties",
+      "role": "producer",
+      "repository": "heimgewebe/heim-pc",
+      "commit": "140e84bc28d3b208a51e2edb1cb27c5946c38d49",
+      "status": "historical",
+      "mode": null,
+      "files": [],
+      "evidence": [],
+      "note": "The repository explicitly declares a historical-only role.",
+      "doesNotEstablish": [
+        "runtime_use",
+        "runtime_health",
+        "semantic_correctness",
+        "future_compatibility"
+      ]
+    },
+    {
+      "id": "heim-pc/state.uncertainties::consumer::heim-pc",
+      "contract": "heim-pc/state.uncertainties",
+      "role": "consumer",
+      "repository": "heimgewebe/heim-pc",
+      "commit": "140e84bc28d3b208a51e2edb1cb27c5946c38d49",
+      "status": "historical",
+      "mode": "mirror",
+      "files": [],
+      "evidence": [],
+      "note": "The contract or its only implementation is historical; this claim is retained for audit, not active routing.",
+      "doesNotEstablish": [
+        "runtime_use",
+        "runtime_health",
+        "semantic_correctness",
+        "future_compatibility"
+      ],
+      "mirrorChecks": []
+    },
+    {
+      "id": "heim-pc/state.insights::producer::heim-pc",
+      "contract": "heim-pc/state.insights",
+      "role": "producer",
+      "repository": "heimgewebe/heim-pc",
+      "commit": "140e84bc28d3b208a51e2edb1cb27c5946c38d49",
+      "status": "historical",
+      "mode": null,
+      "files": [],
+      "evidence": [],
+      "note": "The repository explicitly declares a historical-only role.",
+      "doesNotEstablish": [
+        "runtime_use",
+        "runtime_health",
+        "semantic_correctness",
+        "future_compatibility"
+      ]
+    },
+    {
+      "id": "heim-pc/state.insights::consumer::heim-pc",
+      "contract": "heim-pc/state.insights",
+      "role": "consumer",
+      "repository": "heimgewebe/heim-pc",
+      "commit": "140e84bc28d3b208a51e2edb1cb27c5946c38d49",
+      "status": "historical",
+      "mode": "mirror",
+      "files": [],
+      "evidence": [],
+      "note": "The contract or its only implementation is historical; this claim is retained for audit, not active routing.",
+      "doesNotEstablish": [
+        "runtime_use",
+        "runtime_health",
+        "semantic_correctness",
+        "future_compatibility"
+      ],
+      "mirrorChecks": []
+    },
+    {
+      "id": "heim-pc/state.drift::producer::heim-pc",
+      "contract": "heim-pc/state.drift",
+      "role": "producer",
+      "repository": "heimgewebe/heim-pc",
+      "commit": "140e84bc28d3b208a51e2edb1cb27c5946c38d49",
+      "status": "historical",
+      "mode": null,
+      "files": [],
+      "evidence": [],
+      "note": "The repository explicitly declares a historical-only role.",
+      "doesNotEstablish": [
+        "runtime_use",
+        "runtime_health",
+        "semantic_correctness",
+        "future_compatibility"
+      ]
+    },
+    {
+      "id": "heim-pc/state.drift::consumer::heim-pc",
+      "contract": "heim-pc/state.drift",
+      "role": "consumer",
+      "repository": "heimgewebe/heim-pc",
+      "commit": "140e84bc28d3b208a51e2edb1cb27c5946c38d49",
+      "status": "historical",
+      "mode": "mirror",
+      "files": [],
+      "evidence": [],
+      "note": "The contract or its only implementation is historical; this claim is retained for audit, not active routing.",
+      "doesNotEstablish": [
+        "runtime_use",
+        "runtime_health",
+        "semantic_correctness",
+        "future_compatibility"
+      ],
+      "mirrorChecks": []
+    },
+    {
+      "id": "heim-pc/config.zones::producer::heim-pc",
+      "contract": "heim-pc/config.zones",
+      "role": "producer",
+      "repository": "heimgewebe/heim-pc",
+      "commit": "140e84bc28d3b208a51e2edb1cb27c5946c38d49",
+      "status": "compatibility",
+      "mode": null,
+      "files": [
+        "scripts/validate_contracts.py"
+      ],
+      "evidence": [
+        {
+          "path": "scripts/validate_contracts.py",
+          "line": 97,
+          "kind": "executable_or_test_reference"
+        }
+      ],
+      "note": "The repository retains a compatibility or migration reference; active production is not established.",
+      "doesNotEstablish": [
+        "runtime_use",
+        "runtime_health",
+        "semantic_correctness",
+        "future_compatibility"
+      ]
+    },
+    {
+      "id": "heim-pc/config.zones::consumer::heim-pc",
+      "contract": "heim-pc/config.zones",
+      "role": "consumer",
+      "repository": "heimgewebe/heim-pc",
+      "commit": "140e84bc28d3b208a51e2edb1cb27c5946c38d49",
+      "status": "compatibility",
+      "mode": "mirror",
+      "files": [],
+      "evidence": [
+        {
+          "path": "scripts/validate_contracts.py",
+          "line": 97,
+          "kind": "executable_or_test_reference"
+        }
+      ],
+      "note": "The claim is retained as a bounded compatibility relationship and does not establish active runtime use.",
+      "doesNotEstablish": [
+        "runtime_use",
+        "runtime_health",
+        "semantic_correctness",
+        "future_compatibility"
+      ],
+      "mirrorChecks": []
+    }
+  ],
+  "doesNotEstablish": [
+    "runtime_use",
+    "runtime_health",
+    "semantic_correctness",
+    "producer_execution",
+    "delivery_success",
+    "complete_organization_coverage",
+    "merge_readiness"
+  ]
+}

--- a/contracts/consumers.yaml
+++ b/contracts/consumers.yaml
@@ -1,226 +1,632 @@
 ---
-# Maschinenlesbare Übersicht, welche Repos welche zentralen Heimgewebe-Contracts konsumieren.
-#
-# Grundprinzip:
-# - Alle hier referenzierten Schemas liegen kanonisch im metarepo unter ./contracts/.
-# - Consumer-Repos dürfen diese Schemas:
-#   - nur referenzieren (mode: reference-only), oder
-#   - 1:1 spiegeln (mode: mirror) mit CI-Driftcheck.
-#
-# Diese Datei ist bewusst einfach gehalten, damit sie später von Tools
-# (z. B. wgx oder heimgeist) ausgewertet werden kann.
-
+# Backward-compatible contract governance registry.
+# Existing category/contract/schema/consumers keys remain available.
+# lifecycle/status fields are governance claims bound to contracts/consumer-evidence.v1.json.
+# They do not establish runtime use, health, semantic correctness, or merge readiness.
 event_backbone:
   aussen.event:
     schema: contracts/aussen.event.schema.json
     consumers:
-      - repo: aussensensor
-        files:
-          - contracts/aussen.event.schema.json
-        mode: mirror
-      - repo: chronik
-        files: []
-        mode: reference-only
-
+    - repo: aussensensor
+      files:
+      - contracts/aussen.event.schema.json
+      mode: mirror
+      status: verified
+      last_verified: '2026-07-14T21:35:14+02:00'
+      evidence_ref: contracts/consumer-evidence.v1.json#claims/event_backbone/aussen.event::consumer::aussensensor
+    - repo: chronik
+      files:
+      - .github/workflows/validate-aussen-fixtures.yml
+      - .github/workflows/validate-aussen.yml
+      - .ai-context.yml
+      - README.md
+      mode: reference-only
+      status: verified
+      last_verified: '2026-07-14T21:35:14+02:00'
+      evidence_ref: contracts/consumer-evidence.v1.json#claims/event_backbone/aussen.event::consumer::chronik
+    lifecycle: active
+    last_verified: '2026-07-14T21:35:14+02:00'
+    replacement: null
+    status_reason: Reviewed against exact current default-branch commits for the declared repositories.
+    evidence_ref: contracts/consumer-evidence.v1.json#contracts/event_backbone/aussen.event
+    producers:
+    - repo: aussensensor
+      status: verified
+      files:
+      - .github/workflows/contracts-drift.yml
+      - .github/workflows/fixtures-validate.yml
+      - .github/workflows/validate-aussen-fixtures.yml
+      - .github/workflows/validate-aussen.yml
+      last_verified: '2026-07-14T21:35:14+02:00'
+      evidence_ref: contracts/consumer-evidence.v1.json#claims/event_backbone/aussen.event::producer::aussensensor
   event.line:
     schema: contracts/event.line.schema.json
     consumers:
-      - repo: chronik
-        files: []
-        mode: reference-only
-      # Weitere Repos bei Bedarf ergänzen
-
+    - repo: chronik
+      files:
+      - README.md
+      - docs/event-contracts.md
+      mode: reference-only
+      status: verified
+      last_verified: '2026-07-14T21:35:14+02:00'
+      evidence_ref: contracts/consumer-evidence.v1.json#claims/event_backbone/event.line::consumer::chronik
+    lifecycle: active
+    last_verified: '2026-07-14T21:35:14+02:00'
+    replacement: null
+    status_reason: Reviewed against exact current default-branch commits for the declared repositories.
+    evidence_ref: contracts/consumer-evidence.v1.json#contracts/event_backbone/event.line
+    producers:
+    - repo: chronik
+      status: unverified
+      files:
+      - README.md
+      - docs/event-contracts.md
+      last_verified: '2026-07-14T21:35:14+02:00'
+      evidence_ref: contracts/consumer-evidence.v1.json#claims/event_backbone/event.line::producer::chronik
   heimgeist.insight:
     schema: contracts/events/heimgeist.insight.v1.schema.json
     consumers:
-      - repo: chronik
-        files: []
-        mode: reference-only
-      - repo: semantAH
-        files: []
-        mode: reference-only
-      - repo: leitstand
-        files: []
-        mode: reference-only
-
+    - repo: chronik
+      files:
+      - validation.py
+      - docs/heimgeist_spec.md
+      mode: reference-only
+      status: verified
+      last_verified: '2026-07-14T21:35:14+02:00'
+      evidence_ref: contracts/consumer-evidence.v1.json#claims/event_backbone/heimgeist.insight::consumer::chronik
+    - repo: semantAH
+      files: []
+      mode: reference-only
+      status: unverified
+      last_verified: '2026-07-14T21:35:14+02:00'
+      evidence_ref: contracts/consumer-evidence.v1.json#claims/event_backbone/heimgeist.insight::consumer::semantAH
+    - repo: leitstand
+      files: []
+      mode: reference-only
+      status: unverified
+      last_verified: '2026-07-14T21:35:14+02:00'
+      evidence_ref: contracts/consumer-evidence.v1.json#claims/event_backbone/heimgeist.insight::consumer::leitstand
+    lifecycle: active
+    last_verified: '2026-07-14T21:35:14+02:00'
+    replacement: null
+    status_reason: Reviewed against exact current default-branch commits for the declared repositories.
+    evidence_ref: contracts/consumer-evidence.v1.json#contracts/event_backbone/heimgeist.insight
+    producers:
+    - repo: heimgeist
+      status: unverified
+      files:
+      - docs/specs/heimgeist-insight-v1.md
+      last_verified: '2026-07-14T21:35:14+02:00'
+      evidence_ref: contracts/consumer-evidence.v1.json#claims/event_backbone/heimgeist.insight::producer::heimgeist
 fixtures:
   chronik-fixtures:
     schema: contracts/chronik-fixtures.schema.json
     consumers:
-      - repo: chronik
-        files: []
-        mode: reference-only
-
+    - repo: chronik
+      files:
+      - README.md
+      - docs/event-contracts.md
+      mode: reference-only
+      status: historical
+      last_verified: '2026-07-14T21:35:14+02:00'
+      evidence_ref: contracts/consumer-evidence.v1.json#claims/fixtures/chronik-fixtures::consumer::chronik
+    lifecycle: historical
+    last_verified: '2026-07-14T21:35:14+02:00'
+    replacement: null
+    status_reason: The declared canonical schema path does not exist at the audited Metarepo commit; Chronik contains documentation
+      references only.
+    evidence_ref: contracts/consumer-evidence.v1.json#contracts/fixtures/chronik-fixtures
+    producers: []
 metrics:
   fleet.health:
     schema: contracts/fleet.health.schema.json
     consumers:
-      - repo: wgx
-        files: []
-        mode: reference-only
-      - repo: leitstand
-        files: []
-        mode: reference-only
-
+    - repo: wgx
+      files: []
+      mode: reference-only
+      status: unverified
+      last_verified: '2026-07-14T21:35:14+02:00'
+      evidence_ref: contracts/consumer-evidence.v1.json#claims/metrics/fleet.health::consumer::wgx
+    - repo: leitstand
+      files:
+      - README.md
+      - docs/blueprints/leitstand_visualization.md
+      - docs/data-flow.md
+      mode: reference-only
+      status: verified
+      last_verified: '2026-07-14T21:35:14+02:00'
+      evidence_ref: contracts/consumer-evidence.v1.json#claims/metrics/fleet.health::consumer::leitstand
+    lifecycle: active
+    last_verified: '2026-07-14T21:35:14+02:00'
+    replacement: null
+    status_reason: Reviewed against exact current default-branch commits for the declared repositories.
+    evidence_ref: contracts/consumer-evidence.v1.json#contracts/metrics/fleet.health
+    producers:
+    - repo: wgx
+      status: unverified
+      files: []
+      last_verified: '2026-07-14T21:35:14+02:00'
+      evidence_ref: contracts/consumer-evidence.v1.json#claims/metrics/fleet.health::producer::wgx
 integrity:
   summary:
     schema: contracts/integrity.summary.schema.json
     consumers:
-      - repo: leitstand
-        files: []
-        mode: reference-only
-      - repo: wgx
-        files: []
-        mode: reference-only
-
+    - repo: leitstand
+      files: []
+      mode: reference-only
+      status: unverified
+      last_verified: '2026-07-14T21:35:14+02:00'
+      evidence_ref: contracts/consumer-evidence.v1.json#claims/integrity/summary::consumer::leitstand
+    - repo: wgx
+      files: []
+      mode: reference-only
+      status: unverified
+      last_verified: '2026-07-14T21:35:14+02:00'
+      evidence_ref: contracts/consumer-evidence.v1.json#claims/integrity/summary::consumer::wgx
+    lifecycle: active
+    last_verified: '2026-07-14T21:35:14+02:00'
+    replacement: null
+    status_reason: Reviewed against exact current default-branch commits for the declared repositories.
+    evidence_ref: contracts/consumer-evidence.v1.json#contracts/integrity/summary
+    producers:
+    - repo: semantAH
+      status: unverified
+      files: []
+      last_verified: '2026-07-14T21:35:14+02:00'
+      evidence_ref: contracts/consumer-evidence.v1.json#claims/integrity/summary::producer::semantAH
 knowledge:
   insights.daily:
     schema: contracts/insights.daily.schema.json
     consumers:
-      - repo: semantAH
-        files: []
-        mode: reference-only
-      - repo: chronik
-        files: []
-        mode: reference-only
-      - repo: leitstand
-        files: []
-        mode: reference-only
-
-  insights.daily.published: # Deprecated alias
+    - repo: semantAH
+      files:
+      - .github/workflows/insights-daily-drift.yml
+      - .github/workflows/publish-insights-daily.yml
+      - scripts/diff_daily_insights.py
+      - scripts/export_daily_insights.py
+      mode: reference-only
+      status: verified
+      last_verified: '2026-07-14T21:35:14+02:00'
+      evidence_ref: contracts/consumer-evidence.v1.json#claims/knowledge/insights.daily::consumer::semantAH
+    - repo: chronik
+      files:
+      - validation.py
+      - docs/insights.daily.schema.json
+      mode: reference-only
+      status: verified
+      last_verified: '2026-07-14T21:35:14+02:00'
+      evidence_ref: contracts/consumer-evidence.v1.json#claims/knowledge/insights.daily::consumer::chronik
+    - repo: leitstand
+      files:
+      - README.md
+      - docs/blueprints/leitstand_visualization.md
+      - docs/data-flow.md
+      mode: reference-only
+      status: verified
+      last_verified: '2026-07-14T21:35:14+02:00'
+      evidence_ref: contracts/consumer-evidence.v1.json#claims/knowledge/insights.daily::consumer::leitstand
+    lifecycle: active
+    last_verified: '2026-07-14T21:35:14+02:00'
+    replacement: null
+    status_reason: Reviewed against exact current default-branch commits for the declared repositories.
+    evidence_ref: contracts/consumer-evidence.v1.json#contracts/knowledge/insights.daily
+    producers:
+    - repo: semantAH
+      status: verified
+      files:
+      - .github/workflows/insights-daily-drift.yml
+      - .github/workflows/publish-insights-daily.yml
+      - scripts/diff_daily_insights.py
+      - scripts/export_daily_insights.py
+      last_verified: '2026-07-14T21:35:14+02:00'
+      evidence_ref: contracts/consumer-evidence.v1.json#claims/knowledge/insights.daily::producer::semantAH
+  insights.daily.published:
     schema: contracts/events/insights.daily.published.v1.schema.json
     consumers: []
     mode: reference-only
-
+    lifecycle: compatibility
+    last_verified: '2026-07-14T21:35:14+02:00'
+    replacement: knowledge/insights.daily.published.v1
+    status_reason: Deprecated alias retained for readers that still address the old key; no consumers are declared.
+    evidence_ref: contracts/consumer-evidence.v1.json#contracts/knowledge/insights.daily.published
+    producers:
+    - repo: semantAH
+      status: compatibility
+      files: []
+      last_verified: '2026-07-14T21:35:14+02:00'
+      evidence_ref: contracts/consumer-evidence.v1.json#claims/knowledge/insights.daily.published::producer::semantAH
   insights.daily.published.v1:
     schema: contracts/events/insights.daily.published.v1.schema.json
     consumers:
-      - repo: plexer
-        files: []
-        mode: notification-only
-      - repo: chronik
-        files: []
-        mode: reference-only
-      - repo: leitstand
-        files: []
-        mode: reference-only
-      - repo: hausKI
-        files: []
-        mode: reference-only
-
+    - repo: plexer
+      files: []
+      mode: notification-only
+      status: unverified
+      last_verified: '2026-07-14T21:35:14+02:00'
+      evidence_ref: contracts/consumer-evidence.v1.json#claims/knowledge/insights.daily.published.v1::consumer::plexer
+    - repo: chronik
+      files: []
+      mode: reference-only
+      status: unverified
+      last_verified: '2026-07-14T21:35:14+02:00'
+      evidence_ref: contracts/consumer-evidence.v1.json#claims/knowledge/insights.daily.published.v1::consumer::chronik
+    - repo: leitstand
+      files: []
+      mode: reference-only
+      status: unverified
+      last_verified: '2026-07-14T21:35:14+02:00'
+      evidence_ref: contracts/consumer-evidence.v1.json#claims/knowledge/insights.daily.published.v1::consumer::leitstand
+    - repo: hausKI
+      files: []
+      mode: reference-only
+      status: unverified
+      last_verified: '2026-07-14T21:35:14+02:00'
+      evidence_ref: contracts/consumer-evidence.v1.json#claims/knowledge/insights.daily.published.v1::consumer::hausKI
+    lifecycle: active
+    last_verified: '2026-07-14T21:35:14+02:00'
+    replacement: null
+    status_reason: Reviewed against exact current default-branch commits for the declared repositories.
+    evidence_ref: contracts/consumer-evidence.v1.json#contracts/knowledge/insights.daily.published.v1
+    producers:
+    - repo: semantAH
+      status: unverified
+      files: []
+      last_verified: '2026-07-14T21:35:14+02:00'
+      evidence_ref: contracts/consumer-evidence.v1.json#claims/knowledge/insights.daily.published.v1::producer::semantAH
   observatory:
     schema: contracts/knowledge.observatory.schema.json
     consumers:
-      - repo: leitstand
-        files: []
-        mode: reference-only
-      - repo: hausKI
-        files: []
-        mode: reference-only
-      - repo: heimlern
-        files: []
-        mode: reference-only
-
+    - repo: leitstand
+      files:
+      - scripts/vendor-contracts.mjs
+      - vendor/contracts/_pin.json
+      - vendor/contracts/knowledge/observatory.schema.json
+      mode: reference-only
+      status: verified
+      last_verified: '2026-07-14T21:35:14+02:00'
+      evidence_ref: contracts/consumer-evidence.v1.json#claims/knowledge/observatory::consumer::leitstand
+    - repo: hausKI
+      files: []
+      mode: reference-only
+      status: unverified
+      last_verified: '2026-07-14T21:35:14+02:00'
+      evidence_ref: contracts/consumer-evidence.v1.json#claims/knowledge/observatory::consumer::hausKI
+    - repo: heimlern
+      files: []
+      mode: reference-only
+      status: unverified
+      last_verified: '2026-07-14T21:35:14+02:00'
+      evidence_ref: contracts/consumer-evidence.v1.json#claims/knowledge/observatory::consumer::heimlern
+    lifecycle: active
+    last_verified: '2026-07-14T21:35:14+02:00'
+    replacement: null
+    status_reason: Reviewed against exact current default-branch commits for the declared repositories.
+    evidence_ref: contracts/consumer-evidence.v1.json#contracts/knowledge/observatory
+    producers:
+    - repo: semantAH
+      status: verified
+      files:
+      - .github/workflows/contracts-sync-guard.yml
+      - .github/workflows/knowledge-observatory-drift.yml
+      - .github/workflows/publish-knowledge-observatory.yml
+      - scripts/observatory_diff.py
+      last_verified: '2026-07-14T21:35:14+02:00'
+      evidence_ref: contracts/consumer-evidence.v1.json#claims/knowledge/observatory::producer::semantAH
   knowledge.observatory.published.v1:
     schema: contracts/events/knowledge.observatory.published.v1.schema.json
     consumers:
-      - repo: leitstand
-        files: []
-        mode: reference-only
-      - repo: hausKI
-        files: []
-        mode: reference-only
-      - repo: plexer
-        files: []
-        mode: notification-only
-
+    - repo: leitstand
+      files: []
+      mode: reference-only
+      status: unverified
+      last_verified: '2026-07-14T21:35:14+02:00'
+      evidence_ref: contracts/consumer-evidence.v1.json#claims/knowledge/knowledge.observatory.published.v1::consumer::leitstand
+    - repo: hausKI
+      files:
+      - crates/core/src/events.rs
+      - crates/core/src/events_tests.rs
+      mode: reference-only
+      status: verified
+      last_verified: '2026-07-14T21:35:14+02:00'
+      evidence_ref: contracts/consumer-evidence.v1.json#claims/knowledge/knowledge.observatory.published.v1::consumer::hausKI
+    - repo: plexer
+      files: []
+      mode: notification-only
+      status: unverified
+      last_verified: '2026-07-14T21:35:14+02:00'
+      evidence_ref: contracts/consumer-evidence.v1.json#claims/knowledge/knowledge.observatory.published.v1::consumer::plexer
+    lifecycle: active
+    last_verified: '2026-07-14T21:35:14+02:00'
+    replacement: null
+    status_reason: Reviewed against exact current default-branch commits for the declared repositories.
+    evidence_ref: contracts/consumer-evidence.v1.json#contracts/knowledge/knowledge.observatory.published.v1
+    producers:
+    - repo: semantAH
+      status: unverified
+      files: []
+      last_verified: '2026-07-14T21:35:14+02:00'
+      evidence_ref: contracts/consumer-evidence.v1.json#claims/knowledge/knowledge.observatory.published.v1::producer::semantAH
 os_context:
   state:
     schema: contracts/os.context.state.schema.json
     consumers:
-      - repo: mitschreiber
-        files: []
-        mode: reference-only
-
+    - repo: mitschreiber
+      files:
+      - .github/workflows/validate.yml
+      - docs/ci.md
+      - docs/contracts.md
+      - renovate.json
+      mode: reference-only
+      status: verified
+      last_verified: '2026-07-14T21:35:14+02:00'
+      evidence_ref: contracts/consumer-evidence.v1.json#claims/os_context/state::consumer::mitschreiber
+    lifecycle: active
+    last_verified: '2026-07-14T21:35:14+02:00'
+    replacement: null
+    status_reason: Reviewed against exact current default-branch commits for the declared repositories.
+    evidence_ref: contracts/consumer-evidence.v1.json#contracts/os_context/state
+    producers: []
   text.embed:
     schema: contracts/os.context.text.embed.schema.json
     consumers:
-      - repo: semantAH
-        files: []
-        mode: reference-only
-
+    - repo: semantAH
+      files:
+      - crates/indexd/src/api.rs
+      - scripts/observatory_mvp.py
+      - IMPLEMENTATION_SUMMARY.md
+      - contracts/os.context.text.embed.schema.json
+      mode: reference-only
+      status: verified
+      last_verified: '2026-07-14T21:35:14+02:00'
+      evidence_ref: contracts/consumer-evidence.v1.json#claims/os_context/text.embed::consumer::semantAH
+    lifecycle: active
+    last_verified: '2026-07-14T21:35:14+02:00'
+    replacement: null
+    status_reason: Reviewed against exact current default-branch commits for the declared repositories.
+    evidence_ref: contracts/consumer-evidence.v1.json#contracts/os_context/text.embed
+    producers: []
 policy:
   decision:
     schema: contracts/policy.decision.schema.json
     consumers:
-      - repo: heimlern
-        files: []
-        mode: reference-only
-      - repo: hausKI
-        files: []
-        mode: reference-only
-
+    - repo: heimlern
+      files:
+      - .github/workflows/validate-policy-decisions.yml
+      - scripts/validate_json.py
+      - README.md
+      - contracts/README.md
+      mode: reference-only
+      status: historical
+      last_verified: '2026-07-14T21:35:14+02:00'
+      evidence_ref: contracts/consumer-evidence.v1.json#claims/policy/decision::consumer::heimlern
+    - repo: hausKI
+      files: []
+      mode: reference-only
+      status: historical
+      last_verified: '2026-07-14T21:35:14+02:00'
+      evidence_ref: contracts/consumer-evidence.v1.json#claims/policy/decision::consumer::hausKI
+    lifecycle: historical
+    last_verified: '2026-07-14T21:35:14+02:00'
+    replacement: null
+    status_reason: Heimlern is explicitly frozen as historical implementation and has no active product or operator role.
+    evidence_ref: contracts/consumer-evidence.v1.json#contracts/policy/decision
+    producers:
+    - repo: heimlern
+      status: historical
+      files:
+      - .github/workflows/validate-policy-decisions.yml
+      - scripts/validate_json.py
+      - README.md
+      - contracts/README.md
+      last_verified: '2026-07-14T21:35:14+02:00'
+      evidence_ref: contracts/consumer-evidence.v1.json#claims/policy/decision::producer::heimlern
   feedback:
     schema: contracts/policy.feedback.schema.json
     consumers:
-      - repo: heimlern
-        files: []
-        mode: reference-only
-
+    - repo: heimlern
+      files:
+      - .github/workflows/rust.yml
+      - .github/workflows/validate-feedback-schema.yml
+      - scripts/validate_json.py
+      - tests/validate_feedback_schema.py
+      mode: reference-only
+      status: historical
+      last_verified: '2026-07-14T21:35:14+02:00'
+      evidence_ref: contracts/consumer-evidence.v1.json#claims/policy/feedback::consumer::heimlern
+    lifecycle: historical
+    last_verified: '2026-07-14T21:35:14+02:00'
+    replacement: null
+    status_reason: Heimlern is explicitly frozen as historical implementation and has no active product or operator role.
+    evidence_ref: contracts/consumer-evidence.v1.json#contracts/policy/feedback
+    producers:
+    - repo: heimlern
+      status: historical
+      files:
+      - .github/workflows/rust.yml
+      - .github/workflows/validate-feedback-schema.yml
+      - scripts/validate_json.py
+      - tests/validate_feedback_schema.py
+      last_verified: '2026-07-14T21:35:14+02:00'
+      evidence_ref: contracts/consumer-evidence.v1.json#claims/policy/feedback::producer::heimlern
   snapshot:
     schema: contracts/policy.snapshot.schema.json
     consumers:
-      - repo: heimlern
-        files: []
-        mode: reference-only
-
+    - repo: heimlern
+      files:
+      - crates/heimlern-bandits/README.md
+      - crates/heimlern-bandits/src/lib.rs
+      - scripts/validate_json.py
+      - Justfile
+      mode: reference-only
+      status: historical
+      last_verified: '2026-07-14T21:35:14+02:00'
+      evidence_ref: contracts/consumer-evidence.v1.json#claims/policy/snapshot::consumer::heimlern
+    lifecycle: historical
+    last_verified: '2026-07-14T21:35:14+02:00'
+    replacement: null
+    status_reason: Heimlern is explicitly frozen as historical implementation and has no active product or operator role.
+    evidence_ref: contracts/consumer-evidence.v1.json#contracts/policy/snapshot
+    producers:
+    - repo: heimlern
+      status: historical
+      files:
+      - crates/heimlern-bandits/README.md
+      - crates/heimlern-bandits/src/lib.rs
+      - scripts/validate_json.py
+      - Justfile
+      last_verified: '2026-07-14T21:35:14+02:00'
+      evidence_ref: contracts/consumer-evidence.v1.json#claims/policy/snapshot::producer::heimlern
   heimlern.ingest.state.v1:
     schema: contracts/heimlern.ingest.state.schema.json
     consumers:
-      - repo: heimlern
-        files: []
-        mode: mirror # Self-mirror: state is persisted and recovered by heimlern itself.
-      - repo: leitstand
-        files: []
-        mode: reference-only
-      - repo: heimgeist
-        files: []
-        mode: reference-only
-
+    - repo: heimlern
+      files: []
+      mode: mirror
+      status: historical
+      last_verified: '2026-07-14T21:35:14+02:00'
+      evidence_ref: contracts/consumer-evidence.v1.json#claims/policy/heimlern.ingest.state.v1::consumer::heimlern
+    - repo: leitstand
+      files: []
+      mode: reference-only
+      status: historical
+      last_verified: '2026-07-14T21:35:14+02:00'
+      evidence_ref: contracts/consumer-evidence.v1.json#claims/policy/heimlern.ingest.state.v1::consumer::leitstand
+    - repo: heimgeist
+      files: []
+      mode: reference-only
+      status: historical
+      last_verified: '2026-07-14T21:35:14+02:00'
+      evidence_ref: contracts/consumer-evidence.v1.json#claims/policy/heimlern.ingest.state.v1::consumer::heimgeist
+    lifecycle: historical
+    last_verified: '2026-07-14T21:35:14+02:00'
+    replacement: null
+    status_reason: The ingest state belongs to the historical Heimlern implementation and has no verified current consumer.
+    evidence_ref: contracts/consumer-evidence.v1.json#contracts/policy/heimlern.ingest.state.v1
+    producers:
+    - repo: heimlern
+      status: historical
+      files: []
+      last_verified: '2026-07-14T21:35:14+02:00'
+      evidence_ref: contracts/consumer-evidence.v1.json#claims/policy/heimlern.ingest.state.v1::producer::heimlern
 heim-pc:
   state.index:
     schema: contracts/heim-pc/state/heim-pc.state.index.schema.json
     consumers:
-      - repo: heim-pc
-        files: []
-        mode: mirror
+    - repo: heim-pc
+      files: []
+      mode: mirror
+      status: historical
+      last_verified: '2026-07-14T21:35:14+02:00'
+      evidence_ref: contracts/consumer-evidence.v1.json#claims/heim-pc/state.index::consumer::heim-pc
+    lifecycle: historical
+    last_verified: '2026-07-14T21:35:14+02:00'
+    replacement: null
+    status_reason: The current heim-pc operator-entry contract excludes state/index.json as current truth.
+    evidence_ref: contracts/consumer-evidence.v1.json#contracts/heim-pc/state.index
+    producers:
+    - repo: heim-pc
+      status: historical
+      files: []
+      last_verified: '2026-07-14T21:35:14+02:00'
+      evidence_ref: contracts/consumer-evidence.v1.json#claims/heim-pc/state.index::producer::heim-pc
   state.repos:
     schema: contracts/heim-pc/state/heim-pc.state.repos.schema.json
     consumers:
-      - repo: heim-pc
-        files: []
-        mode: mirror
+    - repo: heim-pc
+      files: []
+      mode: mirror
+      status: historical
+      last_verified: '2026-07-14T21:35:14+02:00'
+      evidence_ref: contracts/consumer-evidence.v1.json#claims/heim-pc/state.repos::consumer::heim-pc
+    lifecycle: historical
+    last_verified: '2026-07-14T21:35:14+02:00'
+    replacement: null
+    status_reason: The current heim-pc operator-entry contract excludes state/repos.json as current truth.
+    evidence_ref: contracts/consumer-evidence.v1.json#contracts/heim-pc/state.repos
+    producers:
+    - repo: heim-pc
+      status: historical
+      files: []
+      last_verified: '2026-07-14T21:35:14+02:00'
+      evidence_ref: contracts/consumer-evidence.v1.json#claims/heim-pc/state.repos::producer::heim-pc
   state.uncertainties:
     schema: contracts/heim-pc/state/heim-pc.state.uncertainties.schema.json
     consumers:
-      - repo: heim-pc
-        files: []
-        mode: mirror
+    - repo: heim-pc
+      files: []
+      mode: mirror
+      status: historical
+      last_verified: '2026-07-14T21:35:14+02:00'
+      evidence_ref: contracts/consumer-evidence.v1.json#claims/heim-pc/state.uncertainties::consumer::heim-pc
+    lifecycle: historical
+    last_verified: '2026-07-14T21:35:14+02:00'
+    replacement: null
+    status_reason: No current repository reference to this schema was found in the audited heim-pc main commit.
+    evidence_ref: contracts/consumer-evidence.v1.json#contracts/heim-pc/state.uncertainties
+    producers:
+    - repo: heim-pc
+      status: historical
+      files: []
+      last_verified: '2026-07-14T21:35:14+02:00'
+      evidence_ref: contracts/consumer-evidence.v1.json#claims/heim-pc/state.uncertainties::producer::heim-pc
   state.insights:
     schema: contracts/heim-pc/state/heim-pc.state.insights.schema.json
     consumers:
-      - repo: heim-pc
-        files: []
-        mode: mirror
+    - repo: heim-pc
+      files: []
+      mode: mirror
+      status: historical
+      last_verified: '2026-07-14T21:35:14+02:00'
+      evidence_ref: contracts/consumer-evidence.v1.json#claims/heim-pc/state.insights::consumer::heim-pc
+    lifecycle: historical
+    last_verified: '2026-07-14T21:35:14+02:00'
+    replacement: null
+    status_reason: No current repository reference to this schema was found in the audited heim-pc main commit.
+    evidence_ref: contracts/consumer-evidence.v1.json#contracts/heim-pc/state.insights
+    producers:
+    - repo: heim-pc
+      status: historical
+      files: []
+      last_verified: '2026-07-14T21:35:14+02:00'
+      evidence_ref: contracts/consumer-evidence.v1.json#claims/heim-pc/state.insights::producer::heim-pc
   state.drift:
     schema: contracts/heim-pc/state/heim-pc.state.drift.schema.json
     consumers:
-      - repo: heim-pc
-        files: []
-        mode: mirror
+    - repo: heim-pc
+      files: []
+      mode: mirror
+      status: historical
+      last_verified: '2026-07-14T21:35:14+02:00'
+      evidence_ref: contracts/consumer-evidence.v1.json#claims/heim-pc/state.drift::consumer::heim-pc
+    lifecycle: historical
+    last_verified: '2026-07-14T21:35:14+02:00'
+    replacement: null
+    status_reason: No current repository reference to this schema was found in the audited heim-pc main commit.
+    evidence_ref: contracts/consumer-evidence.v1.json#contracts/heim-pc/state.drift
+    producers:
+    - repo: heim-pc
+      status: historical
+      files: []
+      last_verified: '2026-07-14T21:35:14+02:00'
+      evidence_ref: contracts/consumer-evidence.v1.json#claims/heim-pc/state.drift::producer::heim-pc
   config.zones:
     schema: contracts/heim-pc/config/zones.schema.json
     consumers:
-      - repo: heim-pc
-        files: []
-        mode: mirror
+    - repo: heim-pc
+      files: []
+      mode: mirror
+      status: compatibility
+      last_verified: '2026-07-14T21:35:14+02:00'
+      evidence_ref: contracts/consumer-evidence.v1.json#claims/heim-pc/config.zones::consumer::heim-pc
+    lifecycle: compatibility
+    last_verified: '2026-07-14T21:35:14+02:00'
+    replacement: null
+    status_reason: Advalidator reference remains in heim-pc, but the registry does not establish an active runtime data flow.
+    evidence_ref: contracts/consumer-evidence.v1.json#contracts/heim-pc/config.zones
+    producers:
+    - repo: heim-pc
+      status: compatibility
+      files:
+      - scripts/validate_contracts.py
+      last_verified: '2026-07-14T21:35:14+02:00'
+      evidence_ref: contracts/consumer-evidence.v1.json#claims/heim-pc/config.zones::producer::heim-pc

--- a/docs/contracts/contracts-index.md
+++ b/docs/contracts/contracts-index.md
@@ -1,17 +1,21 @@
 # Contracts-Index des Heimgewebes
 
-Dieses Dokument listet die wichtigsten und derzeit aktiv genutzten Daten-Contracts des Heimgewebes und verknüpft sie mit den jeweiligen Repositories.
+Dieses Dokument ist eine menschlich lesbare Orientierung über wichtige Contractfamilien. Es ist weder vollständig noch eine aktuelle Consumer- oder Runtime-Inventur.
 
-**Hinweis:** Dies ist ein kuratierter Einstiegspunkt, der keinen Anspruch auf Vollständigkeit erhebt, sondern die systemweit relevanten Contracts hervorhebt.
+Maschinenlesbare Quellen:
 
-Ziel:
+- Die von Metarepo veröffentlichten Shared-Contract-Bytes liegen unter `contracts/`.
+- `contracts/consumers.yaml` enthält Lifecycle, Ablösepfade und den überprüften Claimstatus.
+- `contracts/consumer-evidence.v1.json` bindet jeden Claim an exakte Repository-Commits und Pfade.
+- `scripts/contracts/validate_consumers.py` prüft die Bindung fail-closed.
 
-- ein **zentraler Blick** auf alle strukturbildenden Schemas,
-- klare Zuordnung: *welches Repo spricht welchen Contract*,
-- Grundlage für **Codegeneration**, **Validierung** und **Review-Automatisierung**.
+Ein `verified`-Claim belegt Repositorykopplung am auditierten Commit, nicht Live-Nutzung, Gesundheit oder Zustellung. `unverified`, `compatibility` und `historical` bleiben absichtlich sichtbar und dürfen nicht zu aktiver Wahrheit hochgestuft werden.
 
-Die Details der Schemas liegen immer in den jeweiligen Dateien (JSON-Schema, Protobuf, YAML).
-**Quelle der Wahrheit ist immer das jeweilige Repo, nicht dieses Dokument.**
+Ziel dieses Dokuments:
+
+- Contractfamilien verständlich einordnen,
+- auf die kanonischen Schema- und Evidenzdateien verweisen,
+- keine zweite Consumer- oder Runtime-Wahrheit erzeugen.
 
 ---
 

--- a/scripts/contracts/validate_consumers.py
+++ b/scripts/contracts/validate_consumers.py
@@ -1,0 +1,362 @@
+#!/usr/bin/env python3
+"""Validate the evidence-bound Metarepo contract consumer registry."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[2]
+REGISTRY_PATH = ROOT / "contracts/consumers.yaml"
+EVIDENCE_PATH = ROOT / "contracts/consumer-evidence.v1.json"
+
+LIFECYCLES = {"active", "compatibility", "historical"}
+STATUSES = {"verified", "unverified", "compatibility", "historical"}
+ROLES = {"producer", "consumer"}
+MODES = {None, "mirror", "reference-only", "notification-only"}
+SHA40 = re.compile(r"^[0-9a-f]{40}$")
+SHA64 = re.compile(r"^[0-9a-f]{64}$")
+REPO_NAME = re.compile(r"^[A-Za-z0-9._-]+$")
+
+
+class RegistryError(ValueError):
+    """Raised when the registry or its evidence is inconsistent."""
+
+
+def _require_string(value: Any, label: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise RegistryError(f"{label} must be a non-empty string")
+    return value
+
+
+def _require_list(value: Any, label: str) -> list[Any]:
+    if not isinstance(value, list):
+        raise RegistryError(f"{label} must be an array")
+    return value
+
+
+def _safe_relative_path(value: Any, label: str) -> str:
+    text = _require_string(value, label)
+    path = Path(text)
+    if path.is_absolute() or ".." in path.parts:
+        raise RegistryError(f"{label} must stay within its repository")
+    return text
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+def _claim_ref(ref: Any, expected_id: str) -> None:
+    expected = f"contracts/consumer-evidence.v1.json#claims/{expected_id}"
+    if ref != expected:
+        raise RegistryError(f"claim evidence_ref mismatch for {expected_id}")
+
+
+def _contract_ref(ref: Any, expected_id: str) -> None:
+    expected = f"contracts/consumer-evidence.v1.json#contracts/{expected_id}"
+    if ref != expected:
+        raise RegistryError(f"contract evidence_ref mismatch for {expected_id}")
+
+
+def _validate_claim(
+    *,
+    identity: str,
+    role: str,
+    item: dict[str, Any],
+    evidence_claims: dict[str, dict[str, Any]],
+    repository_heads: dict[str, str],
+    observed_at: str,
+    schema_sha256: str | None,
+) -> None:
+    if role not in ROLES:
+        raise RegistryError(f"unsupported role: {role}")
+    repo = _require_string(item.get("repo"), f"{identity}.{role}.repo")
+    if not REPO_NAME.fullmatch(repo):
+        raise RegistryError(f"{identity}.{role}.{repo}.repo is invalid")
+    status = item.get("status")
+    if status not in STATUSES:
+        raise RegistryError(f"{identity}.{role}.{repo}.status is invalid")
+    mode = item.get("mode") if role == "consumer" else None
+    if mode not in MODES:
+        raise RegistryError(f"{identity}.{role}.{repo}.mode is invalid")
+    if item.get("last_verified") != observed_at:
+        raise RegistryError(f"{identity}.{role}.{repo}.last_verified differs from evidence")
+    files = _require_list(item.get("files"), f"{identity}.{role}.{repo}.files")
+    normalized_files = [
+        _safe_relative_path(path, f"{identity}.{role}.{repo}.files") for path in files
+    ]
+    if len(normalized_files) != len(set(normalized_files)):
+        raise RegistryError(f"{identity}.{role}.{repo}.files contains duplicates")
+
+    claim_id = f"{identity}::{role}::{repo}"
+    _claim_ref(item.get("evidence_ref"), claim_id)
+    claim = evidence_claims.get(claim_id)
+    if claim is None:
+        raise RegistryError(f"evidence claim missing: {claim_id}")
+    expected_repository = f"heimgewebe/{repo}"
+    expected = {
+        "contract": identity,
+        "role": role,
+        "repository": expected_repository,
+        "status": status,
+        "mode": mode,
+        "files": normalized_files,
+    }
+    for key, value in expected.items():
+        if claim.get(key) != value:
+            raise RegistryError(f"evidence claim {claim_id} differs at {key}")
+    commit = claim.get("commit")
+    if not isinstance(commit, str) or not SHA40.fullmatch(commit):
+        raise RegistryError(f"evidence claim {claim_id} has invalid commit")
+    if repository_heads.get(expected_repository) != commit:
+        raise RegistryError(f"evidence claim {claim_id} is not bound to scope commit")
+
+    evidence_items = _require_list(claim.get("evidence"), f"{claim_id}.evidence")
+    evidence_paths: list[str] = []
+    for index, evidence in enumerate(evidence_items):
+        if not isinstance(evidence, dict):
+            raise RegistryError(f"{claim_id}.evidence[{index}] must be an object")
+        path = _safe_relative_path(evidence.get("path"), f"{claim_id}.evidence[{index}].path")
+        line = evidence.get("line")
+        if not isinstance(line, int) or line < 1:
+            raise RegistryError(f"{claim_id}.evidence[{index}].line must be positive")
+        _require_string(evidence.get("kind"), f"{claim_id}.evidence[{index}].kind")
+        evidence_paths.append(path)
+
+    if status == "verified":
+        if not normalized_files or not evidence_items:
+            raise RegistryError(f"verified claim {claim_id} requires files and evidence")
+        if mode != "mirror" and not set(normalized_files).issubset(set(evidence_paths)):
+            raise RegistryError(f"verified claim {claim_id} files are not evidence-bound")
+
+    if mode == "mirror" and status == "verified":
+        checks = _require_list(claim.get("mirrorChecks"), f"{claim_id}.mirrorChecks")
+        if not checks:
+            raise RegistryError(f"verified mirror {claim_id} requires byte checks")
+        checked_paths = set()
+        for index, check in enumerate(checks):
+            if not isinstance(check, dict):
+                raise RegistryError(f"{claim_id}.mirrorChecks[{index}] must be an object")
+            path = _safe_relative_path(
+                check.get("path"), f"{claim_id}.mirrorChecks[{index}].path"
+            )
+            checked_paths.add(path)
+            if check.get("exists") is not True or check.get("matches_canonical") is not True:
+                raise RegistryError(f"verified mirror {claim_id} is not byte-identical")
+            digest = check.get("sha256")
+            if not isinstance(digest, str) or not SHA64.fullmatch(digest):
+                raise RegistryError(f"verified mirror {claim_id} has invalid sha256")
+            if schema_sha256 is not None and digest != schema_sha256:
+                raise RegistryError(f"verified mirror {claim_id} differs from canonical schema")
+        if not set(normalized_files).issubset(checked_paths | set(evidence_paths)):
+            raise RegistryError(f"verified mirror {claim_id} lacks checks for declared files")
+
+
+def validate_registry(root: Path = ROOT) -> dict[str, int]:
+    registry_path = root / REGISTRY_PATH.relative_to(ROOT)
+    evidence_path = root / EVIDENCE_PATH.relative_to(ROOT)
+    try:
+        registry = yaml.safe_load(registry_path.read_text(encoding="utf-8"))
+    except (OSError, yaml.YAMLError) as exc:
+        raise RegistryError(f"cannot parse {registry_path}: {exc}") from exc
+    try:
+        evidence = json.loads(evidence_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise RegistryError(f"cannot parse {evidence_path}: {exc}") from exc
+
+    if not isinstance(registry, dict) or not registry:
+        raise RegistryError("consumer registry must be a non-empty mapping")
+    if evidence.get("schemaVersion") != 1 or evidence.get("kind") != "metarepo_contract_consumer_evidence":
+        raise RegistryError("consumer evidence identity mismatch")
+    observed_at = _require_string(evidence.get("observedAt"), "evidence.observedAt")
+    try:
+        parsed_observed_at = datetime.fromisoformat(observed_at)
+    except ValueError as exc:
+        raise RegistryError("evidence.observedAt must be an ISO-8601 timestamp") from exc
+    if parsed_observed_at.tzinfo is None:
+        raise RegistryError("evidence.observedAt must include a timezone")
+    source = evidence.get("source")
+    if not isinstance(source, dict):
+        raise RegistryError("evidence.source must be an object")
+    if source.get("repository") != "heimgewebe/metarepo":
+        raise RegistryError("evidence source repository mismatch")
+    if not isinstance(source.get("commit"), str) or not SHA40.fullmatch(source["commit"]):
+        raise RegistryError("evidence source commit invalid")
+    if not isinstance(source.get("auditFinalizationReceiptSha256"), str) or not SHA64.fullmatch(
+        source["auditFinalizationReceiptSha256"]
+    ):
+        raise RegistryError("evidence audit receipt invalid")
+    _require_string(source.get("auditJob"), "evidence.source.auditJob")
+    _require_string(source.get("method"), "evidence.source.method")
+
+    scope = evidence.get("scope")
+    if not isinstance(scope, dict):
+        raise RegistryError("evidence.scope must be an object")
+    if scope.get("completeForDeclaredRepositories") is not True:
+        raise RegistryError("evidence must cover every declared repository")
+    if scope.get("completeForOrganization") is not False:
+        raise RegistryError("evidence must not claim complete organization coverage")
+    if not isinstance(scope.get("githubCodeSearchComplete"), bool):
+        raise RegistryError("evidence.scope.githubCodeSearchComplete must be boolean")
+    repository_heads: dict[str, str] = {}
+    for index, repository in enumerate(_require_list(scope.get("repositories"), "scope.repositories")):
+        if not isinstance(repository, dict):
+            raise RegistryError(f"scope.repositories[{index}] must be an object")
+        name = _require_string(repository.get("repository"), f"scope.repositories[{index}].repository")
+        commit = repository.get("commit")
+        if not isinstance(commit, str) or not SHA40.fullmatch(commit):
+            raise RegistryError(f"scope.repositories[{index}].commit invalid")
+        if name in repository_heads:
+            raise RegistryError(f"duplicate scope repository: {name}")
+        repository_heads[name] = commit
+
+    evidence_contracts: dict[str, dict[str, Any]] = {}
+    for item in _require_list(evidence.get("contracts"), "evidence.contracts"):
+        if not isinstance(item, dict):
+            raise RegistryError("evidence contract must be an object")
+        identity = _require_string(item.get("id"), "evidence contract id")
+        if identity in evidence_contracts:
+            raise RegistryError(f"duplicate evidence contract: {identity}")
+        evidence_contracts[identity] = item
+
+    evidence_claims: dict[str, dict[str, Any]] = {}
+    for item in _require_list(evidence.get("claims"), "evidence.claims"):
+        if not isinstance(item, dict):
+            raise RegistryError("evidence claim must be an object")
+        claim_id = _require_string(item.get("id"), "evidence claim id")
+        if claim_id in evidence_claims:
+            raise RegistryError(f"duplicate evidence claim: {claim_id}")
+        evidence_claims[claim_id] = item
+
+    identities: set[str] = set()
+    claim_count = 0
+    for category, entries in registry.items():
+        _require_string(category, "registry category")
+        if not isinstance(entries, dict) or not entries:
+            raise RegistryError(f"registry category {category} must be a non-empty mapping")
+        for contract_name, item in entries.items():
+            identity = f"{category}/{contract_name}"
+            if identity in identities:
+                raise RegistryError(f"duplicate contract identity: {identity}")
+            identities.add(identity)
+            if not isinstance(item, dict):
+                raise RegistryError(f"{identity} must be an object")
+            schema = _safe_relative_path(item.get("schema"), f"{identity}.schema")
+            if not schema.startswith("contracts/"):
+                raise RegistryError(f"{identity}.schema must stay below contracts/")
+            lifecycle = item.get("lifecycle")
+            if lifecycle not in LIFECYCLES:
+                raise RegistryError(f"{identity}.lifecycle is invalid")
+            if item.get("last_verified") != observed_at:
+                raise RegistryError(f"{identity}.last_verified differs from evidence")
+            _require_string(item.get("status_reason"), f"{identity}.status_reason")
+            replacement = item.get("replacement")
+            if replacement is not None:
+                _require_string(replacement, f"{identity}.replacement")
+            _contract_ref(item.get("evidence_ref"), identity)
+
+            schema_path = root / schema
+            schema_exists = schema_path.is_file()
+            if lifecycle != "historical" and not schema_exists:
+                raise RegistryError(f"{identity} active or compatibility schema is missing: {schema}")
+            schema_digest = _sha256(schema_path) if schema_exists else None
+
+            contract_evidence = evidence_contracts.get(identity)
+            if contract_evidence is None:
+                raise RegistryError(f"contract evidence missing: {identity}")
+            expected_contract = {
+                "schema": schema,
+                "schemaExists": schema_exists,
+                "schemaSha256": schema_digest,
+                "lifecycle": lifecycle,
+                "replacement": replacement,
+            }
+            for key, value in expected_contract.items():
+                if contract_evidence.get(key) != value:
+                    raise RegistryError(f"contract evidence {identity} differs at {key}")
+
+            allowed_statuses = {
+                "active": {"verified", "unverified"},
+                "compatibility": {"compatibility"},
+                "historical": {"historical"},
+            }[lifecycle]
+            for producer in _require_list(item.get("producers"), f"{identity}.producers"):
+                if not isinstance(producer, dict):
+                    raise RegistryError(f"{identity}.producer must be an object")
+                if producer.get("status") not in allowed_statuses:
+                    raise RegistryError(f"{identity}.producer status conflicts with lifecycle {lifecycle}")
+                _validate_claim(
+                    identity=identity,
+                    role="producer",
+                    item=producer,
+                    evidence_claims=evidence_claims,
+                    repository_heads=repository_heads,
+                    observed_at=observed_at,
+                    schema_sha256=schema_digest,
+                )
+                claim_count += 1
+            for consumer in _require_list(item.get("consumers"), f"{identity}.consumers"):
+                if not isinstance(consumer, dict):
+                    raise RegistryError(f"{identity}.consumer must be an object")
+                if consumer.get("status") not in allowed_statuses:
+                    raise RegistryError(f"{identity}.consumer status conflicts with lifecycle {lifecycle}")
+                _validate_claim(
+                    identity=identity,
+                    role="consumer",
+                    item=consumer,
+                    evidence_claims=evidence_claims,
+                    repository_heads=repository_heads,
+                    observed_at=observed_at,
+                    schema_sha256=schema_digest,
+                )
+                claim_count += 1
+
+    for identity, item in evidence_contracts.items():
+        if identity not in identities:
+            raise RegistryError(f"orphan evidence contract: {identity}")
+    if set(evidence_claims) != {
+        f"{identity}::{role}::{claim['repo']}"
+        for category, entries in registry.items()
+        for contract_name, contract in entries.items()
+        for role, key in (("producer", "producers"), ("consumer", "consumers"))
+        for claim in contract.get(key, [])
+        for identity in [f"{category}/{contract_name}"]
+    }:
+        raise RegistryError("evidence claim coverage differs from registry")
+
+    replacements = {
+        item.get("replacement")
+        for entries in registry.values()
+        for item in entries.values()
+        if item.get("replacement") is not None
+    }
+    missing_replacements = replacements - identities
+    if missing_replacements:
+        raise RegistryError(f"replacement identities missing: {sorted(missing_replacements)}")
+
+    return {
+        "contracts": len(identities),
+        "claims": claim_count,
+        "repositories": len(repository_heads),
+    }
+
+
+def main() -> int:
+    try:
+        summary = validate_registry()
+    except RegistryError as exc:
+        print(f"contract-consumer-registry: FAIL: {exc}", file=sys.stderr)
+        return 1
+    print(json.dumps({"status": "valid", **summary}, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate-contracts.sh
+++ b/scripts/validate-contracts.sh
@@ -306,3 +306,12 @@ if ((${#fixtures[@]} > 0)); then
 else
   echo "No fixtures found under fixtures/"
 fi
+
+# Governance registry: validate lifecycle, provenance and evidence-bound producer/consumer claims.
+echo "::group::Validate contract consumer registry"
+if command -v uv > /dev/null 2>&1; then
+  uv run python scripts/contracts/validate_consumers.py
+else
+  python3 scripts/contracts/validate_consumers.py
+fi
+echo "::endgroup::"

--- a/tests/test_contract_consumers_registry.py
+++ b/tests/test_contract_consumers_registry.py
@@ -1,0 +1,176 @@
+from __future__ import annotations
+
+import json
+import shutil
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[1]
+VALIDATOR_DIR = ROOT / "scripts" / "contracts"
+if str(VALIDATOR_DIR) not in sys.path:
+    sys.path.insert(0, str(VALIDATOR_DIR))
+
+from validate_consumers import RegistryError, validate_registry  # noqa: E402
+
+
+def _fixture_root(directory: str) -> Path:
+    target = Path(directory) / "repo"
+    shutil.copytree(ROOT / "contracts", target / "contracts")
+    return target
+
+
+def _load_registry(root: Path) -> dict[str, object]:
+    return yaml.safe_load((root / "contracts" / "consumers.yaml").read_text(encoding="utf-8"))
+
+
+def _write_registry(root: Path, registry: dict[str, object]) -> None:
+    (root / "contracts" / "consumers.yaml").write_text(
+        yaml.safe_dump(registry, sort_keys=False, allow_unicode=True),
+        encoding="utf-8",
+    )
+
+
+def _load_evidence(root: Path) -> dict[str, object]:
+    return json.loads(
+        (root / "contracts" / "consumer-evidence.v1.json").read_text(encoding="utf-8")
+    )
+
+
+def _write_evidence(root: Path, evidence: dict[str, object]) -> None:
+    (root / "contracts" / "consumer-evidence.v1.json").write_text(
+        json.dumps(evidence, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _claim(evidence: dict[str, object], claim_id: str) -> dict[str, object]:
+    return next(item for item in evidence["claims"] if item["id"] == claim_id)
+
+
+def _contract_evidence(evidence: dict[str, object], contract_id: str) -> dict[str, object]:
+    return next(item for item in evidence["contracts"] if item["id"] == contract_id)
+
+
+def test_current_registry_is_valid_and_evidence_bound() -> None:
+    summary = validate_registry(ROOT)
+
+    assert summary == {"contracts": 23, "claims": 59, "repositories": 11}
+
+
+def test_active_contract_with_missing_schema_fails_closed() -> None:
+    with tempfile.TemporaryDirectory() as directory:
+        root = _fixture_root(directory)
+        registry = _load_registry(root)
+        registry["event_backbone"]["aussen.event"]["schema"] = (
+            "contracts/missing-active.schema.json"
+        )
+        _write_registry(root, registry)
+
+        with pytest.raises(RegistryError, match="active or compatibility schema is missing"):
+            validate_registry(root)
+
+
+def test_verified_claim_without_files_and_evidence_fails_closed() -> None:
+    with tempfile.TemporaryDirectory() as directory:
+        root = _fixture_root(directory)
+        claim_id = "event_backbone/aussen.event::consumer::chronik"
+        registry = _load_registry(root)
+        consumer = next(
+            item
+            for item in registry["event_backbone"]["aussen.event"]["consumers"]
+            if item["repo"] == "chronik"
+        )
+        consumer["files"] = []
+        _write_registry(root, registry)
+
+        evidence = _load_evidence(root)
+        claim = _claim(evidence, claim_id)
+        claim["files"] = []
+        claim["evidence"] = []
+        _write_evidence(root, evidence)
+
+        with pytest.raises(RegistryError, match="requires files and evidence"):
+            validate_registry(root)
+
+
+def test_verified_mirror_with_wrong_hash_fails_closed() -> None:
+    with tempfile.TemporaryDirectory() as directory:
+        root = _fixture_root(directory)
+        evidence = _load_evidence(root)
+        claim = _claim(
+            evidence,
+            "event_backbone/aussen.event::consumer::aussensensor",
+        )
+        claim["mirrorChecks"][0]["sha256"] = "0" * 64
+        _write_evidence(root, evidence)
+
+        with pytest.raises(RegistryError, match="differs from canonical schema"):
+            validate_registry(root)
+
+
+def test_claim_commit_must_match_audited_scope_commit() -> None:
+    with tempfile.TemporaryDirectory() as directory:
+        root = _fixture_root(directory)
+        evidence = _load_evidence(root)
+        claim = _claim(
+            evidence,
+            "knowledge/insights.daily::producer::semantAH",
+        )
+        claim["commit"] = "0" * 40
+        _write_evidence(root, evidence)
+
+        with pytest.raises(RegistryError, match="is not bound to scope commit"):
+            validate_registry(root)
+
+
+def test_replacement_must_resolve_to_registered_contract() -> None:
+    with tempfile.TemporaryDirectory() as directory:
+        root = _fixture_root(directory)
+        registry = _load_registry(root)
+        registry["knowledge"]["insights.daily.published"]["replacement"] = (
+            "knowledge/missing-replacement"
+        )
+        _write_registry(root, registry)
+
+        evidence = _load_evidence(root)
+        _contract_evidence(
+            evidence,
+            "knowledge/insights.daily.published",
+        )["replacement"] = "knowledge/missing-replacement"
+        _write_evidence(root, evidence)
+
+        with pytest.raises(RegistryError, match="replacement identities missing"):
+            validate_registry(root)
+
+def test_claim_status_must_match_contract_lifecycle() -> None:
+    with tempfile.TemporaryDirectory() as directory:
+        root = _fixture_root(directory)
+        registry = _load_registry(root)
+        producer = registry["policy"]["decision"]["producers"][0]
+        producer["status"] = "verified"
+        _write_registry(root, registry)
+
+        evidence = _load_evidence(root)
+        claim = _claim(evidence, "policy/decision::producer::heimlern")
+        claim["status"] = "verified"
+        _write_evidence(root, evidence)
+
+        with pytest.raises(RegistryError, match="status conflicts with lifecycle historical"):
+            validate_registry(root)
+
+
+def test_evidence_must_cover_every_declared_repository() -> None:
+    with tempfile.TemporaryDirectory() as directory:
+        root = _fixture_root(directory)
+        evidence = _load_evidence(root)
+        evidence["scope"]["completeForDeclaredRepositories"] = False
+        _write_evidence(root, evidence)
+
+        with pytest.raises(RegistryError, match="must cover every declared repository"):
+            validate_registry(root)
+


### PR DESCRIPTION
## Zweck

`contracts/consumers.yaml` war bislang eine unvalidierte Mischung aus aktuellen, historischen und nur behaupteten Beziehungen. Dieser PR erhält die vorhandene YAML-Grundstruktur rückwärtskompatibel, bindet aber jeden Contract sowie jeden Producer-/Consumer-Claim an einen maschinenlesbaren Evidenzsatz.

## Live-Audit

Geprüft wurden alle 23 vorhandenen Registereinträge gegen exakte aktuelle Main-Commits der elf bereits deklarierten Repositories. Grundlage waren isolierte flache Klone und fixed-string Repository-Scans; fremde lokale Checkouts blieben unangetastet.

Ergebnis vor dem Patch:
- 23 Contracts, davon 1 referenziertes Schema nicht vorhanden
- 39 deklarierte Consumer
- 1 von 8 Mirror-Beziehungen bytegleich belegt
- 16 deklarierte Referenzen im angegebenen aktuellen Repository nicht auffindbar

## Änderungen

- `contracts/consumers.yaml` um Lifecycle, Ablösepfad, Verifikationszeitpunkt, Producer und Claimstatus erweitert
- `contracts/consumer-evidence.v1.json` mit 23 Contract- und 59 commit-/pfadgebundenen Claimbelegen ergänzt
- Lifecycle ausdrücklich getrennt: 11 aktiv, 2 Compatibility, 10 historisch
- Claimstatus ausdrücklich getrennt: 15 verified, 19 unverified, 3 compatibility, 22 historical
- fehlendes Chronik-Fixture-Schema nicht erfunden, sondern historisch und sichtbar markiert
- Heimlern-Policyflächen sowie ausgeschlossene heim-pc-State-Dateien historisiert
- `scripts/contracts/validate_consumers.py` als fail-closed Guard ergänzt
- acht positive/negative Regressionstests ergänzt
- Contract-CI und lokalen Contract-Entry um Validator und Tests erweitert
- README und Contract-Index an die tatsächlichen Wahrheitsgrenzen angepasst

## Verifikationsregeln

Der Guard blockiert insbesondere:
- fehlende aktive oder Compatibility-Schemas
- Lifecycle-/Claimstatus-Widersprüche
- `verified` ohne Datei- und Pfadevidenz
- falsche Repository-Commits
- falsche Mirror-Hashes
- verwaiste Ablöseziele
- zurückgenommene Abdeckung der elf deklarierten Repositories

`verified` belegt Repositorykopplung am auditierten Commit. Es belegt nicht Runtime-Nutzung, Gesundheit, Zustellung, semantische Korrektheit oder künftige Kompatibilität. Organisationsvollständigkeit wird ausdrücklich nicht behauptet.

## Prüfung

- `uv run python scripts/contracts/validate_consumers.py`: PASS, 23 Contracts / 59 Claims / 11 Repositories
- gezielte Guardtests: 8/8 PASS
- `env ALLOW_NET=1 just validate`: PASS am Commit `70b9c25e18a97fc44e83cfe5f3fe85d87edd74b0`
- vollständige Python-Suite: 101 Tests PASS
- Shell-Regressionen, YAML-Validierung und actionlint: PASS
- commitgebundener Finalization-Receipt: `ffd5c5f02c08fa5b388d1db4e535309ea05b1eecd5db2c5ba351c34a407706bc`
- `git diff --check`: PASS

## Parallelität

Der Patch berührt ausschließlich acht separat geleaste Contract-/CI-Dateien und überschneidet sich nicht mit der parallel aktiven Fleet-Konsolidierung T002.

Bureau-Kandidat: `METAREPO-LEGACY-RECONCILIATION-V1-T004`