### PR TITLE
fleet: add konvergenzregelkreis

### DIFF
--- a/docs/decisions/konvergenzregelkreis-fleet-admission-v1.md
+++ b/docs/decisions/konvergenzregelkreis-fleet-admission-v1.md
@@ -1,0 +1,22 @@
+# Fleet-Aufnahme: Konvergenzregelkreis v1
+
+## Entscheidung
+
+`heimgewebe/konvergenzregelkreis` wird als Core-Fleet-Repository in `fleet/repos.yml` aufgenommen.
+
+## Begründung gegen die Aufnahmekriterien
+
+- **Konkreter gemeinsamer Bedarf:** Das Repository besitzt versionierte Protokollschemas, Evidence-Profile R0–R3, Konformitätsfixtures und eine zustandslose Referenzauswertung. Diese Lieferflächen sind für Bureau-, Grabowski-, Systemkatalog-, Chronik- sowie Projektionsintegrationen vorgesehen.
+- **Eindeutiger Name und Scope:** Der Konvergenzregelkreis bewertet ausschließlich, ob ein vorgelegtes Evidence-Paket einen definierten Übergang erfüllt. Er besitzt keinen Task-, Queue-, Lease-, Merge-, Deployment-, Runtime-, Fleet- oder Ereignisstatus.
+- **Consumer-Auswirkung:** Die Aufnahme macht das Repository für gemeinsame Contract-, Prüf- und Driftwerkzeuge sichtbar. Sie ändert keinen bestehenden Consumer automatisch und ersetzt keine domäneneigene Wahrheit.
+- **Nicht nur allgemeine Zugehörigkeit:** Der konkrete Fleet-Nutzen liegt in gemeinsamen versionierten Verträgen und Konformitätsprüfungen, nicht in der bloßen Sichtbarkeit im Ökosystem.
+
+## Sicherheitsgrenze
+
+Die Fleet-Aufnahme autorisiert keinen pauschalen Template-, Workflow- oder Contract-Rollout. Jeder Consumer übernimmt eine konkrete Protokollversion weiterhin über einen eigenen PR mit Kompatibilitäts-, Review- und Rückrollbeleg.
+
+## Primärquelle
+
+- Repository: `https://github.com/heimgewebe/konvergenzregelkreis`
+- initiale öffentliche Version: `v0.1.0`
+- initialer Commit: `de8b2733da57a27a94ff55ce79b04fc1dbe7835b`

--- a/fleet/repos.yml
+++ b/fleet/repos.yml
@@ -19,6 +19,7 @@ repos:
   - name: aussensensor
   - name: chronik
   - name: lenskit
+  - name: konvergenzregelkreis
   - name: mitschreiber
   - name: sichter
   - name: leitstand


### PR DESCRIPTION
## Zweck

Nimmt `heimgewebe/konvergenzregelkreis` als Core-Fleet-Repository auf.

## Begründung

- gemeinsamer versionierter Protokoll- und Konformitätskern für mehrere Heimgewebe-Consumer
- eindeutige Zuständigkeitsgrenze ohne Task-, Runtime- oder Merge-Autorität
- keine automatische Consumer-Adoption
- keine erfundenen Legacy-Metadaten; `repos.yml` bleibt unverändert

## Änderungen

- `fleet/repos.yml`: normative Fleet-Mitgliedschaft
- `docs/decisions/konvergenzregelkreis-fleet-admission-v1.md`: Aufnahmebegründung und Sicherheitsgrenze

## Prüfung

- `just fleet-projection-check` PASS
- 24 fokussierte Fleet-/Rollenprüfungen PASS
- vollständiges `ALLOW_NET=1 just validate` PASS
- 127 Python-Tests PASS
- YAML, Shell-Regressionen und actionlint PASS

## Bindung

- Basis: `6715c67c1d326a2c0d2f170e1c23e896e8889b59`
- Head: `5ad7bb8f8ebac2291ea69c07183355f58770889f`
- Diff SHA-256: `0957e7602609629557adbd3cc76f5938400a32de1ebefbdf23d7c792b5c0b955`

## Nichtbehauptungen

Die Aufnahme rollt keine Templates, Workflows oder Contracts automatisch aus und etabliert keine Systemkatalog-, Bureau-, Grabowski-, Deployment- oder Runtime-Wahrheit.