### PR TITLE
feat: establish Fleet-bound Renovate V1 policy

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -23,6 +23,7 @@ help:
     @printf "  just log-sync      # Report-Vorlage unter reports/sync-logs/\n"
     @printf "  just fleet         # Fleet Readiness & Repos List generieren\n"
     @printf "  just fleet-projection # repos.yml aus kanonischen Fleet-Quellen erzeugen\n"
+    @printf "  just renovate-policy-check # Renovate-V1-Policy und Scope-Projektion prüfen\n"
     @printf "  just doctor        # Fleet Diagnose (Health Check)\n"
     @printf "\nWeitere Ziele: just --list\n"
 
@@ -117,6 +118,14 @@ fleet-projection:
 fleet-projection-check:
     @uv run python scripts/fleet/generate_repos_projection.py --check
 
+# Generate the bounded Renovate V1 scope projection from Fleet truth and policy
+renovate-policy:
+    @uv run python scripts/fleet/renovate_policy.py generate
+
+# Fail closed on Renovate policy, preset, baseline or scope drift
+renovate-policy-check:
+    @uv run python scripts/fleet/renovate_policy.py check
+
 # Diagnose current fleet readiness from reports/heimgewebe-readiness.json
 doctor:
     @[ -f reports/heimgewebe-readiness.json ] || just fleet
@@ -159,6 +168,7 @@ fleet-push-all:
 validate: yq_ensure lint
     just fleet-check
     just fleet-projection-check
+    just renovate-policy-check
     scripts/ci/validate-local.sh
     @if [ -d tests ] && [ -f pyproject.toml ] && grep -q "pytest" pyproject.toml; then echo "Running python tests..."; uv run pytest tests/; fi
     @printf "Running shell regression tests...\n"

--- a/automation/renovate/baseline-2026-06-23_2026-07-23.json
+++ b/automation/renovate/baseline-2026-06-23_2026-07-23.json
@@ -1,0 +1,56 @@
+{
+  "schema_version": 1,
+  "kind": "dependabot-pr-baseline",
+  "window": {
+    "start": "2026-06-23",
+    "end": "2026-07-23"
+  },
+  "source": {
+    "kind": "github-search",
+    "observed_on": "2026-07-23",
+    "query": "gh search prs --owner heimgewebe --author app/dependabot --created >=2026-06-23 --limit 100"
+  },
+  "repositories": {
+    "hausKI": {
+      "total": 11,
+      "merged": 10,
+      "closed_unmerged": 1,
+      "open": 0
+    },
+    "hausKI-audio": {
+      "total": 10,
+      "merged": 9,
+      "closed_unmerged": 1,
+      "open": 0
+    },
+    "metarepo": {
+      "total": 5,
+      "merged": 3,
+      "closed_unmerged": 2,
+      "open": 0
+    },
+    "repoground": {
+      "total": 6,
+      "merged": 1,
+      "closed_unmerged": 5,
+      "open": 0
+    },
+    "weltgewebe": {
+      "total": 19,
+      "merged": 17,
+      "closed_unmerged": 2,
+      "open": 0
+    }
+  },
+  "totals": {
+    "total": 51,
+    "merged": 40,
+    "closed_unmerged": 11,
+    "open": 0
+  },
+  "nonclaims": [
+    "The baseline does not prove Dependabot caused a PR to merge or close without merge.",
+    "The baseline does not prove every PR was a routine version update rather than security-related maintenance.",
+    "The baseline does not predict Renovate PR volume, merge rate or convergence quality."
+  ]
+}

--- a/automation/renovate/default.json
+++ b/automation/renovate/default.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": "Heimgewebe Fleet Renovate V1 baseline: bounded PR production only; no automerge or control-plane authority.",
+  "extends": [
+    "config:recommended"
+  ],
+  "automerge": false,
+  "dependencyDashboard": false,
+  "prConcurrentLimit": 2,
+  "branchConcurrentLimit": 2,
+  "prHourlyLimit": 2,
+  "separateMajorMinor": true,
+  "labels": [
+    "dependencies",
+    "renovate"
+  ],
+  "packageRules": [
+    {
+      "description": "Group compatible non-major GitHub Actions updates",
+      "matchManagers": [
+        "github-actions"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
+      ],
+      "groupName": "github-actions non-major"
+    }
+  ]
+}

--- a/automation/renovate/dependency-updates.v1.yml
+++ b/automation/renovate/dependency-updates.v1.yml
@@ -1,0 +1,73 @@
+---
+schema_version: 1
+kind: renovate-fleet-policy
+fleet_source: fleet/repos.yml
+github_owner: heimgewebe
+
+security_updates:
+  provider: dependabot
+  version_update_cutover_changes_security_updates: false
+
+version_update_defaults:
+  provider: renovate
+  automerge: false
+  duplicate_producer_policy: fail-closed
+  hosted_app_repository_selection: selected
+  all_repositories_allowed: false
+  minimum_observed_cycles_before_expansion: 2
+
+cutover_sequence:
+  - prove-renovate-coverage
+  - disable-overlapping-dependabot-version-updates
+  - verify-single-version-update-producer
+
+rollout:
+  waves:
+    - id: custom-manager-pilot
+      order: 1
+      purpose: Modernize and validate the existing Mitschreiber custom pin manager before standard package-manager rollout.
+      repositories:
+        - name: mitschreiber
+          dependabot_version_updates: none
+          renovate_version_updates: prepared
+
+    - id: volume-pilot
+      order: 2
+      purpose: Measure PR-volume and convergence changes on repositories with recent high Dependabot activity.
+      repositories:
+        - name: hausKI
+          dependabot_version_updates: enabled
+          renovate_version_updates: prepared
+        - name: hausKI-audio
+          dependabot_version_updates: enabled
+          renovate_version_updates: prepared
+
+    - id: signal-quality-pilot
+      order: 3
+      purpose: Measure whether grouped Renovate updates improve the unusually low recent merge ratio without assuming the bot caused it.
+      repositories:
+        - name: repoground
+          dependabot_version_updates: enabled
+          renovate_version_updates: prepared
+
+    - id: multi-ecosystem-pilot
+      order: 4
+      purpose: Prove the bounded model on the complex npm, Cargo and GitHub Actions update surface after earlier waves pass.
+      repositories:
+        - name: weltgewebe
+          dependabot_version_updates: enabled
+          renovate_version_updates: prepared
+
+    - id: control-plane-cutover
+      order: 5
+      purpose: Migrate Metarepo only after the consumer pilots prove the shared policy and prevent a self-approval loop.
+      repositories:
+        - name: metarepo
+          dependabot_version_updates: enabled
+          renovate_version_updates: prepared
+
+    - id: fleet-expansion
+      order: 6
+      purpose: Evaluate remaining eligible active Fleet repositories after all bounded pilots pass their acceptance gates.
+      selector: remaining-eligible-active-fleet
+      repositories: []

--- a/automation/renovate/expected-scope.v1.json
+++ b/automation/renovate/expected-scope.v1.json
@@ -1,0 +1,113 @@
+{
+  "deferred_selectors": [
+    "remaining-eligible-active-fleet"
+  ],
+  "expected_hosted_app_repositories": [],
+  "kind": "renovate-fleet-scope-projection",
+  "nonclaims": [
+    "This projection is not Fleet membership truth.",
+    "Prepared repositories are not proof that the Renovate GitHub App is installed or active.",
+    "An empty expected hosted-app scope is not proof that no external app installation exists.",
+    "This projection grants no merge, queue, claim, deployment or task-verification authority."
+  ],
+  "prepared_repositories": [
+    "heimgewebe/hausKI",
+    "heimgewebe/hausKI-audio",
+    "heimgewebe/metarepo",
+    "heimgewebe/mitschreiber",
+    "heimgewebe/repoground",
+    "heimgewebe/weltgewebe"
+  ],
+  "schema_version": 1,
+  "sources": {
+    "fleet": {
+      "path": "fleet/repos.yml",
+      "sha256": "ea9f6285be9556105ff0ed208766946f3c951a8392d59b3066bb4d8c9f476bc8"
+    },
+    "policy": {
+      "path": "automation/renovate/dependency-updates.v1.yml",
+      "sha256": "5b41a2b5eca3778688b5129a719e1af4d7d3d8dbf7abd9de53ac4454a48fb80a"
+    }
+  },
+  "version_update_ownership": [
+    {
+      "dependabot_version_updates": "enabled",
+      "renovate_version_updates": "prepared",
+      "repository": "heimgewebe/hausKI"
+    },
+    {
+      "dependabot_version_updates": "enabled",
+      "renovate_version_updates": "prepared",
+      "repository": "heimgewebe/hausKI-audio"
+    },
+    {
+      "dependabot_version_updates": "enabled",
+      "renovate_version_updates": "prepared",
+      "repository": "heimgewebe/metarepo"
+    },
+    {
+      "dependabot_version_updates": "none",
+      "renovate_version_updates": "prepared",
+      "repository": "heimgewebe/mitschreiber"
+    },
+    {
+      "dependabot_version_updates": "enabled",
+      "renovate_version_updates": "prepared",
+      "repository": "heimgewebe/repoground"
+    },
+    {
+      "dependabot_version_updates": "enabled",
+      "renovate_version_updates": "prepared",
+      "repository": "heimgewebe/weltgewebe"
+    }
+  ],
+  "waves": [
+    {
+      "id": "custom-manager-pilot",
+      "order": 1,
+      "repositories": [
+        "mitschreiber"
+      ],
+      "selector": null
+    },
+    {
+      "id": "volume-pilot",
+      "order": 2,
+      "repositories": [
+        "hausKI",
+        "hausKI-audio"
+      ],
+      "selector": null
+    },
+    {
+      "id": "signal-quality-pilot",
+      "order": 3,
+      "repositories": [
+        "repoground"
+      ],
+      "selector": null
+    },
+    {
+      "id": "multi-ecosystem-pilot",
+      "order": 4,
+      "repositories": [
+        "weltgewebe"
+      ],
+      "selector": null
+    },
+    {
+      "id": "control-plane-cutover",
+      "order": 5,
+      "repositories": [
+        "metarepo"
+      ],
+      "selector": null
+    },
+    {
+      "id": "fleet-expansion",
+      "order": 6,
+      "repositories": [],
+      "selector": "remaining-eligible-active-fleet"
+    }
+  ]
+}

--- a/docs/fleet/renovate-v1.md
+++ b/docs/fleet/renovate-v1.md
@@ -1,0 +1,156 @@
+# Renovate Fleet V1
+
+Stand: 2026-07-23
+
+## Zweck
+
+Renovate V1 ist ein Fleet-gebundener Dependency-Sensor und PR-Produzent. Es ist
+keine neue Control Plane. Fleet-Mitgliedschaft bleibt ausschließlich in
+`fleet/repos.yml`; die Renovate-Policy beschreibt nur operative Rollout- und
+Provider-Zustände für eine Teilmenge dieser Fleet.
+
+Renovate darf in V1:
+
+- bekannte Dependency-Manager auswerten;
+- kompatible Patch-/Minor-Updates managerweise gruppieren;
+- Update-Branches und Pull Requests erzeugen.
+
+Renovate darf in V1 nicht:
+
+- automatisch mergen;
+- Bureau-Tasks, Queue-Einträge oder Claims erzeugen;
+- Deployments oder Task-Verifikation ausführen;
+- eine eigene Fleet-Mitgliedschaft definieren;
+- GitHub-/CI- oder Grabowski-Head-/Diff-/Review-Gates ersetzen.
+
+## Kanonische Dateien
+
+- `fleet/repos.yml`: einzige normative Fleet-Mitgliedschaft.
+- `automation/renovate/dependency-updates.v1.yml`: versionierte operative
+  Rollout-Policy; keine zweite Fleet-Liste.
+- `automation/renovate/default.json`: gemeinsamer Renovate-V1-Preset.
+- `automation/renovate/expected-scope.v1.json`: deterministisch erzeugte,
+  nicht-authoritative Scope-Projektion.
+- `automation/renovate/baseline-2026-06-23_2026-07-23.json`: unveränderliche
+  Vorher-Baseline für die Pilotbewertung.
+- `scripts/fleet/renovate_policy.py`: fail-closed Validierung und Projektion.
+
+Ein Consumer kann den zentralen Preset später beispielsweise über einen
+Repo-gehosteten Preset-Pfad referenzieren. Der konkrete Consumer-Cutover ist
+bewusst nicht Teil dieses Foundation-Tasks und benötigt eigene Repo-Claims,
+Leases, Review- und Rollback-Evidenz.
+
+## Single-Producer-Vertrag
+
+Pro Repository und Dependency-Scope darf genau ein aktiver Produzent regulärer
+Version-Update-PRs existieren.
+
+Der Cutover ist daher strikt geordnet:
+
+1. Renovate-Abdeckung im Zielrepo belegen.
+2. Überlappende Dependabot-Version-Updates deaktivieren.
+3. Per Readback bestätigen, dass nur ein Version-Update-Produzent aktiv ist.
+
+`renovate_version_updates: prepared` bedeutet ausdrücklich **nicht aktiv**. Der
+Foundation-Stand markiert alle geplanten Pilot-Repositories nur als `prepared`;
+die erwartete aktive Hosted-App-Scope-Projektion ist deshalb leer.
+
+Dependabot Security Updates bleiben in V1 als separater Security-Pfad bestehen.
+Eine Version-Update-Migration behauptet nicht, Security Alerts oder
+Security-Update-Verhalten zu deaktivieren oder zu ersetzen.
+
+## Rollout-Wellen
+
+1. `mitschreiber`: bestehende Custom-Pin-Erkennung modernisieren und ohne
+   Automerge validieren.
+2. `hausKI`, `hausKI-audio`: Volumenpilot gegen die 30-Tage-Baseline.
+3. `repoground`: Signalqualität und Closed-unmerged-Verhalten untersuchen.
+4. `weltgewebe`: Multi-Ecosystem-Pilot erst nach bestandenen früheren Wellen.
+5. `metarepo`: Control-Plane-Cutover zuletzt, damit die Policy sich nicht selbst
+   freigibt.
+6. Restliche geeignete aktive Fleet-Repositories werden erst nach den Piloten
+   bewertet; sie werden nicht als zweite vollständige Liste in der Policy
+   dupliziert.
+
+Zwischen automatischer Erweiterung zweier Wellen verlangt der Vertrag
+mindestens zwei beobachtete Update-Zyklen. Die konkrete Freigabe bleibt an die
+jeweiligen Repo-, Review-, CI- und Operator-Gates gebunden.
+
+## Hosted-App-Scope
+
+Für einen Mend-hosted Renovate-Pfad verlangt V1 GitHubs Auswahlmodus
+`Select repositories`. Eine All-Repositories-Installation ist im V1-Vertrag
+nicht zulässig.
+
+`expected-scope.v1.json` enthält nur Repositories mit
+`renovate_version_updates: enabled` als erwarteten aktiven App-Scope. Ein
+beobachteter App-Scope kann mit `renovate_policy.py check --observed-app-scope`
+gegen diese Git-autorisierte Erwartung geprüft werden. Eine Abweichung ist ein
+fail-closed Driftbefund.
+
+Die Projektion beweist weder, dass eine GitHub App installiert ist, noch dass
+keine externe Installation existiert. Der tatsächliche GitHub-App-Zustand muss
+live gelesen werden.
+
+## Preset-Grenzen
+
+Der gemeinsame Preset:
+
+- erweitert `config:recommended`;
+- setzt `automerge: false`;
+- begrenzt PR-, Branch- und Stundenparallelität auf höchstens zwei;
+- hält Major-Updates getrennt;
+- gruppiert zentral nur Patch-/Minor-Updates für GitHub Actions; npm-/Cargo-Gruppen werden wegen Monorepo- und Verzeichnisgrenzen erst repo-spezifisch im jeweiligen Pilot definiert;
+- enthält keine Post-Upgrade-Command-Ausführung.
+
+Die lokale Validierung lehnt Automerge, gruppierte Major-Updates, zu hohe
+Parallelität und unbekannte Policy-Felder fail-closed ab.
+
+## Baseline und Messung
+
+Die eingefrorene Vergleichsbasis vom 23. Juni bis 23. Juli 2026 enthält 51
+Dependabot-PRs: 40 gemergt und 11 ohne Merge geschlossen. Die per Repository
+gespeicherten Zähler werden beim Policy-Check gegen die reviewte Baseline
+verifiziert.
+
+Diese Zahlen beweisen weder eine Ursache für Merge-/Close-Entscheidungen noch
+einen künftigen Vorteil von Renovate. Spätere Pilot-Auswertungen sollen unter
+anderem PR-Zahl, Merge-Rate, Closed-unmerged-Anteil, stale PRs,
+Duplicate-Producer-Vorfälle, Automerge-Vorfälle, Merge-Gate-Bypässe und echte
+Bureau-Eskalationen vergleichen.
+
+## Validierung
+
+`just renovate-policy-check` prüft:
+
+- Policy gegen die aktive Fleet aus `fleet/repos.yml`;
+- keine archivierten oder `fleet: false` Repositories;
+- keine Repo-Duplikate über Wellen;
+- keine zwei gleichzeitig aktiven Version-Update-Produzenten;
+- keinen vollständigen zweiten Fleet-Abzug in der Rollout-Policy;
+- zentrale Preset-Sicherheitsgrenzen;
+- unveränderte Baseline;
+- bytegenaue Reproduzierbarkeit der Scope-Projektion.
+
+`just renovate-policy` regeneriert ausschließlich die deterministische
+Scope-Projektion. `just validate` führt den Check automatisch aus.
+
+## Rollback
+
+Dieser Foundation-Slice verändert keine Consumer-Dependabot-Konfiguration und
+keine GitHub-App-Berechtigung. Er ist daher durch Revert des Metarepo-Commits
+rückrollbar.
+
+Jeder spätere Consumer-Cutover braucht zusätzlich einen eigenen Rollback:
+Renovate für das betroffene Repository stoppen, den vorherigen reviewten
+Dependabot-Version-Update-Stand wiederherstellen und anschließend live prüfen,
+dass wieder exakt ein Version-Update-Produzent aktiv ist.
+
+Bureau-, Chronik- und Git-Historie werden dabei nicht umgeschrieben.
+
+## Bekannte Folgegrenze
+
+`repo.mitschreiber` ist zum Stand dieser Entscheidung nicht als Bureau-
+Repository-Resource registriert. T046 erfindet deshalb keinen Claim. Die
+Resource-Katalog-Erweiterung und der Mitschreiber-Cutover müssen über den
+operator-native Bureau-Intake als getrennte Folgearbeit registriert werden.

--- a/scripts/fleet/renovate_policy.py
+++ b/scripts/fleet/renovate_policy.py
@@ -1,0 +1,625 @@
+#!/usr/bin/env python3
+"""Validate and project the Fleet-bound Renovate V1 rollout policy.
+
+The policy is operational metadata only. Fleet membership remains authoritative
+in fleet/repos.yml. This tool deliberately produces a bounded Renovate scope
+projection instead of a second complete Fleet registry.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+import sys
+from typing import Any
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_FLEET = ROOT / "fleet" / "repos.yml"
+DEFAULT_POLICY = ROOT / "automation" / "renovate" / "dependency-updates.v1.yml"
+DEFAULT_PRESET = ROOT / "automation" / "renovate" / "default.json"
+DEFAULT_BASELINE = ROOT / "automation" / "renovate" / "baseline-2026-06-23_2026-07-23.json"
+DEFAULT_SCOPE = ROOT / "automation" / "renovate" / "expected-scope.v1.json"
+
+EXPECTED_BASELINE_WINDOW = {"start": "2026-06-23", "end": "2026-07-23"}
+EXPECTED_BASELINE_TOTALS = {"total": 51, "merged": 40, "closed_unmerged": 11, "open": 0}
+EXPECTED_BASELINE_REPOSITORIES = {
+    "hausKI": {"total": 11, "merged": 10, "closed_unmerged": 1, "open": 0},
+    "hausKI-audio": {"total": 10, "merged": 9, "closed_unmerged": 1, "open": 0},
+    "metarepo": {"total": 5, "merged": 3, "closed_unmerged": 2, "open": 0},
+    "repoground": {"total": 6, "merged": 1, "closed_unmerged": 5, "open": 0},
+    "weltgewebe": {"total": 19, "merged": 17, "closed_unmerged": 2, "open": 0},
+}
+EXPECTED_CUTOVER_SEQUENCE = [
+    "prove-renovate-coverage",
+    "disable-overlapping-dependabot-version-updates",
+    "verify-single-version-update-producer",
+]
+DEPENDABOT_STATES = {"enabled", "disabled", "none"}
+RENOVATE_STATES = {"enabled", "prepared", "disabled"}
+ALLOWED_SELECTOR = "remaining-eligible-active-fleet"
+
+
+class PolicyError(ValueError):
+    """Raised when Fleet-bound Renovate policy data is unsafe or inconsistent."""
+
+
+class UniqueKeyLoader(yaml.SafeLoader):
+    """YAML loader that rejects duplicate mapping keys."""
+
+
+def _construct_unique_mapping(
+    loader: UniqueKeyLoader,
+    node: yaml.nodes.MappingNode,
+    deep: bool = False,
+) -> dict[Any, Any]:
+    loader.flatten_mapping(node)
+    mapping: dict[Any, Any] = {}
+    for key_node, value_node in node.value:
+        key = loader.construct_object(key_node, deep=deep)
+        try:
+            duplicate = key in mapping
+        except TypeError as exc:
+            raise yaml.constructor.ConstructorError(
+                "while constructing a mapping",
+                node.start_mark,
+                "found an unhashable mapping key",
+                key_node.start_mark,
+            ) from exc
+        if duplicate:
+            raise yaml.constructor.ConstructorError(
+                "while constructing a mapping",
+                node.start_mark,
+                f"found duplicate key {key!r}",
+                key_node.start_mark,
+            )
+        mapping[key] = loader.construct_object(value_node, deep=deep)
+    return mapping
+
+
+UniqueKeyLoader.add_constructor(
+    yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
+    _construct_unique_mapping,
+)
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _load_yaml(path: Path, *, label: str) -> dict[str, Any]:
+    try:
+        value = yaml.load(path.read_text(encoding="utf-8"), Loader=UniqueKeyLoader)
+    except FileNotFoundError as exc:
+        raise PolicyError(f"{label} not found: {path}") from exc
+    except yaml.YAMLError as exc:
+        raise PolicyError(f"{label} is not valid unique-key YAML: {exc}") from exc
+    if not isinstance(value, dict):
+        raise PolicyError(f"{label} must have a mapping root")
+    return value
+
+
+def _load_json(path: Path, *, label: str) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise PolicyError(f"{label} not found: {path}") from exc
+    except json.JSONDecodeError as exc:
+        raise PolicyError(f"{label} is not valid JSON: {exc}") from exc
+    if not isinstance(value, dict):
+        raise PolicyError(f"{label} must have an object root")
+    return value
+
+
+def _exact_keys(
+    value: dict[str, Any],
+    *,
+    allowed: set[str],
+    required: set[str],
+    label: str,
+) -> None:
+    unknown = sorted(set(value) - allowed)
+    missing = sorted(required - set(value))
+    if unknown:
+        raise PolicyError(f"{label} contains unsupported fields: {', '.join(unknown)}")
+    if missing:
+        raise PolicyError(f"{label} is missing required fields: {', '.join(missing)}")
+
+
+def _entry_name(entry: Any, *, label: str) -> str:
+    if isinstance(entry, str) and entry.strip():
+        return entry.strip()
+    if isinstance(entry, dict):
+        name = entry.get("name")
+        if isinstance(name, str) and name.strip():
+            return name.strip()
+    raise PolicyError(f"{label} must contain a non-empty repository name")
+
+
+def active_fleet_repositories(fleet: dict[str, Any]) -> set[str]:
+    repos = fleet.get("repos")
+    if not isinstance(repos, list):
+        raise PolicyError("fleet/repos.yml must contain a repos list")
+    static = fleet.get("static", {}) or {}
+    if not isinstance(static, dict):
+        raise PolicyError("fleet/repos.yml static must be a mapping")
+    include = static.get("include", []) or []
+    if not isinstance(include, list):
+        raise PolicyError("fleet/repos.yml static.include must be a list")
+
+    active: set[str] = set()
+    seen: set[str] = set()
+    for label, entries in (("repos", repos), ("static.include", include)):
+        for index, entry in enumerate(entries):
+            name = _entry_name(entry, label=f"{label}[{index}]")
+            if name in seen:
+                raise PolicyError(f"repository occurs more than once in Fleet scope: {name}")
+            seen.add(name)
+            if isinstance(entry, dict):
+                fleet_flag = entry.get("fleet", True)
+                if not isinstance(fleet_flag, bool):
+                    raise PolicyError(f"{label}[{index}].fleet must be boolean")
+                status = entry.get("status")
+                if status is not None and (not isinstance(status, str) or not status.strip()):
+                    raise PolicyError(f"{label}[{index}].status must be a non-empty string")
+                if fleet_flag is False or status == "archived-reference":
+                    continue
+            active.add(name)
+    if not active:
+        raise PolicyError("Fleet contains no active projectable repositories")
+    return active
+
+
+def validate_preset(preset: dict[str, Any]) -> None:
+    _exact_keys(
+        preset,
+        allowed={
+            "$schema",
+            "description",
+            "extends",
+            "automerge",
+            "dependencyDashboard",
+            "prConcurrentLimit",
+            "branchConcurrentLimit",
+            "prHourlyLimit",
+            "separateMajorMinor",
+            "labels",
+            "packageRules",
+        },
+        required={
+            "$schema",
+            "extends",
+            "automerge",
+            "prConcurrentLimit",
+            "branchConcurrentLimit",
+            "prHourlyLimit",
+            "separateMajorMinor",
+            "packageRules",
+        },
+        label="Renovate preset",
+    )
+    extends = preset["extends"]
+    if not isinstance(extends, list) or "config:recommended" not in extends:
+        raise PolicyError("Renovate preset must extend config:recommended")
+    if preset["automerge"] is not False:
+        raise PolicyError("Renovate preset must set automerge=false")
+    if preset["separateMajorMinor"] is not True:
+        raise PolicyError("Renovate preset must keep major updates separate")
+    for field in ("prConcurrentLimit", "branchConcurrentLimit", "prHourlyLimit"):
+        value = preset[field]
+        if not isinstance(value, int) or isinstance(value, bool) or value < 1 or value > 2:
+            raise PolicyError(f"Renovate preset {field} must be an integer between 1 and 2")
+
+    rules = preset["packageRules"]
+    if not isinstance(rules, list) or not rules:
+        raise PolicyError("Renovate preset packageRules must be a non-empty list")
+    for index, rule in enumerate(rules):
+        if not isinstance(rule, dict):
+            raise PolicyError(f"packageRules[{index}] must be an object")
+        _exact_keys(
+            rule,
+            allowed={"description", "matchManagers", "matchUpdateTypes", "groupName"},
+            required={"matchManagers", "matchUpdateTypes", "groupName"},
+            label=f"packageRules[{index}]",
+        )
+        managers = rule["matchManagers"]
+        update_types = rule["matchUpdateTypes"]
+        group_name = rule["groupName"]
+        if not isinstance(managers, list) or not managers or not all(
+            isinstance(item, str) and item.strip() for item in managers
+        ):
+            raise PolicyError(f"packageRules[{index}].matchManagers must be non-empty strings")
+        if not isinstance(update_types, list) or not update_types:
+            raise PolicyError(f"packageRules[{index}].matchUpdateTypes must be non-empty")
+        if set(update_types) - {"minor", "patch"}:
+            raise PolicyError(
+                f"packageRules[{index}] groups unsupported update types; major updates must remain isolated"
+            )
+        if not isinstance(group_name, str) or not group_name.strip():
+            raise PolicyError(f"packageRules[{index}].groupName must be non-empty")
+
+
+def validate_baseline(baseline: dict[str, Any]) -> None:
+    _exact_keys(
+        baseline,
+        allowed={"schema_version", "kind", "window", "source", "repositories", "totals", "nonclaims"},
+        required={"schema_version", "kind", "window", "source", "repositories", "totals", "nonclaims"},
+        label="Dependabot baseline",
+    )
+    if baseline["schema_version"] != 1 or baseline["kind"] != "dependabot-pr-baseline":
+        raise PolicyError("Dependabot baseline identity is unsupported")
+    if baseline["window"] != EXPECTED_BASELINE_WINDOW:
+        raise PolicyError("Dependabot baseline window must remain the reviewed 2026-06-23..2026-07-23 window")
+    if baseline["totals"] != EXPECTED_BASELINE_TOTALS:
+        raise PolicyError("Dependabot baseline totals differ from reviewed evidence")
+    if baseline["repositories"] != EXPECTED_BASELINE_REPOSITORIES:
+        raise PolicyError("Dependabot per-repository baseline differs from reviewed evidence")
+    calculated = {key: 0 for key in EXPECTED_BASELINE_TOTALS}
+    for values in baseline["repositories"].values():
+        if not isinstance(values, dict):
+            raise PolicyError("Dependabot repository baseline entries must be objects")
+        for key in calculated:
+            value = values.get(key)
+            if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+                raise PolicyError(f"Dependabot repository baseline {key} must be a non-negative integer")
+            calculated[key] += value
+    if calculated != baseline["totals"]:
+        raise PolicyError("Dependabot baseline totals do not equal per-repository sums")
+
+
+def validate_policy(policy: dict[str, Any], *, active_fleet: set[str]) -> list[dict[str, Any]]:
+    _exact_keys(
+        policy,
+        allowed={
+            "schema_version",
+            "kind",
+            "fleet_source",
+            "github_owner",
+            "security_updates",
+            "version_update_defaults",
+            "cutover_sequence",
+            "rollout",
+        },
+        required={
+            "schema_version",
+            "kind",
+            "fleet_source",
+            "github_owner",
+            "security_updates",
+            "version_update_defaults",
+            "cutover_sequence",
+            "rollout",
+        },
+        label="Renovate Fleet policy",
+    )
+    if policy["schema_version"] != 1 or policy["kind"] != "renovate-fleet-policy":
+        raise PolicyError("Renovate Fleet policy identity is unsupported")
+    if policy["fleet_source"] != "fleet/repos.yml":
+        raise PolicyError("Renovate Fleet policy must bind membership to fleet/repos.yml")
+    owner = policy["github_owner"]
+    if not isinstance(owner, str) or not owner.strip():
+        raise PolicyError("github_owner must be a non-empty string")
+
+    security = policy["security_updates"]
+    if not isinstance(security, dict):
+        raise PolicyError("security_updates must be a mapping")
+    _exact_keys(
+        security,
+        allowed={"provider", "version_update_cutover_changes_security_updates"},
+        required={"provider", "version_update_cutover_changes_security_updates"},
+        label="security_updates",
+    )
+    if security["provider"] != "dependabot":
+        raise PolicyError("Renovate V1 keeps Dependabot as the declared security-update provider")
+    if security["version_update_cutover_changes_security_updates"] is not False:
+        raise PolicyError("version-update cutover may not claim to change the security-update path")
+
+    defaults = policy["version_update_defaults"]
+    if not isinstance(defaults, dict):
+        raise PolicyError("version_update_defaults must be a mapping")
+    _exact_keys(
+        defaults,
+        allowed={
+            "provider",
+            "automerge",
+            "duplicate_producer_policy",
+            "hosted_app_repository_selection",
+            "all_repositories_allowed",
+            "minimum_observed_cycles_before_expansion",
+        },
+        required={
+            "provider",
+            "automerge",
+            "duplicate_producer_policy",
+            "hosted_app_repository_selection",
+            "all_repositories_allowed",
+            "minimum_observed_cycles_before_expansion",
+        },
+        label="version_update_defaults",
+    )
+    expected_defaults = {
+        "provider": "renovate",
+        "automerge": False,
+        "duplicate_producer_policy": "fail-closed",
+        "hosted_app_repository_selection": "selected",
+        "all_repositories_allowed": False,
+        "minimum_observed_cycles_before_expansion": 2,
+    }
+    if defaults != expected_defaults:
+        raise PolicyError("version_update_defaults do not match the reviewed Renovate V1 safety contract")
+    if policy["cutover_sequence"] != EXPECTED_CUTOVER_SEQUENCE:
+        raise PolicyError("cutover_sequence must prove coverage, disable overlap, then verify one producer")
+
+    rollout = policy["rollout"]
+    if not isinstance(rollout, dict):
+        raise PolicyError("rollout must be a mapping")
+    _exact_keys(rollout, allowed={"waves"}, required={"waves"}, label="rollout")
+    waves = rollout["waves"]
+    if not isinstance(waves, list) or not waves:
+        raise PolicyError("rollout.waves must be a non-empty list")
+
+    seen_ids: set[str] = set()
+    seen_orders: set[int] = set()
+    seen_repositories: set[str] = set()
+    normalized: list[dict[str, Any]] = []
+    selector_count = 0
+    for index, wave in enumerate(waves):
+        if not isinstance(wave, dict):
+            raise PolicyError(f"rollout.waves[{index}] must be a mapping")
+        _exact_keys(
+            wave,
+            allowed={"id", "order", "purpose", "repositories", "selector"},
+            required={"id", "order", "purpose", "repositories"},
+            label=f"rollout.waves[{index}]",
+        )
+        wave_id = wave["id"]
+        order = wave["order"]
+        purpose = wave["purpose"]
+        if not isinstance(wave_id, str) or not wave_id.strip() or wave_id in seen_ids:
+            raise PolicyError(f"rollout.waves[{index}].id must be unique and non-empty")
+        if not isinstance(order, int) or isinstance(order, bool) or order < 1 or order in seen_orders:
+            raise PolicyError(f"rollout.waves[{index}].order must be a unique positive integer")
+        if not isinstance(purpose, str) or not purpose.strip():
+            raise PolicyError(f"rollout.waves[{index}].purpose must be non-empty")
+        seen_ids.add(wave_id)
+        seen_orders.add(order)
+
+        selector = wave.get("selector")
+        repositories = wave["repositories"]
+        if not isinstance(repositories, list):
+            raise PolicyError(f"rollout.waves[{index}].repositories must be a list")
+        if selector is not None:
+            selector_count += 1
+            if selector != ALLOWED_SELECTOR:
+                raise PolicyError(f"rollout.waves[{index}].selector is unsupported")
+            if repositories:
+                raise PolicyError("selector-based Fleet expansion may not duplicate an explicit repository list")
+        entries: list[dict[str, str]] = []
+        for repo_index, repo in enumerate(repositories):
+            if not isinstance(repo, dict):
+                raise PolicyError(f"rollout.waves[{index}].repositories[{repo_index}] must be a mapping")
+            _exact_keys(
+                repo,
+                allowed={"name", "dependabot_version_updates", "renovate_version_updates"},
+                required={"name", "dependabot_version_updates", "renovate_version_updates"},
+                label=f"rollout.waves[{index}].repositories[{repo_index}]",
+            )
+            name = repo["name"]
+            dependabot = repo["dependabot_version_updates"]
+            renovate = repo["renovate_version_updates"]
+            if not isinstance(name, str) or not name.strip():
+                raise PolicyError("rollout repository name must be non-empty")
+            name = name.strip()
+            if name not in active_fleet:
+                raise PolicyError(f"Renovate rollout repository is not active Fleet scope: {name}")
+            if name in seen_repositories:
+                raise PolicyError(f"Renovate rollout repository occurs in more than one wave: {name}")
+            if dependabot not in DEPENDABOT_STATES:
+                raise PolicyError(f"unsupported Dependabot version-update state for {name}: {dependabot}")
+            if renovate not in RENOVATE_STATES:
+                raise PolicyError(f"unsupported Renovate version-update state for {name}: {renovate}")
+            if dependabot == "enabled" and renovate == "enabled":
+                raise PolicyError(f"duplicate active version-update producers for {name}")
+            seen_repositories.add(name)
+            entries.append(
+                {
+                    "name": name,
+                    "dependabot_version_updates": dependabot,
+                    "renovate_version_updates": renovate,
+                }
+            )
+        normalized.append(
+            {
+                "id": wave_id,
+                "order": order,
+                "purpose": purpose.strip(),
+                "selector": selector,
+                "repositories": entries,
+            }
+        )
+
+    if selector_count != 1:
+        raise PolicyError("Renovate V1 must have exactly one deferred remaining-Fleet selector")
+    if seen_repositories == active_fleet:
+        raise PolicyError("Renovate policy may not duplicate the complete active Fleet membership list")
+    return sorted(normalized, key=lambda item: item["order"])
+
+
+def build_scope_projection(
+    *,
+    policy: dict[str, Any],
+    waves: list[dict[str, Any]],
+    fleet_path: Path,
+    policy_path: Path,
+) -> dict[str, Any]:
+    owner = policy["github_owner"].strip()
+    prepared: list[str] = []
+    enabled: list[str] = []
+    ownership: list[dict[str, Any]] = []
+    projected_waves: list[dict[str, Any]] = []
+    selectors: list[str] = []
+    for wave in waves:
+        repo_names: list[str] = []
+        if wave["selector"] is not None:
+            selectors.append(wave["selector"])
+        for repo in wave["repositories"]:
+            name = repo["name"]
+            repo_names.append(name)
+            renovate_state = repo["renovate_version_updates"]
+            if renovate_state == "prepared":
+                prepared.append(f"{owner}/{name}")
+            elif renovate_state == "enabled":
+                enabled.append(f"{owner}/{name}")
+            ownership.append(
+                {
+                    "repository": f"{owner}/{name}",
+                    "dependabot_version_updates": repo["dependabot_version_updates"],
+                    "renovate_version_updates": renovate_state,
+                }
+            )
+        projected_waves.append(
+            {
+                "id": wave["id"],
+                "order": wave["order"],
+                "repositories": repo_names,
+                "selector": wave["selector"],
+            }
+        )
+    return {
+        "schema_version": 1,
+        "kind": "renovate-fleet-scope-projection",
+        "sources": {
+            "fleet": {"path": "fleet/repos.yml", "sha256": _sha256(fleet_path)},
+            "policy": {
+                "path": "automation/renovate/dependency-updates.v1.yml",
+                "sha256": _sha256(policy_path),
+            },
+        },
+        "expected_hosted_app_repositories": sorted(enabled),
+        "prepared_repositories": sorted(prepared),
+        "version_update_ownership": sorted(ownership, key=lambda item: item["repository"]),
+        "waves": projected_waves,
+        "deferred_selectors": selectors,
+        "nonclaims": [
+            "This projection is not Fleet membership truth.",
+            "Prepared repositories are not proof that the Renovate GitHub App is installed or active.",
+            "An empty expected hosted-app scope is not proof that no external app installation exists.",
+            "This projection grants no merge, queue, claim, deployment or task-verification authority.",
+        ],
+    }
+
+
+def render_projection(projection: dict[str, Any]) -> str:
+    return json.dumps(projection, indent=2, sort_keys=True, ensure_ascii=False) + "\n"
+
+
+def compare_observed_app_scope(projection: dict[str, Any], observed: Any) -> None:
+    if isinstance(observed, dict):
+        _exact_keys(observed, allowed={"repositories"}, required={"repositories"}, label="observed app scope")
+        observed = observed["repositories"]
+    if not isinstance(observed, list) or not all(isinstance(item, str) and item.strip() for item in observed):
+        raise PolicyError("observed app scope must be a list of repository names")
+    normalized = sorted(item.strip() for item in observed)
+    if len(normalized) != len(set(normalized)):
+        raise PolicyError("observed app scope contains duplicate repositories")
+    expected = projection["expected_hosted_app_repositories"]
+    if normalized != expected:
+        raise PolicyError(
+            "observed hosted Renovate app scope differs from Git-authored expected scope: "
+            f"expected={expected} observed={normalized}"
+        )
+
+
+def validate_all(
+    *,
+    fleet_path: Path = DEFAULT_FLEET,
+    policy_path: Path = DEFAULT_POLICY,
+    preset_path: Path = DEFAULT_PRESET,
+    baseline_path: Path = DEFAULT_BASELINE,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    fleet = _load_yaml(fleet_path, label="Fleet membership")
+    policy = _load_yaml(policy_path, label="Renovate Fleet policy")
+    preset = _load_json(preset_path, label="Renovate shared preset")
+    baseline = _load_json(baseline_path, label="Dependabot baseline")
+    active = active_fleet_repositories(fleet)
+    waves = validate_policy(policy, active_fleet=active)
+    validate_preset(preset)
+    validate_baseline(baseline)
+    projection = build_scope_projection(
+        policy=policy,
+        waves=waves,
+        fleet_path=fleet_path,
+        policy_path=policy_path,
+    )
+    return projection, {
+        "active_fleet_count": len(active),
+        "explicit_rollout_count": sum(len(w["repositories"]) for w in waves),
+    }
+
+
+def _read_observed_scope(path: Path) -> Any:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise PolicyError(f"observed app scope not found: {path}") from exc
+    except json.JSONDecodeError as exc:
+        raise PolicyError(f"observed app scope is not valid JSON: {exc}") from exc
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+    generate = sub.add_parser("generate", help="write the deterministic Renovate scope projection")
+    generate.add_argument("--output", type=Path, default=DEFAULT_SCOPE)
+    check = sub.add_parser(
+        "check", help="validate policy/preset/baseline and committed scope projection"
+    )
+    check.add_argument("--scope", type=Path, default=DEFAULT_SCOPE)
+    check.add_argument("--observed-app-scope", type=Path)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    projection, summary = validate_all()
+    expected = render_projection(projection)
+    if args.command == "generate":
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(expected, encoding="utf-8")
+        print(f"wrote Renovate scope projection: {args.output}")
+        return 0
+
+    try:
+        current = args.scope.read_text(encoding="utf-8")
+    except FileNotFoundError as exc:
+        raise PolicyError(f"Renovate scope projection missing: {args.scope}") from exc
+    if current != expected:
+        raise PolicyError("Renovate scope projection is stale; run renovate_policy.py generate")
+    if args.observed_app_scope is not None:
+        compare_observed_app_scope(projection, _read_observed_scope(args.observed_app_scope))
+    print(
+        json.dumps(
+            {
+                "status": "ok",
+                "active_fleet_count": summary["active_fleet_count"],
+                "explicit_rollout_count": summary["explicit_rollout_count"],
+                "expected_hosted_app_repositories": projection[
+                    "expected_hosted_app_repositories"
+                ],
+            },
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except PolicyError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        raise SystemExit(2) from exc

--- a/tests/test_renovate_policy.py
+++ b/tests/test_renovate_policy.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import copy
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MODULE_PATH = ROOT / "scripts" / "fleet" / "renovate_policy.py"
+SPEC = importlib.util.spec_from_file_location("renovate_policy", MODULE_PATH)
+assert SPEC is not None and SPEC.loader is not None
+renovate_policy = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(renovate_policy)
+
+
+def _inputs():
+    fleet = renovate_policy._load_yaml(ROOT / "fleet/repos.yml", label="fleet")
+    policy = renovate_policy._load_yaml(
+        ROOT / "automation/renovate/dependency-updates.v1.yml", label="policy"
+    )
+    preset = renovate_policy._load_json(
+        ROOT / "automation/renovate/default.json", label="preset"
+    )
+    return fleet, policy, preset
+
+
+def test_current_policy_preset_baseline_and_projection_are_valid() -> None:
+    projection, summary = renovate_policy.validate_all()
+    assert summary == {"active_fleet_count": 18, "explicit_rollout_count": 6}
+    assert projection["expected_hosted_app_repositories"] == []
+    assert projection["prepared_repositories"] == [
+        "heimgewebe/hausKI",
+        "heimgewebe/hausKI-audio",
+        "heimgewebe/metarepo",
+        "heimgewebe/mitschreiber",
+        "heimgewebe/repoground",
+        "heimgewebe/weltgewebe",
+    ]
+    committed = json.loads(
+        (ROOT / "automation/renovate/expected-scope.v1.json").read_text(encoding="utf-8")
+    )
+    assert committed == projection
+
+
+def test_archived_or_non_fleet_repository_is_rejected() -> None:
+    fleet, policy, _ = _inputs()
+    mutated = copy.deepcopy(policy)
+    mutated["rollout"]["waves"][0]["repositories"][0]["name"] = "heimlern"
+    with pytest.raises(renovate_policy.PolicyError, match="not active Fleet scope"):
+        renovate_policy.validate_policy(
+            mutated,
+            active_fleet=renovate_policy.active_fleet_repositories(fleet),
+        )
+
+
+def test_repository_cannot_appear_in_multiple_waves() -> None:
+    fleet, policy, _ = _inputs()
+    mutated = copy.deepcopy(policy)
+    mutated["rollout"]["waves"][1]["repositories"].append(
+        {
+            "name": "mitschreiber",
+            "dependabot_version_updates": "none",
+            "renovate_version_updates": "prepared",
+        }
+    )
+    with pytest.raises(renovate_policy.PolicyError, match="more than one wave"):
+        renovate_policy.validate_policy(
+            mutated,
+            active_fleet=renovate_policy.active_fleet_repositories(fleet),
+        )
+
+
+def test_two_active_version_update_producers_fail_closed() -> None:
+    fleet, policy, _ = _inputs()
+    mutated = copy.deepcopy(policy)
+    repo = mutated["rollout"]["waves"][1]["repositories"][0]
+    repo["dependabot_version_updates"] = "enabled"
+    repo["renovate_version_updates"] = "enabled"
+    with pytest.raises(renovate_policy.PolicyError, match="duplicate active"):
+        renovate_policy.validate_policy(
+            mutated,
+            active_fleet=renovate_policy.active_fleet_repositories(fleet),
+        )
+
+
+def test_shared_preset_groups_only_github_actions_non_major_updates() -> None:
+    _, _, preset = _inputs()
+    assert [rule["matchManagers"] for rule in preset["packageRules"]] == [["github-actions"]]
+    assert preset["packageRules"][0]["matchUpdateTypes"] == ["minor", "patch"]
+
+
+def test_preset_cannot_enable_automerge() -> None:
+    _, _, preset = _inputs()
+    mutated = copy.deepcopy(preset)
+    mutated["automerge"] = True
+    with pytest.raises(renovate_policy.PolicyError, match="automerge=false"):
+        renovate_policy.validate_preset(mutated)
+
+
+def test_major_updates_cannot_be_added_to_grouped_rule() -> None:
+    _, _, preset = _inputs()
+    mutated = copy.deepcopy(preset)
+    mutated["packageRules"][0]["matchUpdateTypes"].append("major")
+    with pytest.raises(renovate_policy.PolicyError, match="major updates must remain isolated"):
+        renovate_policy.validate_preset(mutated)
+
+
+def test_observed_hosted_app_scope_must_match_enabled_policy_scope() -> None:
+    projection, _ = renovate_policy.validate_all()
+    renovate_policy.compare_observed_app_scope(projection, [])
+    with pytest.raises(renovate_policy.PolicyError, match="differs"):
+        renovate_policy.compare_observed_app_scope(
+            projection,
+            ["heimgewebe/mitschreiber"],
+        )
+
+
+def test_complete_fleet_copy_is_rejected_as_second_membership_list() -> None:
+    fleet, policy, _ = _inputs()
+    active = renovate_policy.active_fleet_repositories(fleet)
+    mutated = copy.deepcopy(policy)
+    explicit = {
+        entry["name"]
+        for wave in mutated["rollout"]["waves"]
+        for entry in wave["repositories"]
+    }
+    mutated["rollout"]["waves"][0]["repositories"].extend(
+        {
+            "name": name,
+            "dependabot_version_updates": "none",
+            "renovate_version_updates": "disabled",
+        }
+        for name in sorted(active - explicit)
+    )
+    with pytest.raises(renovate_policy.PolicyError, match="complete active Fleet"):
+        renovate_policy.validate_policy(mutated, active_fleet=active)


### PR DESCRIPTION
Bureau-Task: OPERATOR-ECOSYSTEM-REDUNDANCY-V1-T046

## Scope

Establish the Metarepo-only Renovate V1 foundation: central no-automerge preset, Fleet-bound rollout policy, deterministic expected-scope projection, single-version-update-producer guards, immutable 2026-06-23..2026-07-23 Dependabot baseline, validation tooling, tests and documentation.

This PR does not install the Renovate GitHub App, change consumer Dependabot configuration, enable Renovate in any repository, mutate Bureau queue/claims, or grant merge/deploy authority.

## Validation

- `uv run pytest -q tests/test_renovate_policy.py`: 9 passed
- `uv run ruff check scripts/fleet/renovate_policy.py tests/test_renovate_policy.py`: PASS
- `just validate`: PASS, 152 Python tests plus Fleet/YAML/shell/actionlint gates

## Review finding fixed before publication

The first central preset grouped npm and Cargo non-major updates globally. Review identified that this could couple independent monorepo directories. The final preset groups only GitHub Actions centrally; npm/Cargo grouping is deferred to repository-specific pilot policy.

## Follow-ups

Operator-native Bureau candidates were recorded for the missing `repo.mitschreiber` resource-catalog entry and the subsequent Mitschreiber custom-manager pilot. Neither is claimed complete by this PR.
