### PR TITLE
tools: Actionlint-Installer fail-closed härten

### DIFF
--- a/scripts/tools/actionlint-pin.sh
+++ b/scripts/tools/actionlint-pin.sh
@@ -73,10 +73,12 @@ download_tool() {
   local checksum_base="https://github.com/rhysd/actionlint/releases/download/${req_version_raw}"
 
   ensure_dir
-  local tmp_bin tmp_checksum
+  local tmp_bin tmp_checksum tmp_extract tmp_target
   tmp_bin="$(mktemp)"
   tmp_checksum="$(mktemp)"
-  trap 'rm -f -- "${tmp_bin-}" "${tmp_checksum-}" 2>/dev/null || true' EXIT
+  tmp_extract="$(mktemp -d)"
+  tmp_target="$(mktemp "${BIN_DIR}/.${TOOL_NAME}.tmp.XXXXXX")"
+  trap 'rm -rf -- "${tmp_bin-}" "${tmp_checksum-}" "${tmp_extract-}" "${tmp_target-}" 2>/dev/null || true' EXIT
 
   log "Downloading actionlint from ${url}"
   log "Version: ${req_version_raw}, Target: ${target}, Filename: ${filename}"
@@ -90,57 +92,51 @@ download_tool() {
     die "Download fehlgeschlagen: ${url}"
   fi
 
-  local checksum_candidates=("checksums.txt" "checksums" "SHA256SUMS")
-  local checksum_found=false
+  local checksum_filename="${TOOL_NAME}_${ver_numeric}_checksums.txt"
+  local checksum_url="${checksum_base}/${checksum_filename}"
 
-  for cand in "${checksum_candidates[@]}"; do
-    local c_url="${checksum_base}/${cand}"
-    log "Versuche Checksummen von ${c_url}..."
-    if curl -fSL --retry 3 --connect-timeout 10 "${c_url}" -o "${tmp_checksum}"; then
-      log "Checksummen geladen: ${cand}"
-      checksum_found=true
-      break
-    fi
-  done
-
-  if $checksum_found; then
-    log "Verifiziere Checksumme..."
-    local expected_sum
-    expected_sum=$(grep "${filename}$" "${tmp_checksum}" | awk '{print $1}' || true)
-
-    if [[ -z "${expected_sum}" ]]; then
-      log "WARN: Keine Checksumme für ${filename} gefunden."
-    else
-      local actual_sum
-      if have_cmd sha256sum; then
-        actual_sum=$(sha256sum "${tmp_bin}" | awk '{print $1}')
-      elif have_cmd shasum; then
-        actual_sum=$(shasum -a 256 "${tmp_bin}" | awk '{print $1}')
-      elif have_cmd python3; then
-        log "Using Python3 fallback for SHA256 checksum..."
-        actual_sum=$(python3 -c "import hashlib; print(hashlib.sha256(open('${tmp_bin}', 'rb').read()).hexdigest())")
-      elif have_cmd python; then
-        log "Using Python fallback for SHA256 checksum..."
-        actual_sum=$(python -c "import hashlib; print(hashlib.sha256(open('${tmp_bin}', 'rb').read()).hexdigest())")
-      else
-        log "WARN: No checksum tool (sha256sum, shasum, python) available - skipping checksum verification."
-        actual_sum=""
-      fi
-
-      if [[ -n "${actual_sum}" ]]; then
-        if [[ "${expected_sum}" != "${actual_sum}" ]]; then
-          die "Checksum-Fehler! Erwartet: ${expected_sum}, Ist: ${actual_sum}"
-        fi
-        log "Checksumme OK: ${actual_sum}"
-      fi
-    fi
-  else
-    log "WARN: Konnte keine Checksummen-Datei laden. Überspringe Verifikation."
+  log "Lade offizielle Prüfsummen von ${checksum_url}..."
+  if ! curl -fSL --retry 3 --connect-timeout 10 "${checksum_url}" -o "${tmp_checksum}"; then
+    die "Prüfsummen-Download fehlgeschlagen: ${checksum_url}"
   fi
 
-  tar -xzf "${tmp_bin}" -C "${BIN_DIR}" actionlint
-  chmod +x "${TOOL_LOCAL}" || true
-  log "${TOOL_NAME} erfolgreich installiert."
+  local checksum_matches expected_sum actual_sum
+  checksum_matches=$(awk -v expected="${filename}" '$2 == expected { count += 1 } END { print count + 0 }' "${tmp_checksum}")
+  if [[ "${checksum_matches}" != "1" ]]; then
+    die "Prüfsummen-Datei muss genau einen Eintrag für ${filename} enthalten; gefunden: ${checksum_matches}"
+  fi
+  expected_sum=$(awk -v expected="${filename}" '$2 == expected { print $1 }' "${tmp_checksum}")
+  if [[ ! "${expected_sum}" =~ ^[0-9a-fA-F]{64}$ ]]; then
+    die "Ungültige SHA-256-Prüfsumme für ${filename}: ${expected_sum}"
+  fi
+  expected_sum="$(printf '%s' "${expected_sum}" | tr '[:upper:]' '[:lower:]')"
+
+  if have_cmd sha256sum; then
+    actual_sum=$(sha256sum "${tmp_bin}" | awk '{print $1}')
+  elif have_cmd shasum; then
+    actual_sum=$(shasum -a 256 "${tmp_bin}" | awk '{print $1}')
+  elif have_cmd python3; then
+    actual_sum=$(python3 -c 'import hashlib, sys; print(hashlib.sha256(open(sys.argv[1], "rb").read()).hexdigest())' "${tmp_bin}")
+  elif have_cmd python; then
+    actual_sum=$(python -c 'import hashlib, sys; print(hashlib.sha256(open(sys.argv[1], "rb").read()).hexdigest())' "${tmp_bin}")
+  else
+    die "Kein SHA-256-Werkzeug verfügbar; Installation wird nicht ungeprüft fortgesetzt."
+  fi
+
+  if [[ "${expected_sum}" != "${actual_sum}" ]]; then
+    die "Checksum-Fehler! Erwartet: ${expected_sum}, Ist: ${actual_sum}"
+  fi
+  log "Checksumme OK: ${actual_sum}"
+
+  if ! tar -xzf "${tmp_bin}" -C "${tmp_extract}" actionlint; then
+    die "Actionlint-Archiv konnte nicht sicher entpackt werden."
+  fi
+  if [[ ! -f "${tmp_extract}/actionlint" ]]; then
+    die "Actionlint-Binary fehlt im verifizierten Archiv."
+  fi
+  install -m 0755 "${tmp_extract}/actionlint" "${tmp_target}"
+  mv -f "${tmp_target}" "${TOOL_LOCAL}"
+  log "${TOOL_NAME} erfolgreich geprüft und atomar installiert."
 }
 
 resolved_tool() {

--- a/tests/test_actionlint_pin.py
+++ b/tests/test_actionlint_pin.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+import hashlib
+import os
+import shutil
+import subprocess
+import tarfile
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "tools" / "actionlint-pin.sh"
+SEMVER = ROOT / "scripts" / "lib" / "semver.sh"
+
+
+def _write_executable(path: Path, content: str) -> None:
+    path.write_text(content, encoding="utf-8")
+    path.chmod(0o755)
+
+
+def _fixture(tmp_path: Path, *, checksum_mode: str = "valid") -> tuple[Path, Path]:
+    repo = tmp_path / "repo"
+    (repo / "scripts" / "tools").mkdir(parents=True)
+    (repo / "scripts" / "lib").mkdir(parents=True)
+    (repo / "tools" / "bin").mkdir(parents=True)
+    shutil.copy2(SCRIPT, repo / "scripts" / "tools" / "actionlint-pin.sh")
+    shutil.copy2(SEMVER, repo / "scripts" / "lib" / "semver.sh")
+    (repo / "toolchain.versions.yml").write_text('actionlint: "v1.7.5"\n', encoding="utf-8")
+
+    payload = tmp_path / "payload"
+    payload.mkdir()
+    actionlint = payload / "actionlint"
+    _write_executable(
+        actionlint,
+        "#!/usr/bin/env sh\n"
+        'if [ "${1:-}" = "-version" ]; then printf "1.7.5\\n"; exit 0; fi\n'
+        'exit 0\n',
+    )
+    archive = tmp_path / "actionlint_1.7.5_linux_amd64.tar.gz"
+    with tarfile.open(archive, "w:gz") as tar:
+        tar.add(actionlint, arcname="actionlint")
+    digest = hashlib.sha256(archive.read_bytes()).hexdigest()
+
+    fakebin = tmp_path / "fakebin"
+    fakebin.mkdir()
+    _write_executable(
+        fakebin / "uname",
+        "#!/usr/bin/env sh\n"
+        'case "${1:-}" in -s) printf "Linux\\n";; -m) printf "x86_64\\n";; *) exit 2;; esac\n',
+    )
+    curl_log = tmp_path / "curl.log"
+    checksum_name = "actionlint_1.7.5_checksums.txt"
+    filename = archive.name
+    if checksum_mode == "valid":
+        checksum_body = f"{digest}  {filename}\n"
+        checksum_exit = 0
+    elif checksum_mode == "mismatch":
+        checksum_body = f"{'0' * 64}  {filename}\n"
+        checksum_exit = 0
+    elif checksum_mode == "missing_entry":
+        checksum_body = f"{digest}  other.tar.gz\n"
+        checksum_exit = 0
+    elif checksum_mode == "duplicate_entry":
+        checksum_body = f"{digest}  {filename}\n{digest}  {filename}\n"
+        checksum_exit = 0
+    elif checksum_mode == "unavailable":
+        checksum_body = ""
+        checksum_exit = 22
+    else:
+        raise AssertionError(checksum_mode)
+
+    curl_script = f"""#!/usr/bin/env python3
+import pathlib
+import shutil
+import sys
+
+args = sys.argv[1:]
+url = next(arg for arg in args if arg.startswith("https://"))
+out = pathlib.Path(args[args.index("-o") + 1])
+with pathlib.Path({str(curl_log)!r}).open("a", encoding="utf-8") as handle:
+    handle.write(url + "\\n")
+if url.endswith({checksum_name!r}):
+    if {checksum_exit} != 0:
+        raise SystemExit({checksum_exit})
+    out.write_text({checksum_body!r}, encoding="utf-8")
+else:
+    shutil.copyfile({str(archive)!r}, out)
+"""
+    _write_executable(fakebin / "curl", curl_script)
+    return repo, fakebin
+
+
+def _run(repo: Path, fakebin: Path) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["PATH"] = f"{fakebin}:{env['PATH']}"
+    return subprocess.run(
+        ["bash", "scripts/tools/actionlint-pin.sh", "ensure"],
+        cwd=repo,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def test_uses_exact_official_checksum_asset_and_installs_verified_binary(tmp_path: Path) -> None:
+    repo, fakebin = _fixture(tmp_path, checksum_mode="valid")
+
+    result = _run(repo, fakebin)
+
+    assert result.returncode == 0, result.stderr
+    installed = repo / "tools" / "bin" / "actionlint"
+    assert installed.is_file()
+    assert subprocess.check_output([str(installed), "-version"], text=True).strip() == "1.7.5"
+    urls = (tmp_path / "curl.log").read_text(encoding="utf-8").splitlines()
+    assert urls == [
+        "https://github.com/rhysd/actionlint/releases/download/v1.7.5/actionlint_1.7.5_linux_amd64.tar.gz",
+        "https://github.com/rhysd/actionlint/releases/download/v1.7.5/actionlint_1.7.5_checksums.txt",
+    ]
+
+
+@pytest.mark.parametrize(
+    ("mode", "message"),
+    [
+        ("unavailable", "Prüfsummen-Download fehlgeschlagen"),
+        ("missing_entry", "genau einen Eintrag"),
+        ("duplicate_entry", "genau einen Eintrag"),
+        ("mismatch", "Checksum-Fehler"),
+    ],
+)
+def test_checksum_failures_block_installation(tmp_path: Path, mode: str, message: str) -> None:
+    repo, fakebin = _fixture(tmp_path, checksum_mode=mode)
+
+    result = _run(repo, fakebin)
+
+    assert result.returncode != 0
+    assert message in result.stderr
+    assert not (repo / "tools" / "bin" / "actionlint").exists()
+
+def test_checksum_failure_preserves_existing_binary(tmp_path: Path) -> None:
+    repo, fakebin = _fixture(tmp_path, checksum_mode="mismatch")
+    installed = repo / "tools" / "bin" / "actionlint"
+    original = b"existing-incompatible-actionlint\n"
+    installed.write_bytes(original)
+    installed.chmod(0o755)
+
+    result = _run(repo, fakebin)
+
+    assert result.returncode != 0
+    assert "Checksum-Fehler" in result.stderr
+    assert installed.read_bytes() == original
+

--- a/tests/test_actionlint_pin.py
+++ b/tests/test_actionlint_pin.py
@@ -4,6 +4,7 @@ import hashlib
 import os
 import shutil
 import subprocess
+import sys
 import tarfile
 from pathlib import Path
 
@@ -12,6 +13,8 @@ import pytest
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPT = ROOT / "scripts" / "tools" / "actionlint-pin.sh"
 SEMVER = ROOT / "scripts" / "lib" / "semver.sh"
+BASH = shutil.which("bash")
+assert BASH is not None
 
 
 def _write_executable(path: Path, content: str) -> None:
@@ -33,7 +36,7 @@ def _fixture(tmp_path: Path, *, checksum_mode: str = "valid") -> tuple[Path, Pat
     actionlint = payload / "actionlint"
     _write_executable(
         actionlint,
-        "#!/usr/bin/env sh\n"
+        "#!/bin/sh\n"
         'if [ "${1:-}" = "-version" ]; then printf "1.7.5\\n"; exit 0; fi\n'
         'exit 0\n',
     )
@@ -46,7 +49,7 @@ def _fixture(tmp_path: Path, *, checksum_mode: str = "valid") -> tuple[Path, Pat
     fakebin.mkdir()
     _write_executable(
         fakebin / "uname",
-        "#!/usr/bin/env sh\n"
+        "#!/bin/sh\n"
         'case "${1:-}" in -s) printf "Linux\\n";; -m) printf "x86_64\\n";; *) exit 2;; esac\n',
     )
     curl_log = tmp_path / "curl.log"
@@ -70,7 +73,7 @@ def _fixture(tmp_path: Path, *, checksum_mode: str = "valid") -> tuple[Path, Pat
     else:
         raise AssertionError(checksum_mode)
 
-    curl_script = f"""#!/usr/bin/env python3
+    curl_script = f"""#!{sys.executable}
 import pathlib
 import shutil
 import sys
@@ -88,14 +91,35 @@ else:
     shutil.copyfile({str(archive)!r}, out)
 """
     _write_executable(fakebin / "curl", curl_script)
+    required_commands = (
+        "awk",
+        "dirname",
+        "grep",
+        "gzip",
+        "head",
+        "install",
+        "ln",
+        "mkdir",
+        "mktemp",
+        "mv",
+        "rm",
+        "sed",
+        "sha256sum",
+        "tar",
+        "tr",
+    )
+    for command in required_commands:
+        source = shutil.which(command)
+        assert source is not None, command
+        (fakebin / command).symlink_to(source)
     return repo, fakebin
 
 
 def _run(repo: Path, fakebin: Path) -> subprocess.CompletedProcess[str]:
     env = os.environ.copy()
-    env["PATH"] = f"{fakebin}:{env['PATH']}"
+    env["PATH"] = str(fakebin)
     return subprocess.run(
-        ["bash", "scripts/tools/actionlint-pin.sh", "ensure"],
+        [BASH, "scripts/tools/actionlint-pin.sh", "ensure"],
         cwd=repo,
         env=env,
         text=True,
@@ -137,6 +161,7 @@ def test_checksum_failures_block_installation(tmp_path: Path, mode: str, message
     assert result.returncode != 0
     assert message in result.stderr
     assert not (repo / "tools" / "bin" / "actionlint").exists()
+
 
 def test_checksum_failure_preserves_existing_binary(tmp_path: Path) -> None:
     repo, fakebin = _fixture(tmp_path, checksum_mode="mismatch")


### PR DESCRIPTION
## Fehlerbild

Der gepinnte Actionlint-Installer suchte für v1.7.5 nach drei nicht existierenden Prüfsummendateien. Nach drei 404-Antworten installierte er das Archiv trotzdem nur mit einer Warnung.

## Ursache

Das offizielle Release-Asset heißt exakt `actionlint_1.7.5_checksums.txt`. Der bisherige Fallback behandelte fehlende Prüfsummen als optional.

## Änderung

- exakte offizielle Release-Prüfsummendatei verwenden
- Downloadfehler fail-closed behandeln
- genau einen Eintrag für das erwartete Plattformarchiv verlangen
- SHA-256-Format und Archivhash prüfen
- ohne verfügbares SHA-256-Werkzeug abbrechen
- erst nach erfolgreicher Prüfung in ein separates Verzeichnis entpacken
- Binary über eine temporäre Datei im Zielverzeichnis atomar ersetzen
- vorhandenes Binary bei jedem Prüfungsfehler unverändert lassen
- Bash-3.2-kompatible Normalisierung ohne `${var,,}`

## Tests

Sechs deterministische Tests prüfen:
- exakte offizielle Checksum-URL und erfolgreiche verifizierte Installation
- nicht verfügbare Prüfsummendatei
- fehlenden Archiveintrag
- doppelten Archiveintrag
- falsche Prüfsumme
- Erhalt eines vorhandenen Binaries bei Prüfungsfehler

## Prüfung

- echter Download von Actionlint v1.7.5 und `actionlint_1.7.5_checksums.txt`: PASS
- offizieller Linux-amd64-Hash `3e6e0a832dfa0b5f027e6b8956aad2632d69b7cb778b1cff847b40279950a856`: PASS
- `env ALLOW_NET=1 just validate`: PASS am Commit `1779ef8c51073d2a46b7ff426486c0d49113185e`
- 107 Python-Tests: PASS
- Shell-Regressionen, YAML und actionlint: PASS
- Finalization-Receipt SHA-256 `98f63c69ec3d5dedc8c55fe5d4be44761119baa6ab9271016c2aaee332d04caa`
- `git diff --check`: PASS

## Abgrenzung

Der Patch berührt ausschließlich `scripts/tools/actionlint-pin.sh` und `tests/test_actionlint_pin.py`. Keine Überschneidung mit der parallelen Fleet-Konsolidierung T002.

Bureau-Kandidat: `METAREPO-LEGACY-RECONCILIATION-V1-T007`