### PR TITLE
chore(fleet): migrate Lenskit registry to RepoGround

### DIFF
--- a/.github/workflows/heimgewebe-command-dispatch.yml
+++ b/.github/workflows/heimgewebe-command-dispatch.yml
@@ -23,7 +23,7 @@ jobs:
     env:
       # Whitelist der Ziel-Repos (kommagetrennt). Kann pro Repo via
       # Repository-Variable HEIMGEWEBE_ALLOWED_REPOS überschrieben werden.
-      ALLOWED_TARGET_REPOS: ${{ vars.HEIMGEWEBE_ALLOWED_REPOS || 'sichter,wgx,heimgeist,metarepo,hausKI,semantAH,heimlern,chronik,leitstand,lenskit' }}
+      ALLOWED_TARGET_REPOS: ${{ vars.HEIMGEWEBE_ALLOWED_REPOS || 'sichter,wgx,heimgeist,metarepo,hausKI,semantAH,heimlern,chronik,leitstand,repoground' }}
 
       # Whitelist der erlaubten Kommandos (kommagetrennt). Kann via
       # Repository-Variable HEIMGEWEBE_ALLOWED_COMMANDS überschrieben werden.
@@ -139,9 +139,9 @@ jobs:
             }
 
             // Whitelist-Checks
-            if (targetRepo === "tools") {
+            if (["tools", "lenskit"].includes(targetRepo)) {
               await reply(
-                "⚠️ Das Ziel-Repo **tools** ist deprecated. Bitte nutze **lenskit**.\n\n" +
+                `⚠️ Das Ziel-Repo **${targetRepo}** ist deprecated. Bitte nutze **repoground**.\n\n` +
                 `Erlaubte Repos: \`${allowedRepos.join(", ")}\`.`
               );
               return;

--- a/ai-contexts/repoground.ai-context.yml
+++ b/ai-contexts/repoground.ai-context.yml
@@ -2,9 +2,9 @@
 ai_context_version: 1.1
 
 project:
-  name: lenskit
-  summary: Scanner- und Merger-Kern für Repo-Snapshots und epistemische Artefakte.
-  role: epistemic_scanner_merger_core
+  name: repoground
+  summary: Verifizierbarer Codebase-Kontext für Menschen und KI-Systeme.
+  role: verifiable_codebase_context
   primary_language: mixed
   visibility: public
 
@@ -21,10 +21,10 @@ interfaces:
     - "Fleet repository trees and metadata"
     - "Commit history and file snapshots"
   produces:
-    - "merge artifacts"
-    - "fleet snapshots"
-    - "scanner reports"
-    - "agent-readable epistemic bundles"
+    - "canonical repository snapshots"
+    - "retrieval and navigation indices"
+    - "evidence-bound codebase context"
+    - "agent-readable bundles"
 
 boundaries:
   responsible_for:
@@ -49,12 +49,12 @@ architecture:
   note: "Historische Pfade wie tools/bin/* nur bei bestätigter Existenz verwenden; nicht automatisch umbenennen."
   data_flow:
     input: "Fleet state and repository trees"
-    processing: "Scan + Merge + Snapshot + Report"
-    output: "Epistemic artifacts and machine-readable reports"
+    processing: "Scan + Snapshot + Index + Evidence binding"
+    output: "Verifiable codebase context and machine-readable evidence"
 
 conventions:
   branching: "main, feature/*"
-  commit_prefix: "lenskit"
+  commit_prefix: "repoground"
   ci_platform: github_actions
 
 documentation:
@@ -66,4 +66,4 @@ ai_guidance:
     - preserve reproducibility of generated artifacts
     - verify concrete filesystem paths before path-specific assumptions
   dont:
-    - introduce repo-local utility assumptions into lenskit identity
+    - introduce repo-local utility assumptions into RepoGround identity

--- a/docs/_generated/fleet.md
+++ b/docs/_generated/fleet.md
@@ -1,6 +1,6 @@
 <!-- GENERATED FILE - DO NOT EDIT -->
 <!-- Source: fleet/repos.yml -->
-<!-- Generated at: 2026-03-10 15:33:28 (Commit: 318e41c) -->
+<!-- Generated at: 2026-07-17 17:42:33 (Commit: 8c6990e) -->
 
 # Heimgewebe Fleet Overview
 
@@ -18,7 +18,8 @@ Repositories managed by WGX (Contracts, Templates, Policies).
 - **semantAH**
 - **aussensensor**
 - **chronik**
-- **lenskit**
+- **repoground**
+- **konvergenzregelkreis**
 - **mitschreiber**
 - **sichter**
 - **leitstand**

--- a/docs/nutzung.md
+++ b/docs/nutzung.md
@@ -9,7 +9,7 @@ autopoetischer KI-Organismus funktioniert:
 - **semantAH** – semantischer Index und Insights
 - **chronik** – Ereignisspeicher (Event-Log, Audit)
 - **leitstand** – UI / Dashboard
-- plus weitere Organe: **aussensensor**, **heimlern**, **vault-gewebe**, **weltgewebe**, **lenskit**, **sichter**, **mitschreiber**, **heimgeist**, **plexer**.
+- plus weitere Organe: **aussensensor**, **heimlern**, **vault-gewebe**, **weltgewebe**, **repoground**, **sichter**, **mitschreiber**, **heimgeist**, **plexer**.
 
 Dieses Dokument erklärt:
 
@@ -222,9 +222,9 @@ wird öffentlich sichtbar.
 
 ---
 
-### 2.11 lenskit – Merger & Scanner
+### 2.11 RepoGround – verifizierbarer Codebase-Kontext
 
-**Repo:** `heimgewebe/lenskit`
+**Repo:** `heimgewebe/repoground`
 
 - Enthält:
   - Merging-Tools (z. B. repomerger, wc-merger) zur Snapshot-Erstellung.
@@ -232,7 +232,7 @@ wird öffentlich sichtbar.
 - Wird von metarepo/wgx genutzt, um Org-Assets zu generieren (z. B. Tabellen aus `repos.yml`).
 
 **Nutzen:**
-lenskit ist der **Scanner-/Merger-Kern**: es erzeugt konsistente Snapshots
+RepoGround erzeugt **verifizierbaren Codebase-Kontext**: konsistente Snapshots
 und mehrstufige Artefakte für Analyse, Reflexion und Agentenbetrieb.
 
 ---

--- a/docs/org-graph.mmd
+++ b/docs/org-graph.mmd
@@ -7,7 +7,7 @@ graph TD
     hausKI["hausKI\n(assistant › policy)"]
     hausKI_audio["hausKI-audio\n(audio › events)"]
     heimlern["heimlern\n(policy › library)"]
-    lenskit["lenskit\n(epistemic › scanner-merger)"]
+    repoground["repoground\n(epistemic › codebase-context)"]
     semantAH["semantAH\n(insights › export)"]
     vault_gewebe["vault-gewebe\n(vault › content)"]
     weltgewebe["weltgewebe\n(aussen › events)"]

--- a/docs/org-index.md
+++ b/docs/org-index.md
@@ -12,7 +12,7 @@ Quelle: [`repos.yml`](../repos.yml).
 | [hausKI](https://github.com/heimgewebe/hausKI) | main | assistant | policy | ✅ | – |
 | [hausKI-audio](https://github.com/heimgewebe/hausKI-audio) | main | audio | events | – | hausKI |
 | [heimlern](https://github.com/heimgewebe/heimlern) | main | policy | library | – | – |
-| [lenskit](https://github.com/heimgewebe/lenskit) | main | epistemic | scanner-merger | – | – |
+| [repoground](https://github.com/heimgewebe/repoground) | main | epistemic | codebase-context | – | – |
 | [semantAH](https://github.com/heimgewebe/semantAH) | main | insights | export | – | – |
 | [vault-gewebe](https://github.com/heimgewebe/vault-gewebe) | main | vault | content | – | – |
 | [weltgewebe](https://github.com/heimgewebe/weltgewebe) | main | aussen | events | – | – |

--- a/docs/repo-matrix.md
+++ b/docs/repo-matrix.md
@@ -16,7 +16,7 @@ Diese Repositories bilden den Organismus und unterliegen den Fleet-Policies (CI,
 | semantAH          | Embeddings / Wissensschicht         | yes   |
 | aussensensor      | Außenwelt-Events                    | yes   |
 | chronik           | Persistenz/Audit                    | yes   |
-| lenskit          | Merger & Scanner für Repo-Artefakte | yes   |
+| repoground       | Verifizierbarer Codebase-Kontext    | yes   |
 | mitschreiber      | Dialog-/Schreibschicht              | yes   |
 | sichter           | Review-Agent / Semantic Checks      | yes   |
 | heimgeist         | Meta-Agent / Beobachtung            | yes   |

--- a/fleet/repo-metadata.yml
+++ b/fleet/repo-metadata.yml
@@ -47,10 +47,10 @@ repositories:
     scope: metrics
     metrics:
       enable: true
-  lenskit:
+  repoground:
     default_branch: main
     domain: epistemic
-    scope: scanner-merger
+    scope: codebase-context
     metrics:
       enable: false
   chronik:

--- a/fleet/repos.txt
+++ b/fleet/repos.txt
@@ -7,7 +7,7 @@ heimlern
 semantAH
 aussensensor
 chronik
-lenskit
+repoground
 mitschreiber
 sichter
 heimgeist

--- a/fleet/repos.yml
+++ b/fleet/repos.yml
@@ -18,7 +18,7 @@ repos:
   - name: semantAH
   - name: aussensensor
   - name: chronik
-  - name: lenskit
+  - name: repoground
   - name: konvergenzregelkreis
   - name: mitschreiber
   - name: sichter

--- a/reports/integrity/sources.v1.json
+++ b/reports/integrity/sources.v1.json
@@ -1,6 +1,6 @@
 {
   "apiVersion": "integrity.sources.v1",
-  "generated_at": "2026-01-17T08:05:04Z",
+  "generated_at": "2026-07-17T14:40:06Z",
   "sources": [
     {
       "repo": "heimgewebe/aussensensor",
@@ -28,6 +28,11 @@
       "enabled": true
     },
     {
+      "repo": "heimgewebe/heim-pc",
+      "summary_url": "https://github.com/heimgewebe/heim-pc/releases/download/integrity/summary.json",
+      "enabled": true
+    },
+    {
       "repo": "heimgewebe/heimgeist",
       "summary_url": "https://github.com/heimgewebe/heimgeist/releases/download/integrity/summary.json",
       "enabled": true
@@ -35,6 +40,11 @@
     {
       "repo": "heimgewebe/heimlern",
       "summary_url": "https://github.com/heimgewebe/heimlern/releases/download/integrity/summary.json",
+      "enabled": true
+    },
+    {
+      "repo": "heimgewebe/konvergenzregelkreis",
+      "summary_url": "https://github.com/heimgewebe/konvergenzregelkreis/releases/download/integrity/summary.json",
       "enabled": true
     },
     {
@@ -58,6 +68,11 @@
       "enabled": true
     },
     {
+      "repo": "heimgewebe/repoground",
+      "summary_url": "https://github.com/heimgewebe/repoground/releases/download/integrity/summary.json",
+      "enabled": true
+    },
+    {
       "repo": "heimgewebe/semantAH",
       "summary_url": "https://github.com/heimgewebe/semantAH/releases/download/integrity/summary.json",
       "enabled": true
@@ -68,18 +83,8 @@
       "enabled": true
     },
     {
-      "repo": "heimgewebe/lenskit",
-      "summary_url": "https://github.com/heimgewebe/lenskit/releases/download/integrity/summary.json",
-      "enabled": true
-    },
-    {
       "repo": "heimgewebe/vault-gewebe",
       "summary_url": "https://github.com/heimgewebe/vault-gewebe/releases/download/integrity/summary.json",
-      "enabled": true
-    },
-    {
-      "repo": "heimgewebe/heim-pc",
-      "summary_url": "https://github.com/heimgewebe/heim-pc/releases/download/integrity/summary.json",
       "enabled": true
     },
     {

--- a/repos.yml
+++ b/repos.yml
@@ -48,11 +48,11 @@ repos:
     scope: metrics
     metrics:
       enable: true
-  - name: lenskit
-    url: https://github.com/heimgewebe/lenskit
+  - name: repoground
+    url: https://github.com/heimgewebe/repoground
     default_branch: main
     domain: epistemic
-    scope: scanner-merger
+    scope: codebase-context
     metrics:
       enable: false
   - name: chronik

--- a/scripts/fleet/check_docs_drift.sh
+++ b/scripts/fleet/check_docs_drift.sh
@@ -90,36 +90,32 @@ if [ "$ERRORS" -eq 1 ]; then
   exit 1
 fi
 
-# 3. Guard against stale repo-identity references to legacy repo name "tools"
-# Allowlist rules (exclusion semantics vary by implementation):
-# - reports/sync-logs/** may contain historical names by design.
-#   (rg: path-scoped glob; grep fallback: basename "sync-logs")
-# - tools/** is a local toolchain tree, not repo identity.
-#   (rg: path-scoped glob; grep fallback: basename "tools" matches all tools dirs)
-# - scripts/tools/** contains local helper scripts, not repo identity.
-#   (rg: path-scoped glob; grep fallback: covered by basename "tools")
-# - scripts/fleet/check_docs_drift.sh contains the guard patterns itself.
-#   (rg: path-scoped glob; grep fallback: basename "check_docs_drift.sh")
-# Note: docs/archive/** was migrated (tools→lenskit) in commit 7038fdd, so no exclusion needed.
-# Implementation note: rg globs are path-scoped and precise; grep fallback uses basename
-# exclusions for portability across GNU/BSD/busybox variants.
+# 3. Guard against stale active repo identities "tools" and "lenskit"
+# Allowlist rules:
+# - reports/sync-logs/** and docs/archive/** are immutable historical evidence.
+# - tools/** and scripts/tools/** are local toolchain trees, not repo identity.
+# - the command-dispatch workflow intentionally recognizes legacy aliases so it
+#   can direct callers to RepoGround; the patterns below target active identity
+#   declarations and allowlists, not that explicit compatibility branch.
+# - this script contains the guard patterns itself.
 
-echo "Scanning for stale repo-identity references (tools -> lenskit)..."
+echo "Scanning for stale repo identities (tools/lenskit -> repoground)..."
 
-LEGACY_PATTERN_PCRE='(github\.com/heimgewebe/tools|heimgewebe/tools|^\s*-\s*name:\s*tools\s*$|ALLOWED_TARGET_REPOS:.*\btools\b)'
-LEGACY_PATTERN_ERE='(github\.com/heimgewebe/tools|heimgewebe/tools|^[[:space:]]*-[[:space:]]*name:[[:space:]]*tools[[:space:]]*$|ALLOWED_TARGET_REPOS:.*(^|[^[:alnum:]_])tools([^[:alnum:]_]|$))'
+LEGACY_PATTERN_RG='(github\.com/heimgewebe/(tools|lenskit)(\.git)?|heimgewebe/(tools|lenskit)\b|^\s*-\s*name:\s*(tools|lenskit)\s*$|^\s*name:\s*(tools|lenskit)\s*$|ALLOWED_TARGET_REPOS:.*\b(tools|lenskit)\b)'
+LEGACY_PATTERN_ERE='(github\.com/heimgewebe/(tools|lenskit)(\.git)?|heimgewebe/(tools|lenskit)([^[:alnum:]_.-]|$)|^[[:space:]]*-[[:space:]]*name:[[:space:]]*(tools|lenskit)[[:space:]]*$|^[[:space:]]*name:[[:space:]]*(tools|lenskit)[[:space:]]*$|ALLOWED_TARGET_REPOS:.*(^|[^[:alnum:]_])(tools|lenskit)([^[:alnum:]_]|$))'
 if has_rg; then
   set +e
-  rg -n --pcre2 \
+  rg -n \
     --glob '!reports/sync-logs/**' \
+    --glob '!docs/archive/**' \
     --glob '!tools/**' \
     --glob '!scripts/tools/**' \
     --glob '!scripts/fleet/check_docs_drift.sh' \
-    "$LEGACY_PATTERN_PCRE" .
+    "$LEGACY_PATTERN_RG" .
   rc=$?
   set -e
   if [ "$rc" -eq 0 ]; then
-    echo "❌ Found stale repo-identity reference(s) to 'tools'. Use 'lenskit' instead."
+    echo "❌ Found stale active repo identity. Use 'repoground' instead."
     exit 1
   elif [ "$rc" -eq 1 ]; then
     :
@@ -134,6 +130,7 @@ else
     grep -r -I -n -E \
       --exclude-dir='.git' \
       --exclude-dir='sync-logs' \
+      --exclude-dir='archive' \
       --exclude-dir='tools' \
       --exclude='check_docs_drift.sh' \
       -e "$LEGACY_PATTERN_ERE" \
@@ -144,15 +141,12 @@ else
   set -e
 
   if [ "$rc" -eq 0 ]; then
-    # Matches found
     echo "$GREP_OUT"
-    echo "❌ Found stale repo-identity reference(s) to 'tools'. Use 'lenskit' instead."
+    echo "❌ Found stale active repo identity. Use 'repoground' instead."
     exit 1
   elif [ "$rc" -eq 1 ]; then
-    # No matches - clean
     :
   else
-    # grep error (exit 2+)
     if [ -n "$GREP_OUT" ]; then
       echo "$GREP_OUT" >&2
     fi

--- a/tests/test_fleet_repos_projection.py
+++ b/tests/test_fleet_repos_projection.py
@@ -15,7 +15,7 @@ from wgx import repo_config
 
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPT = ROOT / "scripts" / "fleet" / "generate_repos_projection.py"
-LEGACY_SEMANTIC_SHA256 = "bbeeb43183de6526d0d2a22a4e82a37ca083416d23060525610bee9bf1a20737"
+PROJECTION_SEMANTIC_SHA256 = "a471bd9907f066acef70dc2f71bf26fda82ee30c657c588ea8d04d0c71164081"
 SPEC = importlib.util.spec_from_file_location("generate_repos_projection", SCRIPT)
 assert SPEC and SPEC.loader
 MODULE = importlib.util.module_from_spec(SPEC)
@@ -43,7 +43,7 @@ def test_projection_is_loadable_by_existing_legacy_consumers() -> None:
     assert len(projection["repos"]) == 11
 
 
-def test_projection_preserves_complete_legacy_semantics() -> None:
+def test_projection_pins_complete_compatibility_semantics() -> None:
     projection = yaml.safe_load((ROOT / "repos.yml").read_text(encoding="utf-8"))
     canonical = json.dumps(
         projection,
@@ -52,7 +52,7 @@ def test_projection_preserves_complete_legacy_semantics() -> None:
         separators=(",", ":"),
     ).encode("utf-8")
 
-    assert hashlib.sha256(canonical).hexdigest() == LEGACY_SEMANTIC_SHA256
+    assert hashlib.sha256(canonical).hexdigest() == PROJECTION_SEMANTIC_SHA256
 
 
 def test_projection_preserves_legacy_consumer_shape() -> None:
@@ -68,7 +68,7 @@ def test_projection_preserves_legacy_consumer_shape() -> None:
         "hausKI-audio",
         "semantAH",
         "wgx",
-        "lenskit",
+        "repoground",
         "chronik",
         "aussensensor",
         "heimlern",

--- a/tests/test_repoground_consumer_registration.py
+++ b/tests/test_repoground_consumer_registration.py
@@ -1,0 +1,44 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _read(relative_path: str) -> str:
+    return (ROOT / relative_path).read_text(encoding="utf-8")
+
+
+def test_active_fleet_surfaces_use_repoground_identity() -> None:
+    active_paths = (
+        "fleet/repos.yml",
+        "fleet/repo-metadata.yml",
+        "repos.yml",
+        "docs/org-index.md",
+        "docs/org-graph.mmd",
+        "docs/nutzung.md",
+        "reports/integrity/sources.v1.json",
+        "ai-contexts/repoground.ai-context.yml",
+    )
+
+    for relative_path in active_paths:
+        text = _read(relative_path)
+        assert "repoground" in text.lower(), relative_path
+        assert "heimgewebe/lenskit" not in text, relative_path
+
+    assert not (ROOT / "ai-contexts" / "lenskit.ai-context.yml").exists()
+
+
+def test_dispatch_keeps_legacy_aliases_but_targets_repoground() -> None:
+    workflow = _read(".github/workflows/heimgewebe-command-dispatch.yml")
+
+    assert "leitstand,repoground" in workflow
+    assert '["tools", "lenskit"].includes(targetRepo)' in workflow
+    assert "Bitte nutze **repoground**" in workflow
+    assert "leitstand,lenskit" not in workflow
+
+
+def test_repo_identity_guard_does_not_require_pcre2() -> None:
+    guard = _read("scripts/fleet/check_docs_drift.sh")
+
+    assert "LEGACY_PATTERN_RG=" in guard
+    assert '"$LEGACY_PATTERN_RG" .' in guard
+    assert "--pcre2" not in guard


### PR DESCRIPTION
## Ziel

Migriert die aktiven metarepo-Registrierungen von `lenskit` zu `repoground`, nachdem das kanonische Repository zu `heimgewebe/repoground` umbenannt wurde.

## Änderungen

- kanonische Fleet-Mitgliedschaft und Metadaten auf `repoground`
- Funktionsscope `scanner-merger` zu `codebase-context`
- RepoGround-Agentenkontext statt Lenskit-Agentenkontext
- generierte Fleet-, Organisations- und Integrity-Projektionen erneuert
- Command-Dispatch erlaubt `repoground`; `tools` und `lenskit` bleiben warnende Legacy-Aliase
- aktive Identitätsschranke verbietet neue `tools`-/`lenskit`-Registrierungen ohne PCRE2-Abhängigkeit
- Regressionstests für aktive RepoGround-Flächen, Aliasverhalten und portable Schranke

Die Generatoren haben außerdem bereits kanonisch registrierte, aber in älteren Projektionen fehlende Einträge (`heim-pc`, `konvergenzregelkreis`) nachgezogen. Archive und historische Sync-Protokolle bleiben unverändert.

## Nicht enthalten

- keine Umschreibung historischer Belege
- keine Änderung persistierter RepoGround/Lenskit-Artefakte
- kein Dienstneustart oder Runtime-Cutover
- keine Bereinigung fremder Worktrees oder Dirty-States

## Reviewbindung

- Basis: `8c6990e024d3e54a0d3dc8f5a0766162d3683497`
- Head: `b1afeede011666717c4153d22a0738a4a53d7e9b`
- gestagter Binärdiff SHA-256: `2dde5bbd720ed41e1cf9470fe4c9ab370e180b6bce044663811cbaeae17ec92f`
- Umfang: 15 Pfade, 114 Einfügungen, 70 Löschungen

## Verifikation

- `bash scripts/fleet/check_docs_drift.sh` — PASS
- gezielte Fleet-/Integrity-/Dispatch-/Rollen-Tests — `44 passed`
- `ALLOW_NET=1 just validate` — PASS
  - YAML-Prüfung
  - Fleet- und Projektionsprüfung
  - `130 passed`
  - Shell-Regressionen
  - shfmt und shellcheck
  - actionlint
- `git diff --cached --check` — PASS
- aktive Suche nach harten `heimgewebe/lenskit`-Adressen — keine Treffer außerhalb bewusst ausgenommener Historie/Regression
