### PR TITLE
fleet: Manifestquellen konsolidieren

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,8 +35,9 @@ Diese Informationen nicht im Metarepo nachbauen oder aus Legacy-Dokumenten ablei
 
 ### Fleet
 
-- `fleet/repos.yml` ist normativ.
-- `repos.yml` ist eine nicht normative Legacy-Fläche.
+- `fleet/repos.yml` ist die einzige normative Mitgliedschaftsquelle.
+- `fleet/repo-metadata.yml` ist die normative Quelle operativer Zusatzdaten.
+- `repos.yml` ist eine deterministisch generierte, nicht normative Kompatibilitätsprojektion und darf nicht manuell bearbeitet werden.
 - Fleet-Mitgliedschaft bedeutet nicht automatisch Zugehörigkeit zum gesamten Operator-Ökosystem.
 - Repositories nur nach expliziten Aufnahmekriterien ergänzen oder entfernen.
 
@@ -61,7 +62,7 @@ Vor jeder Contract-Änderung:
 
 Folgende Pfade sind nicht Teil der normativen Rolle:
 
-- `repos.yml`
+- `repos.yml` (generierte Kompatibilitätsprojektion)
 - `wgx/`
 - `servers/local-mcp/`
 
@@ -80,12 +81,13 @@ Die früheren Organismus- und Zielbilddokumente sind keine aktuelle Architekturw
 ## Prüfungen
 
 ```bash
+just fleet-projection-check
 just validate
 just contracts-validate
 python3 -m pytest tests/test_metarepo_role_contract.py
 ```
 
-Für Template- und Fleet-Arbeit zusätzlich die betroffenen Drift-, WGX- und Consumer-Checks ausführen.
+Für Fleet-Änderungen zuerst die kanonischen Dateien bearbeiten, anschließend `just fleet-projection` ausführen und danach die betroffenen Drift-, WGX- und Consumer-Checks prüfen.
 
 ## Bestehendes Tooling
 

--- a/Justfile
+++ b/Justfile
@@ -22,6 +22,7 @@ help:
     @printf "  just smoke         # Schneller Fleet-Integrationslauf\n"
     @printf "  just log-sync      # Report-Vorlage unter reports/sync-logs/\n"
     @printf "  just fleet         # Fleet Readiness & Repos List generieren\n"
+    @printf "  just fleet-projection # repos.yml aus kanonischen Fleet-Quellen erzeugen\n"
     @printf "  just doctor        # Fleet Diagnose (Health Check)\n"
     @printf "\nWeitere Ziele: just --list\n"
 
@@ -108,6 +109,14 @@ fleet-check:
         --matrix docs/repo-matrix.md \
         --fleet fleet/repos.txt
 
+# Generate the legacy repos.yml compatibility projection from canonical inputs
+fleet-projection:
+    @uv run python scripts/fleet/generate_repos_projection.py
+
+# Fail when repos.yml was edited manually or canonical inputs were not projected
+fleet-projection-check:
+    @uv run python scripts/fleet/generate_repos_projection.py --check
+
 # Diagnose current fleet readiness from reports/heimgewebe-readiness.json
 doctor:
     @[ -f reports/heimgewebe-readiness.json ] || just fleet
@@ -149,6 +158,7 @@ fleet-push-all:
 # Local CI
 validate: yq_ensure lint
     just fleet-check
+    just fleet-projection-check
     scripts/ci/validate-local.sh
     @if [ -d tests ] && [ -f pyproject.toml ] && grep -q "pytest" pyproject.toml; then echo "Running python tests..."; uv run pytest tests/; fi
     @printf "Running shell regression tests...\n"

--- a/README.md
+++ b/README.md
@@ -34,13 +34,19 @@ Zugehörigkeit zum vollständigen Operator-Ökosystem.
 
 ### Fleet
 
-[`fleet/repos.yml`](fleet/repos.yml) ist die normative Quelle der gemeinsam
-verwalteten Metarepo-Fleet. Die gerenderte Übersicht wird daraus erzeugt:
-[`docs/_generated/fleet.md`](docs/_generated/fleet.md).
+[`fleet/repos.yml`](fleet/repos.yml) ist die einzige normative Quelle der
+Fleet-Mitgliedschaft. Operative Zusatzdaten wie Branch, Domain, Abhängigkeiten
+und Tooling-Overrides liegen getrennt in
+[`fleet/repo-metadata.yml`](fleet/repo-metadata.yml).
 
-Das Top-Level-[`repos.yml`](repos.yml) wird noch von bestehendem Tooling
-verwendet. Es ist eine **nicht normative Legacy-Fläche** und soll zu einer
-reproduzierbaren Projektion von `fleet/repos.yml` werden.
+Das Top-Level-[`repos.yml`](repos.yml) ist eine **generierte, nicht normative
+Kompatibilitätsprojektion** für bestehendes WGX-, Graph- und Template-Tooling.
+Sie wird ausschließlich mit `just fleet-projection` aus den beiden kanonischen
+Fleet-Dateien erzeugt. `just fleet-projection-check` und `just validate`
+blockieren manuelle Änderungen oder vergessene Regeneration.
+
+Die gerenderte Fleet-Übersicht wird aus der Mitgliedschaftsquelle erzeugt:
+[`docs/_generated/fleet.md`](docs/_generated/fleet.md).
 
 ### Contracts
 
@@ -65,7 +71,7 @@ Workflowverträge. Änderungen benötigen:
 Diese Flächen sind weiterhin vorhanden, aber nicht Teil der normativen
 Metarepo-Rolle:
 
-- `repos.yml` – aktives Legacy-Manifest; Ziel: generierte Fleet-Projektion
+- `repos.yml` – deterministisch generierte Kompatibilitätsprojektion; nicht manuell bearbeiten
 - `wgx/` – vendierter Altstand; kanonischer Eigentümer ist das Repository `wgx`
 - `servers/local-mcp/` – lokale Legacy-Brücke; Nutzung und Ablösung werden geprüft
 - `.github/workflows/heimgewebe-command-dispatch.yml` – aktive
@@ -87,7 +93,10 @@ gegenwärtige Systemtopologie ist der Systemkatalog zuständig.
 # Abhängigkeiten installieren
 just deps
 
-# lokale Validierung einschließlich Tests und Workflow-Linting
+# repos.yml aus den kanonischen Fleet-Quellen erzeugen
+just fleet-projection
+
+# lokale Validierung einschließlich Projektionsdrift, Tests und Workflow-Linting
 just validate
 
 # Contract-Prüfungen
@@ -137,14 +146,14 @@ Beispiele für bestehendes Tooling:
 ```text
 metarepo/
 ├── system/              # Maschinenlesbare Rollen- und Wahrheitsverträge
-├── fleet/               # Normative Fleet-Mitgliedschaft
+├── fleet/               # Mitgliedschaft und getrennte operative Fleet-Metadaten
 ├── contracts/           # Gemeinsame versionierte Contracts
 ├── templates/           # Kuratierte Shared Templates
 ├── .github/workflows/   # Reusable Workflows und Repo-CI
 ├── scripts/             # Sync-, Prüf- und Migrationswerkzeuge
 ├── docs/                # Metarepo-Dokumentation und Legacy-Material
 ├── reports/             # Nicht normative Befunde und Drift-Reports
-├── repos.yml            # Legacy-Manifest; nicht normativ
+├── repos.yml            # Generierte Kompatibilitätsprojektion; nicht normativ
 └── Justfile
 ```
 

--- a/docs/contracts/integrity.md
+++ b/docs/contracts/integrity.md
@@ -35,7 +35,7 @@ Der Integritätsstatus wird aktiv gesammelt:
     *   Der Bericht muss als Datei `summary.json` unter dem Release-Tag **`integrity`** veröffentlicht werden.
     *   Die `summary_url` in der Quellenliste zeigt auf dieses Asset.
 *   **`reports/integrity/sources.v1.json`**: Die **Single Source of Truth (SoT)** für Integritätsquellen.
-    *   Wird generiert aus der Fleet-Definition (`fleet/repos.yml`).
+    *   Wird aus der Fleet-Mitgliedschaft (`fleet/repos.yml`) und den operativen Overrides (`fleet/repo-metadata.yml`) generiert.
     *   Schema: `contracts/integrity.sources.v1.schema.json`.
 
 ### Quellen-Liste (SoT)

--- a/docs/fleet/fleet.md
+++ b/docs/fleet/fleet.md
@@ -1,42 +1,71 @@
-# Fleet-Operations im metarepo
+# Fleet-Operations im Metarepo
 
-Das **metarepo** ist die Flotten-Leitstelle für alle Repositories unter `heimgewebe`.
-Es hält das Inventar (`repos.yml`), verteilt Templates/CI-Reusables und stößt WGX-Läufe an.
-Die kanonische WGX-Dokumentation bleibt im [WGX-Repository](https://github.com/heimgewebe/wgx).
+Das Metarepo verwaltet gemeinsame Fleet-Assets für **explizit aufgenommene**
+Repositories. Es ist weder Leitstelle für alle Repositories unter `heimgewebe`
+noch Quelle der gesamten Ökosystemarchitektur.
+
+Die Quellen sind getrennt:
+
+- `fleet/repos.yml` – normative Fleet-Mitgliedschaft und Related-Scope;
+- `fleet/repo-metadata.yml` – operative Zusatzdaten für bestehende Consumer;
+- `repos.yml` – deterministisch generierte, nicht normative
+  Kompatibilitätsprojektion.
+
+Die kanonische WGX-Dokumentation bleibt im
+[WGX-Repository](https://github.com/heimgewebe/wgx).
 
 ## Verantwortungsabgrenzung
-- **metarepo**
-  - Kuratiert Fleet-Scope und Standard-Templates (`templates/**`).
-  - Pflegt wiederverwendbare Workflows und Runbooks.
-  - Initiiert Fleet-Zyklen über `just` oder `scripts/wgx`.
-- **WGX-Repo**
-  - Enthält Master-Doku, Policies und Guard-Implementierung.
-  - Liefert die ausführbare Engine; metarepo ruft sie nur auf.
 
-## Fleet-Zyklus (sync → validate → smoke)
+- **Metarepo**
+  - kuratiert Fleet-Scope und Standard-Templates unter `templates/**`;
+  - pflegt wiederverwendbare Workflows und Runbooks;
+  - erzeugt die Kompatibilitätsprojektion für noch nicht migrierte Consumer;
+  - initiiert Fleet-Zyklen über `just` oder `scripts/wgx`.
+- **WGX-Repository**
+  - enthält Master-Dokumentation, Policies und Guard-Implementierung;
+  - liefert die ausführbare Engine; das Metarepo ruft sie nur auf.
+- **Systemkatalog**
+  - beschreibt das vollständige Operator-Ökosystem und seine Beziehungen;
+  - leitet daraus keine Metarepo-Fleet-Mitgliedschaft ab.
+
+## Fleet-Änderung
+
+1. Mitgliedschaft ausschließlich in `fleet/repos.yml` ändern.
+2. Nur benötigte operative Daten in `fleet/repo-metadata.yml` ergänzen.
+3. `just fleet-projection` ausführen.
+4. `just fleet-projection-check` und `just validate` ausführen.
+5. Auswirkungen auf WGX-, Graph-, Template- und Integrity-Consumer prüfen.
+
+`repos.yml` darf nicht manuell bearbeitet werden. Einträge mit `fleet: false`
+sind nicht projektierbar und dürfen nicht allein aufgrund ihrer Erwähnung als
+Fleet-Ziel behandelt werden.
+
+## Fleet-Zyklus: sync → validate → smoke
+
 1. **sync** – `just up` oder `./scripts/wgx up`
-   - Spiegelt die Templates/Runbooks in jedes Ziel-Repo.
-   - Nutzt `templates/**` als Quelle der Wahrheit.
+   - spiegelt Templates und Runbooks in die ausgewählten Ziel-Repositories;
+   - nutzt `templates/**` als jeweilige Asset-Quelle.
 2. **validate** – `just wgx:validate` oder `./scripts/wgx validate`
-   - Prüft `repos.yml` auf Schemafehler und verifiziert, dass Pflicht-Templates vorhanden sind.
-   - Ergänzend `just validate` für lokale YAML-/Template-Checks (yq v4).
-   - Optional ergänzen durch `./scripts/wgx-doctor` für Drift-Analysen.
+   - prüft die generierte `repos.yml`-Kompatibilitätsfläche und die erwarteten
+     Templates;
+   - `just validate` prüft zusätzlich Projektionsdrift, YAML, Tests und
+     Workflow-Linting.
 3. **smoke** – `just smoke` oder `./scripts/wgx smoke`
-   - Triggert die WGX-Smoke-Workflows in jedem Repo (`wgx-smoke.yml`).
-   - Ergebnis dient als Fleet-Gesundheitsindikator.
-
-> 💡 Detailwissen zu WGX-Kommandos, Guards oder Profilen wird **nicht** im metarepo verdoppelt.
-> Link stattdessen direkt auf die Master-Doku im WGX-Repo.
+   - startet die vorgesehenen WGX-Smoke-Workflows;
+   - das Ergebnis ist ein technischer Prüfbefund, keine allgemeine
+     Ökosystemgesundheit.
 
 ## Betriebsnotizen
-- `reports/` sammelt Ausgaben von Drift-/Doctor-Läufen.
-- Fleet-Änderungen immer mit kurzem Incident-Log in PR-Beschreibung dokumentieren.
-- Für Ad-hoc-Syncs einzelner Repos `scripts/sync-templates.sh --push-to <repo> --pattern "templates/**"` nutzen.
+
+- `reports/` enthält nicht normative Drift- und Doctor-Ausgaben.
+- Fleet-Aufnahmen und -Entfernungen benötigen eine begründete Consumerprüfung.
+- Für Ad-hoc-Syncs einzelner Repositories gilt weiterhin
+  `scripts/sync-templates.sh --push-to <repo> --pattern "templates/**"`.
 
 ## Siehe auch
 
-- [WGX Konzept](./wgx-konzept.md) – Fleet-Motor Konzept und Kommandos
-- [Templates](../templates.md) – Template-Verteilung im Detail
-- [Push to Fleet](./push-to-fleet.md) – Detaillierte Fleet-Deployment-Prozesse
-- [Repo Matrix](../repo-matrix.md) – Repository-Rollen und Status
-- [ADR-0002: Fleet-Rollout via reusable GitHub Actions](../adrs/0002-reusable-actions-rollout.md) – Entscheidungsgrundlage
+- [Fleet-Quellen und Projektion](../repos.yml.md)
+- [WGX-Konzept](./wgx-konzept.md)
+- [Templates](../templates.md)
+- [Push to Fleet](./push-to-fleet.md)
+- [ADR-0002: Fleet-Rollout via reusable GitHub Actions](../adrs/0002-reusable-actions-rollout.md)

--- a/docs/konzept-kern.md
+++ b/docs/konzept-kern.md
@@ -1,59 +1,80 @@
 # Kernkonzepte des Metarepo
 
-Dieses Dokument beschreibt die grundlegende Architektur und die zentralen Prozesse des `metarepo`. Das Ziel ist es, ein konsistentes und zentral verwaltetes System über eine Flotte von Sub-Repositories zu schaffen.
+Das Metarepo veröffentlicht gemeinsame Fleet-Assets für ausdrücklich
+aufgenommene Repositories. Seine normative Rolle ist in
+[`system/metarepo-role.v1.json`](../system/metarepo-role.v1.json) festgelegt.
+Es ist keine Control Plane und keine Quelle der gesamten
+Ökosystemarchitektur.
 
-## Metarepo-Architektur
+## Kernflächen
 
-Das `metarepo` dient als "Single Source of Truth" für kanonische Konfigurationen, die in andere Repositories (Sub-Repos) verteilt werden. Die Hauptkomponenten sind:
+- **`fleet/repos.yml`** – einzige normative Quelle der Fleet-Mitgliedschaft und
+  des Related-Scope.
+- **`fleet/repo-metadata.yml`** – operative Zusatzdaten für bestehende
+  Metarepo-Consumer, beispielsweise Branch, Domain, Abhängigkeiten und
+  Tooling-Overrides.
+- **`repos.yml`** – deterministisch erzeugte, nicht normative
+  Kompatibilitätsprojektion für noch nicht migrierte WGX-, Graph-, Readiness-
+  und Template-Consumer.
+- **`templates/`** – kuratierte Vorlagen, die ausdrücklich für mehrere
+  Consumer-Repositories bestimmt sind.
+- **`.github/workflows/`** – wiederverwendbare CI-Bausteine und ihre
+  Kompatibilitätsverträge.
+- **`contracts/`** – gemeinsame versionierte Daten- und Workflowverträge.
 
-- **`templates/`**: Dieses Verzeichnis enthält die Vorlagen, die in die Sub-Repos synchronisiert werden. Dazu gehören CI/CD-Workflows, `Justfile`-Konfigurationen, Dokumentation und `.wgx/profile.yml`-Dateien.
-- **`repos.yml`**: Die zentrale Inventarliste der Flotte. Diese Datei definiert, welche Repositories vom `metarepo` verwaltet werden, und enthält Metadaten wie den Namen, den Branch und die Abhängigkeiten.
-- **`scripts/`**: Enthält die Orchestrierungs- und Synchronisationslogik. Das `wgx`-Skript ist das primäre Werkzeug für die Interaktion mit der Flotte.
-- **`AGENTS.md`**: Definiert die Regeln und Prozesse für automatisierte Agenten (wie diesen), die im Repository arbeiten.
+## Wahrheitsgrenzen
 
-## Synchronisationsprozess
+Fleet-Mitgliedschaft bedeutet nicht automatisch Zugehörigkeit zum gesamten
+Operator-Ökosystem. Systemzwecke und Beziehungen gehören in den Systemkatalog;
+Aufgabenstatus und Abschlusswahrheit ins Bureau; operative Ausführung,
+Leases und Recovery zu Grabowski.
 
-Der Abgleich von Konfigurationen zwischen dem `metarepo` und den Sub-Repos ist ein fundamentaler Prozess. Er folgt einem dialektischen Modell des Lernens und Verteilens.
+Ein Repository wird nur dann in die Core-Fleet aufgenommen, wenn ein konkreter
+gemeinsamer Contract-, Template-, Workflow- oder Prüfbedarf besteht.
+`static.include` kann Related-Repositories sichtbar machen. Einträge mit
+`fleet: false` sind nicht projektierbar und dürfen nicht als Fleet-Ziel
+behandelt werden.
 
-### Push (Kanon → Sub-Repo)
-Dies ist der Standardprozess, bei dem die kanonischen Vorlagen aus dem `metarepo` in die Sub-Repos verteilt werden. Der `wgx up`-Befehl automatisiert diesen Prozess:
+## Projektion statt zweiter Wahrheit
 
-1.  **Klonen**: Das Ziel-Repo wird temporär geklont.
-2.  **Kopieren**: Die Vorlagen aus `templates/` werden in das geklonte Repo kopiert. Variablen (`{{REPO_NAME}}`) werden ersetzt.
-3.  **Commit & PR**: Die Änderungen werden in einen neuen Branch committet, und ein Pull Request wird erstellt.
+Die operative Legacy-Struktur bleibt vorübergehend erhalten, wird aber nicht
+mehr manuell gepflegt:
 
-### Pull (Sub-Repo → Kanon)
-In manchen Fällen werden Verbesserungen direkt in einem Sub-Repo entwickelt. Der `scripts/sync-templates.sh`-Befehl ermöglicht es, diese Änderungen zurück in das `metarepo` zu ziehen, um sie zu kuratieren und als neuen kanonischen Standard zu übernehmen.
-
-### Drift
-Als "Drift" wird der Zustand bezeichnet, in dem die Konfiguration eines Sub-Repos von der kanonischen Vorlage im `metarepo` abweicht. Werkzeuge wie `scripts/wgx-doctor` sind dazu gedacht, diesen Drift zu erkennen und zu melden.
-
-## Die Rolle von `repos.yml`
-
-Die `repos.yml`-Datei ist das Herzstück der Flottenverwaltung. Sie definiert den "Scope" der Operationen und ermöglicht eine präzise Steuerung der Synchronisation. Eine typische Struktur sieht wie folgt aus:
-
-```yaml
-github:
-  owner: heimgewebe
-  mode: github # 'github' für dynamische Listen, 'static' für feste
-
-repos:
-  - name: metarepo
-    branch: main
-  - name: wgx
-    branch: main
+```bash
+just fleet-projection
+just fleet-projection-check
 ```
 
-- **`owner`**: Der GitHub-Organisationname.
-- **`mode`**: Bestimmt, ob die Liste der Repos dynamisch von GitHub (`github`) oder aus der statischen Liste in `repos` (`static`) bezogen wird.
-- **`repos`**: Eine Liste von Repository-Objekten, die den Namen und optional weitere Metadaten enthalten.
+Der Generator liest ausschließlich `fleet/repos.yml` und
+`fleet/repo-metadata.yml`. `just validate` prüft bytegenaue Reproduzierbarkeit.
+Die semantische Struktur der Projektion ist zusätzlich an einen
+Consumer-Vertragstest gebunden.
 
----
+## Verteilung gemeinsamer Assets
+
+### Metarepo → Consumer
+
+Kuratierte Templates, Contracts oder reusable Workflows werden nach
+Consumerprüfung veröffentlicht. Bestehendes WGX- oder Sync-Tooling kann die
+generierte `repos.yml` weiterverwenden, bis es auf die kanonischen Quellen
+umgestellt ist.
+
+### Consumer → Metarepo
+
+Verbesserungen aus einzelnen Repositories werden nicht automatisch zur
+Fleet-Norm. Sie müssen im Metarepo kuratiert, gegen aktive Consumer geprüft und
+als eigener Review- und Mergevorgang veröffentlicht werden.
+
+### Drift
+
+Drift bezeichnet eine Abweichung zwischen normativen Quellen, generierten
+Projektionen oder verteilten gemeinsamen Assets. Driftberichte sind Befunde;
+sie ändern weder Fleet-Mitgliedschaft noch Aufgabenstatus automatisch.
 
 ## Siehe auch
 
-- [Templates](./templates.md) – Template-Verteilung und Drift-Kontrolle
-- [Fleet Management](./fleet/fleet.md) – Fleet-Operationen im Überblick
-- [WGX Konzept](./fleet/wgx-konzept.md) – Fleet-Motor und Kommandos
-- [Architecture](./system/architecture.md) – Systemarchitektur
-- [ADR-002: Distribution & Drift-Regeln](./adrs/002-distribution-drift.md) – Architekturentscheidung
+- [Fleet-Quellen und `repos.yml`-Projektion](./repos.yml.md)
+- [Fleet-Operations](./fleet/fleet.md)
+- [Templates](./templates.md)
+- [WGX-Konzept](./fleet/wgx-konzept.md)
+- [ADR-002: Distribution und Drift](./adrs/002-distribution-drift.md)

--- a/docs/repos.yml.md
+++ b/docs/repos.yml.md
@@ -1,24 +1,64 @@
-# repos.yml – Fleet-Konfiguration
+# Fleet-Quellen und `repos.yml`-Projektion
 
-> **⚠️ SOURCE OF TRUTH NOTICE**
-> The canonical definition of the Fleet is located in `fleet/repos.yml`.
-> All lists of repositories in this documentation are derived or exemplary.
-> Do not edit repository lists manually in Markdown files.
+## Normative Quellen
 
-Die **Fleet** umfasst alle Repositories, die operativ über WGX und Contracts
-gesteuert werden sollen.
+Die Fleet ist **nicht** das vollständige Operator-Ökosystem und auch nicht die
+Menge aller Repositories der Organisation.
 
-**Wichtig:**
-Die Fleet ist **nicht** identisch mit „allen öffentlichen Repos der Organisation“.
+- [`fleet/repos.yml`](../fleet/repos.yml) entscheidet ausschließlich über
+  Fleet-Scope und Related-Einträge.
+- [`fleet/repo-metadata.yml`](../fleet/repo-metadata.yml) enthält operative
+  Zusatzdaten für bestehende Consumer, etwa Branch, Domain, Abhängigkeiten und
+  Tooling-Overrides.
+- [`repos.yml`](../repos.yml) ist eine generierte Kompatibilitätsprojektion und
+  niemals eine Quelle für Mitgliedschaftsentscheidungen.
 
-Es gibt drei Klassen:
-1. **Core-Fleet**: Repos in `repos:`
-2. **Related**: Repos in `static.include`
-3. **Private**: niemals in der Fleet
+## Klassen
 
-Eine aktuelle, generierte Übersicht befindet sich in:
-👉 **[docs/_generated/fleet.md](_generated/fleet.md)**
+1. **Core-Fleet** – Einträge unter `repos:`. Sie gehören zur gemeinsam
+   verwalteten Metarepo-Fleet und dürfen Ziel gemeinsamer Contracts, Templates,
+   Workflows und Fleet-Prüfungen sein.
+2. **Related** – Einträge unter `static.include` ohne `fleet: false`. Sie sind
+   für Abdeckung oder Kompatibilität relevant, aber nicht automatisch
+   Core-Fleet. Sie erscheinen nur dann in der Kompatibilitätsprojektion, wenn
+   zusätzlich operative Metadaten vorhanden sind.
+3. **Ausgeschlossen oder nur referenziert** – Einträge mit `fleet: false`.
+   Sie dürfen weder in `repos.yml` projiziert noch allein aufgrund ihrer
+   Erwähnung als Fleet-Ziel behandelt werden.
 
----
+## Aufnahmekriterien
 
-Die Definition in `fleet/repos.yml` ist maßgeblich.
+Ein Repository wird nur dann in `repos:` aufgenommen, wenn:
+
+- ein konkreter gemeinsamer Contract-, Template-, Workflow- oder Prüfbedarf
+  besteht;
+- Name und Zuständigkeit eindeutig sind;
+- Auswirkungen auf bestehende Consumer geprüft wurden;
+- die Aufnahme nicht bloß eine allgemeine Zugehörigkeit zum Ökosystem
+  ausdrücken soll.
+
+Ein Related-Eintrag genügt, wenn ein Repository für Abdeckung oder Beziehungen
+sichtbar sein muss, aber nicht als gemeinsam verwaltetes Ziel gelten soll.
+
+## Projektion und Drift-Gate
+
+```bash
+just fleet-projection
+just fleet-projection-check
+```
+
+`just fleet-projection` erzeugt `repos.yml` deterministisch aus beiden
+normativen Fleet-Dateien. `just fleet-projection-check` und `just validate`
+blockieren:
+
+- manuelle Änderungen an `repos.yml`;
+- Metadaten für unbekannte oder mit `fleet: false` ausgeschlossene Repositories;
+- ungültige Abhängigkeiten oder Metadatenformen;
+- eine vergessene Regeneration der Projektion.
+
+Die vollständige Legacy-Semantik der Projektion ist zusätzlich durch einen
+kanonischen SHA-256-Test gebunden. Änderungen daran sind daher bewusste
+Consumer-Vertragsänderungen.
+
+Die aktuelle gerenderte Mitgliedschaftsübersicht befindet sich unter
+[`docs/_generated/fleet.md`](_generated/fleet.md).

--- a/docs/runbooks/troubleshooting.md
+++ b/docs/runbooks/troubleshooting.md
@@ -35,8 +35,10 @@ Kurzer Spickzettel für die häufigsten Stolpersteine rund um Fleet-Sync & WGX.
   Ohne Drift wird kein Abschnitt erzeugt – dennoch entsteht eine leere Report-Datei. CI-Artefakte gezielt einsammeln.
 
 ## 8. `scripts/sync-templates.sh` meldet „Keine Repos in Datei“
-- Symptom: `--repos-from` liefert keine Ziele.
-- Fix: In `repos.yml` müssen unter `repos:` oder `static.include:` Einträge mit mindestens `name:` vorhanden sein (Kommentare zählen nicht).
+- Symptom: `--repos-from repos.yml` liefert keine Ziele.
+- Fix: `repos.yml` nicht manuell bearbeiten. Mitgliedschaft in `fleet/repos.yml`
+  und benötigte operative Daten in `fleet/repo-metadata.yml` prüfen, danach
+  `just fleet-projection` und `just fleet-projection-check` ausführen.
 
 ## 9. SSH statt HTTPS erwartet
 - Symptom: `scripts/wgx up` schlägt beim Klonen fehl.
@@ -44,7 +46,8 @@ Kurzer Spickzettel für die häufigsten Stolpersteine rund um Fleet-Sync & WGX.
 
 ## 10. Fehlende Owner-Angabe
 - Symptom: `scripts/wgx` gibt `owner=` leer aus.
-- Fix: `github.owner` in `repos.yml` setzen oder `GITHUB_OWNER` exportieren.
+- Fix: `github.owner` in `fleet/repo-metadata.yml` setzen, `just fleet-projection`
+  ausführen oder für einen einzelnen Lauf `GITHUB_OWNER` exportieren.
 
 ## 11. Bats-Testregressionen nach Template-Updates
 > Bats läuft bei uns mit Bash sowie `set -euo pipefail`. Fehlende Defaults schlagen daher sofort durch – die folgenden Snippets zeigen robuste Muster.

--- a/fleet/repo-metadata.yml
+++ b/fleet/repo-metadata.yml
@@ -1,0 +1,81 @@
+---
+schema_version: 1
+
+# Operative Metadaten für Repositories, die von bestehendem Metarepo-Tooling
+# verarbeitet werden. Die Zugehörigkeit zur Fleet wird ausschließlich in
+# fleet/repos.yml entschieden. Jeder Eintrag hier muss dort entweder als
+# Core-Fleet- oder als Related-Repository bekannt sein.
+github:
+  owner: heimgewebe
+
+repositories:
+  contracts-mirror:
+    default_branch: main
+    domain: contracts
+    scope: schema
+    metrics:
+      enable: false
+  weltgewebe:
+    default_branch: main
+    domain: aussen
+    scope: events
+    metrics:
+      enable: false
+  hausKI:
+    default_branch: main
+    domain: assistant
+    scope: policy
+    metrics:
+      enable: true
+  hausKI-audio:
+    default_branch: main
+    depends_on:
+      - hausKI
+    domain: audio
+    scope: events
+    metrics:
+      enable: false
+  semantAH:
+    default_branch: main
+    domain: insights
+    scope: export
+    metrics:
+      enable: false
+  wgx:
+    default_branch: main
+    domain: platform
+    scope: metrics
+    metrics:
+      enable: true
+  lenskit:
+    default_branch: main
+    domain: epistemic
+    scope: scanner-merger
+    metrics:
+      enable: false
+  chronik:
+    default_branch: main
+    domain: chronik
+    scope: ingest
+    metrics:
+      enable: false
+  aussensensor:
+    default_branch: main
+    domain: aussen
+    scope: events
+    metrics:
+      enable: false
+  heimlern:
+    default_branch: main
+    domain: policy
+    scope: library
+    metrics:
+      enable: false
+  vault-gewebe:
+    default_branch: main
+    domain: vault
+    scope: content
+    metrics:
+      enable: false
+    wgx:
+      profile_expected: false

--- a/repos.yml
+++ b/repos.yml
@@ -1,88 +1,87 @@
 # GENERATED FILE. DO NOT EDIT.
 # Sources: fleet/repos.yml and fleet/repo-metadata.yml
----
 mode: static
 github:
   owner: heimgewebe
 repos:
-- name: contracts-mirror
-  url: https://github.com/heimgewebe/contracts-mirror
-  default_branch: main
-  domain: contracts
-  scope: schema
-  metrics:
-    enable: false
-- name: weltgewebe
-  url: https://github.com/heimgewebe/weltgewebe
-  default_branch: main
-  domain: aussen
-  scope: events
-  metrics:
-    enable: false
-- name: hausKI
-  url: https://github.com/heimgewebe/hausKI
-  default_branch: main
-  domain: assistant
-  scope: policy
-  metrics:
-    enable: true
-- name: hausKI-audio
-  url: https://github.com/heimgewebe/hausKI-audio
-  default_branch: main
-  depends_on:
-  - hausKI
-  domain: audio
-  scope: events
-  metrics:
-    enable: false
-- name: semantAH
-  url: https://github.com/heimgewebe/semantAH
-  default_branch: main
-  domain: insights
-  scope: export
-  metrics:
-    enable: false
-- name: wgx
-  url: https://github.com/heimgewebe/wgx
-  default_branch: main
-  domain: platform
-  scope: metrics
-  metrics:
-    enable: true
-- name: lenskit
-  url: https://github.com/heimgewebe/lenskit
-  default_branch: main
-  domain: epistemic
-  scope: scanner-merger
-  metrics:
-    enable: false
-- name: chronik
-  url: https://github.com/heimgewebe/chronik
-  default_branch: main
-  domain: chronik
-  scope: ingest
-  metrics:
-    enable: false
-- name: aussensensor
-  url: https://github.com/heimgewebe/aussensensor
-  default_branch: main
-  domain: aussen
-  scope: events
-  metrics:
-    enable: false
-- name: heimlern
-  url: https://github.com/heimgewebe/heimlern
-  default_branch: main
-  domain: policy
-  scope: library
-  metrics:
-    enable: false
-- name: vault-gewebe
-  url: https://github.com/heimgewebe/vault-gewebe
-  default_branch: main
-  domain: vault
-  scope: content
-  metrics:
-    enable: false
-  wgx:
-    profile_expected: false
+  - name: contracts-mirror
+    url: https://github.com/heimgewebe/contracts-mirror
+    default_branch: main
+    domain: contracts
+    scope: schema
+    metrics:
+      enable: false
+  - name: weltgewebe
+    url: https://github.com/heimgewebe/weltgewebe
+    default_branch: main
+    domain: aussen
+    scope: events
+    metrics:
+      enable: false
+  - name: hausKI
+    url: https://github.com/heimgewebe/hausKI
+    default_branch: main
+    domain: assistant
+    scope: policy
+    metrics:
+      enable: true
+  - name: hausKI-audio
+    url: https://github.com/heimgewebe/hausKI-audio
+    default_branch: main
+    depends_on:
+      - hausKI
+    domain: audio
+    scope: events
+    metrics:
+      enable: false
+  - name: semantAH
+    url: https://github.com/heimgewebe/semantAH
+    default_branch: main
+    domain: insights
+    scope: export
+    metrics:
+      enable: false
+  - name: wgx
+    url: https://github.com/heimgewebe/wgx
+    default_branch: main
+    domain: platform
+    scope: metrics
+    metrics:
+      enable: true
+  - name: lenskit
+    url: https://github.com/heimgewebe/lenskit
+    default_branch: main
+    domain: epistemic
+    scope: scanner-merger
+    metrics:
+      enable: false
+  - name: chronik
+    url: https://github.com/heimgewebe/chronik
+    default_branch: main
+    domain: chronik
+    scope: ingest
+    metrics:
+      enable: false
+  - name: aussensensor
+    url: https://github.com/heimgewebe/aussensensor
+    default_branch: main
+    domain: aussen
+    scope: events
+    metrics:
+      enable: false
+  - name: heimlern
+    url: https://github.com/heimgewebe/heimlern
+    default_branch: main
+    domain: policy
+    scope: library
+    metrics:
+      enable: false
+  - name: vault-gewebe
+    url: https://github.com/heimgewebe/vault-gewebe
+    default_branch: main
+    domain: vault
+    scope: content
+    metrics:
+      enable: false
+    wgx:
+      profile_expected: false

--- a/repos.yml
+++ b/repos.yml
@@ -1,88 +1,88 @@
-# Repos, die vom Metarepo Templates bekommen
+# GENERATED FILE. DO NOT EDIT.
+# Sources: fleet/repos.yml and fleet/repo-metadata.yml
+---
 mode: static
-
 github:
   owner: heimgewebe
-
 repos:
-  - name: contracts-mirror
-    url: https://github.com/heimgewebe/contracts-mirror
-    default_branch: main
-    domain: contracts
-    scope: schema
-    metrics:
-      enable: false
-  - name: weltgewebe
-    url: https://github.com/heimgewebe/weltgewebe
-    default_branch: main
-    domain: aussen
-    scope: events
-    metrics:
-      enable: false
-  - name: hausKI
-    url: https://github.com/heimgewebe/hausKI
-    default_branch: main
-    domain: assistant
-    scope: policy
-    metrics:
-      enable: true
-  - name: hausKI-audio
-    url: https://github.com/heimgewebe/hausKI-audio
-    default_branch: main
-    depends_on:
-      - hausKI
-    domain: audio
-    scope: events
-    metrics:
-      enable: false
-  - name: semantAH
-    url: https://github.com/heimgewebe/semantAH
-    default_branch: main
-    domain: insights
-    scope: export
-    metrics:
-      enable: false
-  - name: wgx
-    url: https://github.com/heimgewebe/wgx
-    default_branch: main
-    domain: platform
-    scope: metrics
-    metrics:
-      enable: true
-  - name: lenskit
-    url: https://github.com/heimgewebe/lenskit
-    default_branch: main
-    domain: epistemic
-    scope: scanner-merger
-    metrics:
-      enable: false
-  - name: chronik
-    url: https://github.com/heimgewebe/chronik
-    default_branch: main
-    domain: chronik
-    scope: ingest
-    metrics:
-      enable: false
-  - name: aussensensor
-    url: https://github.com/heimgewebe/aussensensor
-    default_branch: main
-    domain: aussen
-    scope: events
-    metrics:
-      enable: false
-  - name: heimlern
-    url: https://github.com/heimgewebe/heimlern
-    default_branch: main
-    domain: policy
-    scope: library
-    metrics:
-      enable: false
-  - name: vault-gewebe
-    url: https://github.com/heimgewebe/vault-gewebe
-    default_branch: main
-    domain: vault
-    scope: content
-    metrics:
-      enable: false
-    wgx:
-      profile_expected: false
+- name: contracts-mirror
+  url: https://github.com/heimgewebe/contracts-mirror
+  default_branch: main
+  domain: contracts
+  scope: schema
+  metrics:
+    enable: false
+- name: weltgewebe
+  url: https://github.com/heimgewebe/weltgewebe
+  default_branch: main
+  domain: aussen
+  scope: events
+  metrics:
+    enable: false
+- name: hausKI
+  url: https://github.com/heimgewebe/hausKI
+  default_branch: main
+  domain: assistant
+  scope: policy
+  metrics:
+    enable: true
+- name: hausKI-audio
+  url: https://github.com/heimgewebe/hausKI-audio
+  default_branch: main
+  depends_on:
+  - hausKI
+  domain: audio
+  scope: events
+  metrics:
+    enable: false
+- name: semantAH
+  url: https://github.com/heimgewebe/semantAH
+  default_branch: main
+  domain: insights
+  scope: export
+  metrics:
+    enable: false
+- name: wgx
+  url: https://github.com/heimgewebe/wgx
+  default_branch: main
+  domain: platform
+  scope: metrics
+  metrics:
+    enable: true
+- name: lenskit
+  url: https://github.com/heimgewebe/lenskit
+  default_branch: main
+  domain: epistemic
+  scope: scanner-merger
+  metrics:
+    enable: false
+- name: chronik
+  url: https://github.com/heimgewebe/chronik
+  default_branch: main
+  domain: chronik
+  scope: ingest
+  metrics:
+    enable: false
+- name: aussensensor
+  url: https://github.com/heimgewebe/aussensensor
+  default_branch: main
+  domain: aussen
+  scope: events
+  metrics:
+    enable: false
+- name: heimlern
+  url: https://github.com/heimgewebe/heimlern
+  default_branch: main
+  domain: policy
+  scope: library
+  metrics:
+    enable: false
+- name: vault-gewebe
+  url: https://github.com/heimgewebe/vault-gewebe
+  default_branch: main
+  domain: vault
+  scope: content
+  metrics:
+    enable: false
+  wgx:
+    profile_expected: false

--- a/scripts/fleet/generate_repos_projection.py
+++ b/scripts/fleet/generate_repos_projection.py
@@ -49,6 +49,13 @@ class ProjectionError(ValueError):
     """Raised when canonical Fleet inputs cannot produce a safe projection."""
 
 
+class IndentedSafeDumper(yaml.SafeDumper):
+    """Safe dumper that preserves legacy-compatible sequence indentation."""
+
+    def increase_indent(self, flow: bool = False, indentless: bool = False) -> None:
+        return super().increase_indent(flow, False)
+
+
 class UniqueKeyLoader(yaml.SafeLoader):
     """Safe YAML loader that rejects duplicate mapping keys."""
 
@@ -280,11 +287,11 @@ def build_projection(
 
 
 def render_projection(projection: dict[str, Any]) -> str:
-    body = yaml.safe_dump(
+    body = yaml.dump(
         projection,
+        Dumper=IndentedSafeDumper,
         allow_unicode=True,
         default_flow_style=False,
-        explicit_start=True,
         sort_keys=False,
         width=1000,
     )

--- a/scripts/fleet/generate_repos_projection.py
+++ b/scripts/fleet/generate_repos_projection.py
@@ -117,7 +117,7 @@ def _entry_name(entry: Any, *, label: str) -> str:
     raise ProjectionError(f"{label} entry must contain a non-empty name")
 
 
-def _static_entry_is_projectable(entry: Any, *, label: str) -> bool:
+def _entry_is_projectable(entry: Any, *, label: str) -> bool:
     if not isinstance(entry, dict) or "fleet" not in entry:
         return True
     fleet_flag = entry["fleet"]
@@ -140,7 +140,8 @@ def collect_projectable_repositories(fleet: dict[str, Any]) -> set[str]:
         if name in all_names:
             raise ProjectionError(f"duplicate Fleet repository: {name}")
         all_names.add(name)
-        projectable.add(name)
+        if _entry_is_projectable(entry, label=f"repos[{index}]"):
+            projectable.add(name)
 
     static = fleet.get("static", {})
     if static is None:
@@ -158,7 +159,7 @@ def collect_projectable_repositories(fleet: dict[str, Any]) -> set[str]:
         if name in all_names:
             raise ProjectionError(f"repository occurs more than once in Fleet scope: {name}")
         all_names.add(name)
-        if _static_entry_is_projectable(entry, label=label):
+        if _entry_is_projectable(entry, label=label):
             projectable.add(name)
 
     if not projectable:

--- a/scripts/fleet/generate_repos_projection.py
+++ b/scripts/fleet/generate_repos_projection.py
@@ -1,0 +1,361 @@
+#!/usr/bin/env python3
+"""Generate the legacy top-level repos.yml compatibility projection.
+
+Canonical inputs:
+  * fleet/repos.yml          -- Fleet membership and related repositories
+  * fleet/repo-metadata.yml  -- operational metadata for legacy consumers
+
+The generated top-level repos.yml is intentionally non-authoritative. Existing
+WGX, graph and template tooling may continue to read it until those consumers
+are migrated, but CI requires byte-for-byte reproducibility from the canonical
+inputs.
+"""
+
+from __future__ import annotations
+
+import argparse
+import difflib
+from pathlib import Path
+import sys
+from typing import Any
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_FLEET = ROOT / "fleet" / "repos.yml"
+DEFAULT_METADATA = ROOT / "fleet" / "repo-metadata.yml"
+DEFAULT_OUTPUT = ROOT / "repos.yml"
+HEADER = (
+    "# GENERATED FILE. DO NOT EDIT.\n"
+    "# Sources: fleet/repos.yml and fleet/repo-metadata.yml\n"
+)
+REPO_FIELD_ORDER = (
+    "url",
+    "default_branch",
+    "depends_on",
+    "domain",
+    "scope",
+    "metrics",
+    "wgx",
+    "integrity",
+)
+ALLOWED_REPO_FIELDS = set(REPO_FIELD_ORDER)
+MAPPING_REPO_FIELDS = ("metrics", "wgx", "integrity")
+STRING_REPO_FIELDS = ("domain", "scope")
+
+
+class ProjectionError(ValueError):
+    """Raised when canonical Fleet inputs cannot produce a safe projection."""
+
+
+class UniqueKeyLoader(yaml.SafeLoader):
+    """Safe YAML loader that rejects duplicate mapping keys."""
+
+
+def _construct_unique_mapping(
+    loader: UniqueKeyLoader,
+    node: yaml.nodes.MappingNode,
+    deep: bool = False,
+) -> dict[Any, Any]:
+    loader.flatten_mapping(node)
+    mapping: dict[Any, Any] = {}
+    for key_node, value_node in node.value:
+        key = loader.construct_object(key_node, deep=deep)
+        try:
+            duplicate = key in mapping
+        except TypeError as exc:
+            raise yaml.constructor.ConstructorError(
+                "while constructing a mapping",
+                node.start_mark,
+                "found an unhashable mapping key",
+                key_node.start_mark,
+            ) from exc
+        if duplicate:
+            raise yaml.constructor.ConstructorError(
+                "while constructing a mapping",
+                node.start_mark,
+                f"found duplicate key {key!r}",
+                key_node.start_mark,
+            )
+        mapping[key] = loader.construct_object(value_node, deep=deep)
+    return mapping
+
+
+UniqueKeyLoader.add_constructor(
+    yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
+    _construct_unique_mapping,
+)
+
+
+def load_mapping(path: Path, *, label: str) -> dict[str, Any]:
+    try:
+        value = yaml.load(path.read_text(encoding="utf-8"), Loader=UniqueKeyLoader)
+    except FileNotFoundError as exc:
+        raise ProjectionError(f"{label} not found: {path}") from exc
+    except yaml.YAMLError as exc:
+        raise ProjectionError(f"{label} is not valid unique-key YAML: {path}: {exc}") from exc
+    if not isinstance(value, dict):
+        raise ProjectionError(f"{label} must have a mapping root: {path}")
+    return value
+
+
+def _entry_name(entry: Any, *, label: str) -> str:
+    if isinstance(entry, str) and entry.strip():
+        return entry.strip()
+    if isinstance(entry, dict):
+        name = entry.get("name")
+        if isinstance(name, str) and name.strip():
+            return name.strip()
+    raise ProjectionError(f"{label} entry must contain a non-empty name")
+
+
+def _static_entry_is_projectable(entry: Any, *, label: str) -> bool:
+    if not isinstance(entry, dict) or "fleet" not in entry:
+        return True
+    fleet_flag = entry["fleet"]
+    if not isinstance(fleet_flag, bool):
+        raise ProjectionError(f"{label}.fleet must be boolean when present")
+    return fleet_flag
+
+
+def collect_projectable_repositories(fleet: dict[str, Any]) -> set[str]:
+    """Return repositories eligible for the public compatibility projection."""
+
+    all_names: set[str] = set()
+    projectable: set[str] = set()
+
+    repos = fleet.get("repos")
+    if not isinstance(repos, list):
+        raise ProjectionError("fleet/repos.yml must contain a repos list")
+    for index, entry in enumerate(repos):
+        name = _entry_name(entry, label=f"repos[{index}]")
+        if name in all_names:
+            raise ProjectionError(f"duplicate Fleet repository: {name}")
+        all_names.add(name)
+        projectable.add(name)
+
+    static = fleet.get("static", {})
+    if static is None:
+        static = {}
+    if not isinstance(static, dict):
+        raise ProjectionError("fleet/repos.yml static must be a mapping")
+    include = static.get("include", [])
+    if include is None:
+        include = []
+    if not isinstance(include, list):
+        raise ProjectionError("fleet/repos.yml static.include must be a list")
+    for index, entry in enumerate(include):
+        label = f"static.include[{index}]"
+        name = _entry_name(entry, label=label)
+        if name in all_names:
+            raise ProjectionError(f"repository occurs more than once in Fleet scope: {name}")
+        all_names.add(name)
+        if _static_entry_is_projectable(entry, label=label):
+            projectable.add(name)
+
+    if not projectable:
+        raise ProjectionError("fleet/repos.yml contains no projectable repositories")
+    return projectable
+
+
+def _validated_metadata_config(
+    name: str,
+    raw_config: Any,
+    *,
+    owner: str,
+    projectable: set[str],
+) -> dict[str, Any]:
+    if not isinstance(raw_config, dict):
+        raise ProjectionError(f"metadata for {name} must be a mapping")
+
+    unknown_fields = sorted(set(raw_config) - ALLOWED_REPO_FIELDS)
+    if unknown_fields:
+        raise ProjectionError(
+            f"unsupported metadata fields for {name}: {', '.join(unknown_fields)}"
+        )
+
+    default_branch = raw_config.get("default_branch")
+    if not isinstance(default_branch, str) or not default_branch.strip():
+        raise ProjectionError(f"{name}.default_branch must be non-empty")
+
+    raw_dependencies = raw_config.get("depends_on", [])
+    if not isinstance(raw_dependencies, list) or not all(
+        isinstance(value, str) and value.strip() for value in raw_dependencies
+    ):
+        raise ProjectionError(f"{name}.depends_on must be a list of names")
+    dependencies = [value.strip() for value in raw_dependencies]
+    if len(dependencies) != len(set(dependencies)):
+        raise ProjectionError(f"{name}.depends_on contains duplicates")
+    unknown_dependencies = sorted(set(dependencies) - projectable)
+    if unknown_dependencies:
+        raise ProjectionError(
+            f"{name}.depends_on references non-projectable repositories: "
+            + ", ".join(unknown_dependencies)
+        )
+
+    raw_url = raw_config.get("url")
+    if raw_url is None:
+        url = f"https://github.com/{owner}/{name}"
+    elif isinstance(raw_url, str) and raw_url.strip():
+        url = raw_url.strip()
+    else:
+        raise ProjectionError(f"{name}.url must be a non-empty string")
+
+    for field in STRING_REPO_FIELDS:
+        value = raw_config.get(field)
+        if value is not None and (not isinstance(value, str) or not value.strip()):
+            raise ProjectionError(f"{name}.{field} must be a non-empty string")
+
+    for field in MAPPING_REPO_FIELDS:
+        value = raw_config.get(field)
+        if value is not None and not isinstance(value, dict):
+            raise ProjectionError(f"{name}.{field} must be a mapping")
+
+    normalized: dict[str, Any] = {"url": url, "default_branch": default_branch.strip()}
+    if dependencies:
+        normalized["depends_on"] = dependencies
+    for field in STRING_REPO_FIELDS:
+        if field in raw_config:
+            normalized[field] = raw_config[field].strip()
+    for field in MAPPING_REPO_FIELDS:
+        if field in raw_config:
+            normalized[field] = raw_config[field]
+    return normalized
+
+
+def build_projection(
+    fleet: dict[str, Any], metadata: dict[str, Any]
+) -> dict[str, Any]:
+    if metadata.get("schema_version") != 1:
+        raise ProjectionError("fleet/repo-metadata.yml schema_version must be 1")
+
+    github = metadata.get("github")
+    if not isinstance(github, dict):
+        raise ProjectionError("fleet/repo-metadata.yml github must be a mapping")
+    owner = github.get("owner")
+    if not isinstance(owner, str) or not owner.strip():
+        raise ProjectionError("fleet/repo-metadata.yml github.owner must be non-empty")
+    owner = owner.strip()
+
+    repositories = metadata.get("repositories")
+    if not isinstance(repositories, dict) or not repositories:
+        raise ProjectionError(
+            "fleet/repo-metadata.yml repositories must be a non-empty mapping"
+        )
+
+    projectable = collect_projectable_repositories(fleet)
+    projected: list[dict[str, Any]] = []
+    normalized_names: set[str] = set()
+
+    for raw_name, raw_config in repositories.items():
+        if not isinstance(raw_name, str) or not raw_name.strip():
+            raise ProjectionError("repository metadata keys must be non-empty strings")
+        name = raw_name.strip()
+        if name in normalized_names:
+            raise ProjectionError(f"duplicate normalized metadata repository: {name}")
+        normalized_names.add(name)
+        if name not in projectable:
+            raise ProjectionError(
+                f"metadata repository is not projectable from fleet/repos.yml: {name}"
+            )
+
+        config = _validated_metadata_config(
+            name,
+            raw_config,
+            owner=owner,
+            projectable=projectable,
+        )
+        entry: dict[str, Any] = {"name": name}
+        for field in REPO_FIELD_ORDER:
+            if field in config:
+                entry[field] = config[field]
+        projected.append(entry)
+
+    return {
+        "mode": "static",
+        "github": {"owner": owner},
+        "repos": projected,
+    }
+
+
+def render_projection(projection: dict[str, Any]) -> str:
+    body = yaml.safe_dump(
+        projection,
+        allow_unicode=True,
+        default_flow_style=False,
+        explicit_start=True,
+        sort_keys=False,
+        width=1000,
+    )
+    return HEADER + body
+
+
+def expected_projection(fleet_path: Path, metadata_path: Path) -> str:
+    fleet = load_mapping(fleet_path, label="Fleet membership")
+    metadata = load_mapping(metadata_path, label="Fleet metadata")
+    return render_projection(build_projection(fleet, metadata))
+
+
+def check_projection(output_path: Path, expected: str) -> bool:
+    try:
+        current = output_path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        print(f"projection missing: {output_path}", file=sys.stderr)
+        return False
+    if current == expected:
+        return True
+    diff = difflib.unified_diff(
+        current.splitlines(),
+        expected.splitlines(),
+        fromfile=str(output_path),
+        tofile=f"generated:{output_path}",
+        lineterm="",
+    )
+    print("repos.yml is stale; regenerate it from canonical Fleet inputs:", file=sys.stderr)
+    print("\n".join(diff), file=sys.stderr)
+    return False
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--fleet-file", type=Path, default=DEFAULT_FLEET)
+    parser.add_argument("--metadata-file", type=Path, default=DEFAULT_METADATA)
+    parser.add_argument("--output", type=Path, default=DEFAULT_OUTPUT)
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="fail unless the output already equals the deterministic projection",
+    )
+    parser.add_argument(
+        "--stdout",
+        action="store_true",
+        help="print the projection instead of writing it",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    if args.check and args.stdout:
+        raise ProjectionError("--check and --stdout are mutually exclusive")
+
+    expected = expected_projection(args.fleet_file, args.metadata_file)
+    if args.check:
+        return 0 if check_projection(args.output, expected) else 1
+    if args.stdout:
+        sys.stdout.write(expected)
+        return 0
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(expected, encoding="utf-8")
+    print(f"wrote generated compatibility projection: {args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except ProjectionError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        raise SystemExit(2) from exc

--- a/scripts/generate_integrity_sources.py
+++ b/scripts/generate_integrity_sources.py
@@ -4,7 +4,10 @@ Generate the canonical list of integrity sources (Pull-Model).
 
 Source of truth:
   - fleet/repos.yml (Fleet membership)
-  - repos.yml (Metadata, overrides)
+  - fleet/repo-metadata.yml (Metadata, overrides)
+
+Compatibility fallback:
+  - repos.yml is read only when the canonical metadata file is absent.
 
 Output:
   - reports/integrity/sources.v1.json
@@ -22,16 +25,29 @@ _REPO_ROOT = Path(__file__).resolve().parents[1]
 if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPO_ROOT))
 
+
 def load_yaml(yaml_mod: Any, path: Path) -> Any:
     with open(path, "r", encoding="utf-8") as f:
         return yaml_mod.safe_load(f)
+
 
 def utc_now_iso() -> str:
     # Support SOURCE_DATE_EPOCH for reproducible builds
     if "SOURCE_DATE_EPOCH" in os.environ:
         ts = int(os.environ["SOURCE_DATE_EPOCH"])
-        return datetime.fromtimestamp(ts, timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
-    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+        return (
+            datetime.fromtimestamp(ts, timezone.utc)
+            .replace(microsecond=0)
+            .isoformat()
+            .replace("+00:00", "Z")
+        )
+    return (
+        datetime.now(timezone.utc)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+
 
 def detect_repo_root() -> Path:
     env = os.environ.get("HG_ROOT") or os.environ.get("HEIMGEWEBE_ROOT")
@@ -39,16 +55,21 @@ def detect_repo_root() -> Path:
         return Path(env).resolve()
     return _REPO_ROOT
 
+
 def main():
     try:
         import yaml
     except ModuleNotFoundError:
-        # Metarepo Control Plane requires PyYAML via uv
-        sys.exit("Error: pyyaml not installed. Please run via 'uv run scripts/generate_integrity_sources.py'.")
+        # Metarepo tooling requires PyYAML via uv.
+        sys.exit(
+            "Error: pyyaml not installed. Please run via "
+            "'uv run scripts/generate_integrity_sources.py'."
+        )
 
     repo_root = detect_repo_root()
     fleet_repos_file = repo_root / "fleet/repos.yml"
-    repos_yml_file = repo_root / "repos.yml"
+    metadata_file = repo_root / "fleet/repo-metadata.yml"
+    legacy_repos_yml_file = repo_root / "repos.yml"
     output_file = repo_root / "reports/integrity/sources.v1.json"
 
     # Load Fleet Membership
@@ -93,19 +114,41 @@ def main():
     repo_configs = {}
     default_owner = "heimgewebe"
 
-    if repos_yml_file.exists():
-        raw_repos = load_yaml(yaml, repos_yml_file)
+    if metadata_file.exists():
+        raw_metadata = load_yaml(yaml, metadata_file)
+        if not isinstance(raw_metadata, dict):
+            sys.exit(f"Error: {metadata_file} must have a mapping root.")
+        if raw_metadata.get("schema_version") != 1:
+            sys.exit(f"Error: {metadata_file} schema_version must be 1.")
+        github = raw_metadata.get("github", {})
+        if not isinstance(github, dict):
+            sys.exit(f"Error: {metadata_file} github must be a mapping.")
+        default_owner = github.get("owner", default_owner)
+        repositories = raw_metadata.get("repositories", {})
+        if not isinstance(repositories, dict):
+            sys.exit(f"Error: {metadata_file} repositories must be a mapping.")
+        for name, config in repositories.items():
+            if isinstance(name, str) and isinstance(config, dict):
+                repo_configs[name] = config
+    elif legacy_repos_yml_file.exists():
+        print(
+            "Warning: canonical metadata missing; using compatibility projection "
+            f"{legacy_repos_yml_file}",
+            file=sys.stderr,
+        )
+        raw_repos = load_yaml(yaml, legacy_repos_yml_file)
         default_owner = raw_repos.get("github", {}).get("owner", default_owner)
 
         if "repos" in raw_repos and isinstance(raw_repos["repos"], list):
-            for r in raw_repos["repos"]:
-                name = r.get("name")
+            for repository in raw_repos["repos"]:
+                name = repository.get("name")
                 if name:
-                    repo_configs[name] = r
+                    repo_configs[name] = repository
 
     if not fleet_list:
         print(
-            f"Warning: No repositories found in {fleet_repos_file}; generated sources list will be empty.",
+            f"Warning: No repositories found in {fleet_repos_file}; "
+            "generated sources list will be empty.",
             file=sys.stderr,
         )
 
@@ -114,7 +157,8 @@ def main():
 
     for repo_name in sorted(fleet_list):
         config = repo_configs.get(repo_name, {})
-        # config usage: specifically to check for integrity.enabled override
+        # Metadata may explicitly disable integrity for one Fleet member. The
+        # generated repos.yml is consulted only by the compatibility fallback.
 
         # Use default owner for all repos (per-repo owner override not currently supported)
         owner = default_owner
@@ -125,22 +169,28 @@ def main():
             sys.exit(1)
         seen_repos.add(full_repo_name)
 
-        # Determine URL
         # Contract: https://github.com/<owner>/<repo>/releases/download/integrity/summary.json
-        summary_url = f"https://github.com/{owner}/{repo_name}/releases/download/integrity/summary.json"
+        summary_url = (
+            f"https://github.com/{owner}/{repo_name}/"
+            "releases/download/integrity/summary.json"
+        )
 
-        # Check if enabled via overrides
-        # Logic: fleet implies enabled, unless explicitly disabled in repos.yml metadata
+        # Fleet implies enabled unless canonical metadata explicitly disables it.
         enabled = True
         integrity_config = config.get("integrity", {})
-        if isinstance(integrity_config, dict) and integrity_config.get("enabled") is False:
+        if (
+            isinstance(integrity_config, dict)
+            and integrity_config.get("enabled") is False
+        ):
             enabled = False
 
-        sources.append({
-            "repo": full_repo_name,
-            "summary_url": summary_url,
-            "enabled": enabled
-        })
+        sources.append(
+            {
+                "repo": full_repo_name,
+                "summary_url": summary_url,
+                "enabled": enabled,
+            }
+        )
 
     # Check for idempotence to avoid drift in timestamps
     existing_data = None
@@ -163,13 +213,14 @@ def main():
     output_data = {
         "apiVersion": "integrity.sources.v1",
         "generated_at": new_generated_at,
-        "sources": sources
+        "sources": sources,
     }
 
     output_file.parent.mkdir(parents=True, exist_ok=True)
     with open(output_file, "w", encoding="utf-8") as f:
         json.dump(output_data, f, indent=2)
         f.write("\n")
+
 
 if __name__ == "__main__":
     main()

--- a/system/metarepo-role.v1.json
+++ b/system/metarepo-role.v1.json
@@ -8,7 +8,8 @@
     {
       "domain": "fleet_membership",
       "authoritative_source": "fleet/repos.yml",
-      "scope": "Mitgliedschaft in der gemeinsam verwalteten Metarepo-Fleet, nicht das vollständige Operator-Ökosystem."
+      "scope": "Mitgliedschaft wird ausschließlich in fleet/repos.yml entschieden; operative Fleet-Metadaten liegen getrennt in fleet/repo-metadata.yml.",
+      "metadata_source": "fleet/repo-metadata.yml"
     },
     {
       "domain": "shared_contracts",
@@ -78,10 +79,14 @@
   "compatibility_surfaces": [
     {
       "path": "repos.yml",
-      "status": "legacy_active",
+      "status": "compatibility_generated",
       "authoritative": false,
-      "target_state": "generated_projection_of:fleet/repos.yml",
-      "removal_gate": "Alle aktiven Tooling-Consumer lesen fleet/repos.yml oder eine nachweislich generierte Projektion."
+      "target_state": "deterministic_generated_projection",
+      "removal_gate": "Alle aktiven Tooling-Consumer lesen die kanonischen Mitgliedschafts- und Metadatenquellen direkt.",
+      "generated_from": [
+        "fleet/repos.yml",
+        "fleet/repo-metadata.yml"
+      ]
     },
     {
       "path": "wgx/",
@@ -116,7 +121,9 @@
     "Fleet-Mitgliedschaft ist nicht gleichbedeutend mit Zugehörigkeit zum vollständigen Operator-Ökosystem.",
     "Shared Assets werden erst nach belegter Consumer-Auswirkung geändert oder entfernt.",
     "README.md, .ai-context.yml und AGENTS.md müssen auf diesen Rollenvertrag verweisen und dieselben Wahrheitsgrenzen ausdrücken.",
-    "Legacy- und Kompatibilitätsflächen bleiben ausdrücklich nicht normativ, solange ihre Ablösung nicht verifiziert ist."
+    "Legacy- und Kompatibilitätsflächen bleiben ausdrücklich nicht normativ, solange ihre Ablösung nicht verifiziert ist.",
+    "repos.yml darf nicht manuell geändert werden und muss bytegenau aus fleet/repos.yml sowie fleet/repo-metadata.yml reproduzierbar sein.",
+    "Einträge mit fleet: false dürfen nicht in repos.yml projiziert oder allein aufgrund ihrer Erwähnung als Fleet-Ziel behandelt werden."
   ],
   "entrypoints": {
     "human": "README.md",
@@ -125,12 +132,14 @@
     "normative_role_contract": "system/metarepo-role.v1.json"
   },
   "verification": {
-    "last_verified_at": "2026-07-14",
-    "last_verified_against_commit": "4777fd5cfafea22813f9c3d647b33a0ffefd994b",
+    "last_verified_at": "2026-07-15",
+    "last_verified_against_commit": "e40c43691257aae2f432c33bd220389627d194b8",
     "evidence_scope": [
       "metarepo origin/main",
       "systemkatalog role projection",
-      "organisation-wide reusable-workflow caller search"
+      "organisation-wide reusable-workflow caller search",
+      "top-level repos.yml consumer and projection audit",
+      "semantic equality with the prior top-level repos.yml consumer contract"
     ],
     "does_not_establish": [
       "vollständige lokale IDE-Nutzung von servers/local-mcp",

--- a/tests/test_fleet_repos_projection.py
+++ b/tests/test_fleet_repos_projection.py
@@ -10,6 +10,8 @@ import sys
 import pytest
 import yaml
 
+from wgx import repo_config
+
 
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPT = ROOT / "scripts" / "fleet" / "generate_repos_projection.py"
@@ -31,6 +33,14 @@ def test_repository_projection_is_current() -> None:
         ROOT / "fleet" / "repo-metadata.yml",
     )
     assert (ROOT / "repos.yml").read_text(encoding="utf-8") == expected
+
+
+def test_projection_is_loadable_by_existing_legacy_consumers() -> None:
+    projection = repo_config.load_config(ROOT / "repos.yml")
+
+    assert projection["mode"] == "static"
+    assert projection["github"]["owner"] == "heimgewebe"
+    assert len(projection["repos"]) == 11
 
 
 def test_projection_preserves_complete_legacy_semantics() -> None:

--- a/tests/test_fleet_repos_projection.py
+++ b/tests/test_fleet_repos_projection.py
@@ -1,0 +1,242 @@
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import json
+from pathlib import Path
+import subprocess
+import sys
+
+import pytest
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "fleet" / "generate_repos_projection.py"
+LEGACY_SEMANTIC_SHA256 = "bbeeb43183de6526d0d2a22a4e82a37ca083416d23060525610bee9bf1a20737"
+SPEC = importlib.util.spec_from_file_location("generate_repos_projection", SCRIPT)
+assert SPEC and SPEC.loader
+MODULE = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+
+ProjectionError = MODULE.ProjectionError
+build_projection = MODULE.build_projection
+expected_projection = MODULE.expected_projection
+
+
+def test_repository_projection_is_current() -> None:
+    expected = expected_projection(
+        ROOT / "fleet" / "repos.yml",
+        ROOT / "fleet" / "repo-metadata.yml",
+    )
+    assert (ROOT / "repos.yml").read_text(encoding="utf-8") == expected
+
+
+def test_projection_preserves_complete_legacy_semantics() -> None:
+    projection = yaml.safe_load((ROOT / "repos.yml").read_text(encoding="utf-8"))
+    canonical = json.dumps(
+        projection,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+
+    assert hashlib.sha256(canonical).hexdigest() == LEGACY_SEMANTIC_SHA256
+
+
+def test_projection_preserves_legacy_consumer_shape() -> None:
+    projection = yaml.safe_load((ROOT / "repos.yml").read_text(encoding="utf-8"))
+
+    assert projection["mode"] == "static"
+    assert projection["github"]["owner"] == "heimgewebe"
+    names = [item["name"] for item in projection["repos"]]
+    assert names == [
+        "contracts-mirror",
+        "weltgewebe",
+        "hausKI",
+        "hausKI-audio",
+        "semantAH",
+        "wgx",
+        "lenskit",
+        "chronik",
+        "aussensensor",
+        "heimlern",
+        "vault-gewebe",
+    ]
+    assert all(
+        item["url"].startswith("https://github.com/heimgewebe/")
+        for item in projection["repos"]
+    )
+
+
+def test_metadata_must_reference_projectable_fleet_or_related_repo() -> None:
+    fleet = {"repos": [{"name": "known"}]}
+    metadata = {
+        "schema_version": 1,
+        "github": {"owner": "example"},
+        "repositories": {
+            "unknown": {"default_branch": "main"},
+        },
+    }
+
+    with pytest.raises(ProjectionError, match="not projectable"):
+        build_projection(fleet, metadata)
+
+
+def test_related_repository_metadata_is_allowed() -> None:
+    fleet = {
+        "static": {"include": [{"name": "related", "status": "related"}]},
+        "repos": [{"name": "core"}],
+    }
+    metadata = {
+        "schema_version": 1,
+        "github": {"owner": "example"},
+        "repositories": {
+            "related": {"default_branch": "main"},
+        },
+    }
+
+    projection = build_projection(fleet, metadata)
+    assert projection["repos"] == [
+        {
+            "name": "related",
+            "url": "https://github.com/example/related",
+            "default_branch": "main",
+        }
+    ]
+
+
+def test_fleet_false_related_repository_cannot_be_projected() -> None:
+    fleet = {
+        "static": {"include": [{"name": "private", "fleet": False}]},
+        "repos": [{"name": "core"}],
+    }
+    metadata = {
+        "schema_version": 1,
+        "github": {"owner": "example"},
+        "repositories": {
+            "private": {"default_branch": "main"},
+        },
+    }
+
+    with pytest.raises(ProjectionError, match="not projectable"):
+        build_projection(fleet, metadata)
+
+
+def test_fleet_flag_must_be_boolean() -> None:
+    fleet = {
+        "static": {"include": [{"name": "related", "fleet": "no"}]},
+        "repos": [{"name": "core"}],
+    }
+    metadata = {
+        "schema_version": 1,
+        "github": {"owner": "example"},
+        "repositories": {"core": {"default_branch": "main"}},
+    }
+
+    with pytest.raises(ProjectionError, match="fleet must be boolean"):
+        build_projection(fleet, metadata)
+
+
+def test_normalized_metadata_names_must_be_unique() -> None:
+    fleet = {"repos": [{"name": "core"}]}
+    metadata = {
+        "schema_version": 1,
+        "github": {"owner": "example"},
+        "repositories": {
+            "core": {"default_branch": "main"},
+            " core ": {"default_branch": "main"},
+        },
+    }
+
+    with pytest.raises(ProjectionError, match="duplicate normalized metadata"):
+        build_projection(fleet, metadata)
+
+
+def test_duplicate_yaml_keys_fail_closed(tmp_path: Path) -> None:
+    fleet = tmp_path / "fleet.yml"
+    metadata = tmp_path / "metadata.yml"
+    fleet.write_text("repos:\n  - name: core\n", encoding="utf-8")
+    metadata.write_text(
+        "schema_version: 1\n"
+        "github:\n"
+        "  owner: example\n"
+        "repositories:\n"
+        "  core:\n"
+        "    default_branch: main\n"
+        "  core:\n"
+        "    default_branch: trunk\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ProjectionError, match="duplicate key 'core'"):
+        expected_projection(fleet, metadata)
+
+
+def test_unknown_dependency_is_rejected() -> None:
+    fleet = {"repos": [{"name": "core"}]}
+    metadata = {
+        "schema_version": 1,
+        "github": {"owner": "example"},
+        "repositories": {
+            "core": {
+                "default_branch": "main",
+                "depends_on": ["missing"],
+            },
+        },
+    }
+
+    with pytest.raises(ProjectionError, match="non-projectable repositories"):
+        build_projection(fleet, metadata)
+
+
+def test_nested_consumer_metadata_must_be_mapping() -> None:
+    fleet = {"repos": [{"name": "core"}]}
+    metadata = {
+        "schema_version": 1,
+        "github": {"owner": "example"},
+        "repositories": {
+            "core": {"default_branch": "main", "metrics": False},
+        },
+    }
+
+    with pytest.raises(ProjectionError, match="metrics must be a mapping"):
+        build_projection(fleet, metadata)
+
+
+def test_check_mode_fails_for_stale_projection(tmp_path: Path) -> None:
+    fleet = tmp_path / "fleet.yml"
+    metadata = tmp_path / "metadata.yml"
+    output = tmp_path / "repos.yml"
+    fleet.write_text("repos:\n  - name: core\n", encoding="utf-8")
+    metadata.write_text(
+        "schema_version: 1\n"
+        "github:\n"
+        "  owner: example\n"
+        "repositories:\n"
+        "  core:\n"
+        "    default_branch: main\n",
+        encoding="utf-8",
+    )
+    output.write_text("stale: true\n", encoding="utf-8")
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--fleet-file",
+            str(fleet),
+            "--metadata-file",
+            str(metadata),
+            "--output",
+            str(output),
+            "--check",
+        ],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 1
+    assert "repos.yml is stale" in result.stderr

--- a/tests/test_fleet_repos_projection.py
+++ b/tests/test_fleet_repos_projection.py
@@ -134,6 +134,25 @@ def test_fleet_false_related_repository_cannot_be_projected() -> None:
         build_projection(fleet, metadata)
 
 
+def test_fleet_false_primary_repository_cannot_be_projected() -> None:
+    fleet = {
+        "repos": [
+            {"name": "core"},
+            {"name": "private", "fleet": False},
+        ]
+    }
+    metadata = {
+        "schema_version": 1,
+        "github": {"owner": "example"},
+        "repositories": {
+            "private": {"default_branch": "main"},
+        },
+    }
+
+    with pytest.raises(ProjectionError, match="not projectable"):
+        build_projection(fleet, metadata)
+
+
 def test_fleet_flag_must_be_boolean() -> None:
     fleet = {
         "static": {"include": [{"name": "related", "fleet": "no"}]},

--- a/tests/test_generate_integrity_sources.py
+++ b/tests/test_generate_integrity_sources.py
@@ -82,6 +82,52 @@ def test_generate_integrity_sources_standard(tmp_path):
 
     assert "testorg/metarepo" in sources_map
 
+def test_generate_integrity_sources_prefers_canonical_metadata(tmp_path):
+    fleet_dir = tmp_path / "fleet"
+    fleet_dir.mkdir()
+    with open(fleet_dir / "repos.yml", "w") as f:
+        yaml.dump({"repos": [{"name": "repo1"}]}, f)
+    with open(fleet_dir / "repo-metadata.yml", "w") as f:
+        yaml.dump(
+            {
+                "schema_version": 1,
+                "github": {"owner": "canonical-owner"},
+                "repositories": {
+                    "repo1": {
+                        "default_branch": "main",
+                        "integrity": {"enabled": False},
+                    }
+                },
+            },
+            f,
+        )
+    with open(tmp_path / "repos.yml", "w") as f:
+        yaml.dump(
+            {
+                "github": {"owner": "legacy-owner"},
+                "repos": [{"name": "repo1"}],
+            },
+            f,
+        )
+
+    env = os.environ.copy()
+    env["HG_ROOT"] = str(tmp_path)
+    result = run_script(env)
+
+    assert result.returncode == 0, result.stderr
+    data = json.loads(
+        (tmp_path / "reports/integrity/sources.v1.json").read_text(encoding="utf-8")
+    )
+    assert data["sources"] == [
+        {
+            "repo": "canonical-owner/repo1",
+            "summary_url": "https://github.com/canonical-owner/repo1/releases/download/integrity/summary.json",
+            "enabled": False,
+        }
+    ]
+    assert "compatibility projection" not in result.stderr
+
+
 def test_generate_integrity_sources_no_repo_config(tmp_path):
     # Setup mock file structure (without repos.yml)
     fleet_dir = tmp_path / "fleet"

--- a/tests/test_metarepo_role_contract.py
+++ b/tests/test_metarepo_role_contract.py
@@ -47,6 +47,9 @@ def test_all_local_contract_paths_exist() -> None:
 
     for item in role["owns"]:
         assert (ROOT / item["authoritative_source"]).exists()
+        metadata_source = item.get("metadata_source")
+        if metadata_source:
+            assert (ROOT / metadata_source).exists()
 
     for item in role["compatibility_surfaces"]:
         assert (ROOT / item["path"]).exists()
@@ -88,6 +91,13 @@ def test_legacy_surfaces_are_explicitly_non_normative() -> None:
     for item in compatibility.values():
         assert item["authoritative"] is False
 
+    repos_projection = compatibility["repos.yml"]
+    assert repos_projection["status"] == "compatibility_generated"
+    assert repos_projection["generated_from"] == [
+        "fleet/repos.yml",
+        "fleet/repo-metadata.yml",
+    ]
+
     dispatcher = compatibility[
         ".github/workflows/heimgewebe-command-dispatch.yml"
     ]
@@ -95,10 +105,18 @@ def test_legacy_surfaces_are_explicitly_non_normative() -> None:
     assert dispatcher["removal_gate"]
 
 
+def test_role_contract_records_projection_safety_invariants() -> None:
+    invariants = load_role()["invariants"]
+
+    assert any("bytegenau" in item and "repos.yml" in item for item in invariants)
+    assert any("fleet: false" in item and "nicht" in item for item in invariants)
+
+
 def test_role_contract_records_verification_limits() -> None:
     verification = load_role()["verification"]
 
+    assert verification["last_verified_at"] == "2026-07-15"
     assert verification["last_verified_against_commit"] == (
-        "4777fd5cfafea22813f9c3d647b33a0ffefd994b"
+        "e40c43691257aae2f432c33bd220389627d194b8"
     )
     assert verification["does_not_establish"]


### PR DESCRIPTION
## Problem

`fleet/repos.yml` wurde als normative Fleet-Quelle beschrieben, während das Top-Level-`repos.yml` weiterhin manuell gepflegt und von zahlreichen WGX-, Graph-, Readiness-, Template- und Integrity-Consumern gelesen wurde. Damit bestanden faktisch zwei operative Wahrheiten.

## Lösung

- `fleet/repos.yml` bleibt die einzige normative Mitgliedschaftsquelle.
- `fleet/repo-metadata.yml` enthält getrennte operative Zusatzdaten für bestehende Consumer.
- `repos.yml` wird deterministisch aus beiden Quellen erzeugt und bleibt vorübergehend als nicht normative Kompatibilitätsprojektion erhalten.
- `just fleet-projection-check` ist Bestandteil von `just validate` und blockiert manuelle oder veraltete Projektionen.
- Der Integrity-Generator liest die kanonische Metadatenquelle; `repos.yml` bleibt nur ein explizit warnender Fallback.

## Sicherheits- und Konsistenzgrenzen

- Einträge mit `fleet: false` können nicht in die öffentliche Projektion gelangen.
- Metadaten für unbekannte oder ausgeschlossene Repositories werden abgewiesen.
- Doppelte YAML-Schlüssel, doppelte normalisierte Namen, unbekannte Abhängigkeiten und ungültige Metadatenformen scheitern fail-closed.
- Die vollständige bisherige `repos.yml`-Semantik bleibt durch SHA-256 `bbeeb43183de6526d0d2a22a4e82a37ca083416d23060525610bee9bf1a20737` gebunden.
- Es wird keine Fleet-Mitgliedschaft hinzugefügt oder entfernt.

## Dokumentation

README, AGENTS sowie die aktiven Fleet-, Kernkonzept- und Troubleshooting-Dokumente unterscheiden nun klar zwischen:

1. Core-Fleet,
2. Related-Scope,
3. `fleet: false` ausgeschlossenen Einträgen,
4. generierter Legacy-Kompatibilität.

## Prüfung

- gezielte T002-Suite: 30 Tests PASS
- `env ALLOW_NET=1 just validate`: PASS
- vollständige Python-Suite: 121 Tests PASS
- YAML-Validierung: PASS
- Fleet- und Projektionsdrift: PASS
- Shell-Regressionen: PASS
- Actionlint: PASS
- `just contracts-validate`: PASS
- `git diff --cached --check`: PASS

Bureau-Kandidat: `METAREPO-LEGACY-RECONCILIATION-V1-T002`