### PR TITLE
feat(deps): cut fleet over to self-hosted Renovate

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 0
     commit-message:
       prefix: "deps(actions)"
       include: "scope"

--- a/.github/grabowski-required-checks.json
+++ b/.github/grabowski-required-checks.json
@@ -1,0 +1,7 @@
+{
+  "schema_version": 1,
+  "required_checks": [
+    "ci (ubuntu-latest)",
+    "ci (macos-latest)"
+  ]
+}

--- a/automation/renovate/dependency-updates.v1.yml
+++ b/automation/renovate/dependency-updates.v1.yml
@@ -12,9 +12,10 @@ version_update_defaults:
   provider: renovate
   automerge: false
   duplicate_producer_policy: fail-closed
-  hosted_app_repository_selection: selected
+  runtime_mode: self-hosted-heim-pc
+  credential_source: gh-auth-token-transient
+  scope_selector: active-fleet
   all_repositories_allowed: false
-  minimum_observed_cycles_before_expansion: 2
 
 cutover_sequence:
   - prove-renovate-coverage
@@ -23,51 +24,31 @@ cutover_sequence:
 
 rollout:
   waves:
-    - id: custom-manager-pilot
+    - id: direct-cutover
       order: 1
-      purpose: Modernize and validate the existing Mitschreiber custom pin manager before standard package-manager rollout.
+      purpose: Cut all known Dependabot version-update repositories directly to Renovate while preserving Dependabot Security Updates and existing merge gates.
       repositories:
         - name: mitschreiber
           dependabot_version_updates: none
-          renovate_version_updates: prepared
-
-    - id: volume-pilot
-      order: 2
-      purpose: Measure PR-volume and convergence changes on repositories with recent high Dependabot activity.
-      repositories:
+          renovate_version_updates: enabled
         - name: hausKI
-          dependabot_version_updates: enabled
-          renovate_version_updates: prepared
+          dependabot_version_updates: disabled
+          renovate_version_updates: enabled
         - name: hausKI-audio
-          dependabot_version_updates: enabled
-          renovate_version_updates: prepared
-
-    - id: signal-quality-pilot
-      order: 3
-      purpose: Measure whether grouped Renovate updates improve the unusually low recent merge ratio without assuming the bot caused it.
-      repositories:
+          dependabot_version_updates: disabled
+          renovate_version_updates: enabled
         - name: repoground
-          dependabot_version_updates: enabled
-          renovate_version_updates: prepared
-
-    - id: multi-ecosystem-pilot
-      order: 4
-      purpose: Prove the bounded model on the complex npm, Cargo and GitHub Actions update surface after earlier waves pass.
-      repositories:
+          dependabot_version_updates: disabled
+          renovate_version_updates: enabled
         - name: weltgewebe
-          dependabot_version_updates: enabled
-          renovate_version_updates: prepared
-
-    - id: control-plane-cutover
-      order: 5
-      purpose: Migrate Metarepo only after the consumer pilots prove the shared policy and prevent a self-approval loop.
-      repositories:
+          dependabot_version_updates: disabled
+          renovate_version_updates: enabled
         - name: metarepo
-          dependabot_version_updates: enabled
-          renovate_version_updates: prepared
+          dependabot_version_updates: disabled
+          renovate_version_updates: enabled
 
-    - id: fleet-expansion
-      order: 6
-      purpose: Evaluate remaining eligible active Fleet repositories after all bounded pilots pass their acceptance gates.
+    - id: active-fleet
+      order: 2
+      purpose: Manage every remaining active Fleet repository through the same central Renovate runtime without duplicating Fleet membership in this policy.
       selector: remaining-eligible-active-fleet
       repositories: []

--- a/automation/renovate/expected-scope.v1.json
+++ b/automation/renovate/expected-scope.v1.json
@@ -1,23 +1,38 @@
 {
+  "credential_source": "gh-auth-token-transient",
   "deferred_selectors": [
     "remaining-eligible-active-fleet"
   ],
   "expected_hosted_app_repositories": [],
+  "expected_renovate_repositories": [
+    "heimgewebe/aussensensor",
+    "heimgewebe/chronik",
+    "heimgewebe/contracts-mirror",
+    "heimgewebe/hausKI",
+    "heimgewebe/hausKI-audio",
+    "heimgewebe/heim-pc",
+    "heimgewebe/heimgeist",
+    "heimgewebe/konvergenzregelkreis",
+    "heimgewebe/leitstand",
+    "heimgewebe/metarepo",
+    "heimgewebe/mitschreiber",
+    "heimgewebe/plexer",
+    "heimgewebe/repoground",
+    "heimgewebe/semantAH",
+    "heimgewebe/sichter",
+    "heimgewebe/vault-gewebe",
+    "heimgewebe/weltgewebe",
+    "heimgewebe/wgx"
+  ],
   "kind": "renovate-fleet-scope-projection",
   "nonclaims": [
     "This projection is not Fleet membership truth.",
-    "Prepared repositories are not proof that the Renovate GitHub App is installed or active.",
+    "The self-hosted runtime target list is derived from fleet/repos.yml and this policy.",
     "An empty expected hosted-app scope is not proof that no external app installation exists.",
     "This projection grants no merge, queue, claim, deployment or task-verification authority."
   ],
-  "prepared_repositories": [
-    "heimgewebe/hausKI",
-    "heimgewebe/hausKI-audio",
-    "heimgewebe/metarepo",
-    "heimgewebe/mitschreiber",
-    "heimgewebe/repoground",
-    "heimgewebe/weltgewebe"
-  ],
+  "prepared_repositories": [],
+  "runtime_mode": "self-hosted-heim-pc",
   "schema_version": 1,
   "sources": {
     "fleet": {
@@ -26,87 +41,132 @@
     },
     "policy": {
       "path": "automation/renovate/dependency-updates.v1.yml",
-      "sha256": "5b41a2b5eca3778688b5129a719e1af4d7d3d8dbf7abd9de53ac4454a48fb80a"
+      "sha256": "0934e2b7131c8712296892cd15cdae25ca6e424e6baad3799971481f84a40a3b"
     }
   },
   "version_update_ownership": [
     {
-      "dependabot_version_updates": "enabled",
-      "renovate_version_updates": "prepared",
+      "dependabot_version_updates": "none",
+      "renovate_version_updates": "enabled",
+      "repository": "heimgewebe/aussensensor"
+    },
+    {
+      "dependabot_version_updates": "none",
+      "renovate_version_updates": "enabled",
+      "repository": "heimgewebe/chronik"
+    },
+    {
+      "dependabot_version_updates": "none",
+      "renovate_version_updates": "enabled",
+      "repository": "heimgewebe/contracts-mirror"
+    },
+    {
+      "dependabot_version_updates": "disabled",
+      "renovate_version_updates": "enabled",
       "repository": "heimgewebe/hausKI"
     },
     {
-      "dependabot_version_updates": "enabled",
-      "renovate_version_updates": "prepared",
+      "dependabot_version_updates": "disabled",
+      "renovate_version_updates": "enabled",
       "repository": "heimgewebe/hausKI-audio"
     },
     {
-      "dependabot_version_updates": "enabled",
-      "renovate_version_updates": "prepared",
+      "dependabot_version_updates": "none",
+      "renovate_version_updates": "enabled",
+      "repository": "heimgewebe/heim-pc"
+    },
+    {
+      "dependabot_version_updates": "none",
+      "renovate_version_updates": "enabled",
+      "repository": "heimgewebe/heimgeist"
+    },
+    {
+      "dependabot_version_updates": "none",
+      "renovate_version_updates": "enabled",
+      "repository": "heimgewebe/konvergenzregelkreis"
+    },
+    {
+      "dependabot_version_updates": "none",
+      "renovate_version_updates": "enabled",
+      "repository": "heimgewebe/leitstand"
+    },
+    {
+      "dependabot_version_updates": "disabled",
+      "renovate_version_updates": "enabled",
       "repository": "heimgewebe/metarepo"
     },
     {
       "dependabot_version_updates": "none",
-      "renovate_version_updates": "prepared",
+      "renovate_version_updates": "enabled",
       "repository": "heimgewebe/mitschreiber"
     },
     {
-      "dependabot_version_updates": "enabled",
-      "renovate_version_updates": "prepared",
+      "dependabot_version_updates": "none",
+      "renovate_version_updates": "enabled",
+      "repository": "heimgewebe/plexer"
+    },
+    {
+      "dependabot_version_updates": "disabled",
+      "renovate_version_updates": "enabled",
       "repository": "heimgewebe/repoground"
     },
     {
-      "dependabot_version_updates": "enabled",
-      "renovate_version_updates": "prepared",
+      "dependabot_version_updates": "none",
+      "renovate_version_updates": "enabled",
+      "repository": "heimgewebe/semantAH"
+    },
+    {
+      "dependabot_version_updates": "none",
+      "renovate_version_updates": "enabled",
+      "repository": "heimgewebe/sichter"
+    },
+    {
+      "dependabot_version_updates": "none",
+      "renovate_version_updates": "enabled",
+      "repository": "heimgewebe/vault-gewebe"
+    },
+    {
+      "dependabot_version_updates": "disabled",
+      "renovate_version_updates": "enabled",
       "repository": "heimgewebe/weltgewebe"
+    },
+    {
+      "dependabot_version_updates": "none",
+      "renovate_version_updates": "enabled",
+      "repository": "heimgewebe/wgx"
     }
   ],
   "waves": [
     {
-      "id": "custom-manager-pilot",
+      "id": "direct-cutover",
       "order": 1,
       "repositories": [
-        "mitschreiber"
-      ],
-      "selector": null
-    },
-    {
-      "id": "volume-pilot",
-      "order": 2,
-      "repositories": [
+        "mitschreiber",
         "hausKI",
-        "hausKI-audio"
-      ],
-      "selector": null
-    },
-    {
-      "id": "signal-quality-pilot",
-      "order": 3,
-      "repositories": [
-        "repoground"
-      ],
-      "selector": null
-    },
-    {
-      "id": "multi-ecosystem-pilot",
-      "order": 4,
-      "repositories": [
-        "weltgewebe"
-      ],
-      "selector": null
-    },
-    {
-      "id": "control-plane-cutover",
-      "order": 5,
-      "repositories": [
+        "hausKI-audio",
+        "repoground",
+        "weltgewebe",
         "metarepo"
       ],
       "selector": null
     },
     {
-      "id": "fleet-expansion",
-      "order": 6,
-      "repositories": [],
+      "id": "active-fleet",
+      "order": 2,
+      "repositories": [
+        "aussensensor",
+        "chronik",
+        "contracts-mirror",
+        "heim-pc",
+        "heimgeist",
+        "konvergenzregelkreis",
+        "leitstand",
+        "plexer",
+        "semantAH",
+        "sichter",
+        "vault-gewebe",
+        "wgx"
+      ],
       "selector": "remaining-eligible-active-fleet"
     }
   ]

--- a/automation/renovate/install-local-runtime.sh
+++ b/automation/renovate/install-local-runtime.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "usage: $0 <expected-head>" >&2
+  exit 2
+fi
+
+EXPECTED_HEAD="$1"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+HEAD="$(git -C "${REPO_ROOT}" rev-parse HEAD)"
+
+if [[ "${HEAD}" != "${EXPECTED_HEAD}" ]]; then
+  echo "HEAD mismatch: expected ${EXPECTED_HEAD}, observed ${HEAD}" >&2
+  exit 2
+fi
+if ! git -C "${REPO_ROOT}" diff --quiet HEAD -- || ! git -C "${REPO_ROOT}" diff --cached --quiet; then
+  echo "tracked repository state is dirty" >&2
+  exit 2
+fi
+
+BASE="${HOME}/.local/share/renovate-fleet"
+RELEASE="${BASE}/releases/${HEAD}"
+CURRENT="${BASE}/current"
+UNIT_DIR="${HOME}/.config/systemd/user"
+TMP="${BASE}/.release-${HEAD}-$$"
+
+mkdir -p "${BASE}/releases" "${UNIT_DIR}"
+rm -rf "${TMP}"
+mkdir -p "${TMP}"
+git -C "${REPO_ROOT}" archive "${HEAD}" automation/renovate | tar -x -C "${TMP}"
+
+if [[ ! -e "${RELEASE}" ]]; then
+  mv "${TMP}" "${RELEASE}"
+else
+  rm -rf "${TMP}"
+fi
+
+ln -sfn "${RELEASE}" "${BASE}/.current-${HEAD}"
+mv -Tf "${BASE}/.current-${HEAD}" "${CURRENT}"
+
+install -m 0644 "${RELEASE}/automation/renovate/systemd/renovate-fleet.service" "${UNIT_DIR}/renovate-fleet.service"
+install -m 0644 "${RELEASE}/automation/renovate/systemd/renovate-fleet.timer" "${UNIT_DIR}/renovate-fleet.timer"
+systemctl --user daemon-reload
+
+printf '{"status":"installed","head":"%s","release":"%s","current":"%s"}\n' "${HEAD}" "${RELEASE}" "${CURRENT}"

--- a/automation/renovate/run-fleet.sh
+++ b/automation/renovate/run-fleet.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+RENOVATE_VERSION="42.99.0"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CONFIG_FILE="${SCRIPT_DIR}/runtime-config.cjs"
+
+command -v gh >/dev/null 2>&1 || { echo "gh is required" >&2; exit 2; }
+command -v npx >/dev/null 2>&1 || { echo "npx is required" >&2; exit 2; }
+[[ -f "${CONFIG_FILE}" ]] || { echo "Renovate runtime config missing: ${CONFIG_FILE}" >&2; exit 2; }
+
+TOKEN="$(gh auth token)"
+[[ -n "${TOKEN}" ]] || { echo "gh auth token returned an empty token" >&2; exit 2; }
+
+export RENOVATE_TOKEN="${TOKEN}"
+export RENOVATE_CONFIG_FILE="${CONFIG_FILE}"
+unset TOKEN
+
+exec npx --yes "renovate@${RENOVATE_VERSION}" "$@"

--- a/automation/renovate/run-fleet.sh
+++ b/automation/renovate/run-fleet.sh
@@ -5,12 +5,24 @@ RENOVATE_VERSION="42.99.0"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CONFIG_FILE="${SCRIPT_DIR}/runtime-config.cjs"
 
-command -v gh >/dev/null 2>&1 || { echo "gh is required" >&2; exit 2; }
-command -v npx >/dev/null 2>&1 || { echo "npx is required" >&2; exit 2; }
-[[ -f "${CONFIG_FILE}" ]] || { echo "Renovate runtime config missing: ${CONFIG_FILE}" >&2; exit 2; }
+command -v gh > /dev/null 2>&1 || {
+  echo "gh is required" >&2
+  exit 2
+}
+command -v npx > /dev/null 2>&1 || {
+  echo "npx is required" >&2
+  exit 2
+}
+[[ -f "${CONFIG_FILE}" ]] || {
+  echo "Renovate runtime config missing: ${CONFIG_FILE}" >&2
+  exit 2
+}
 
 TOKEN="$(gh auth token)"
-[[ -n "${TOKEN}" ]] || { echo "gh auth token returned an empty token" >&2; exit 2; }
+[[ -n "${TOKEN}" ]] || {
+  echo "gh auth token returned an empty token" >&2
+  exit 2
+}
 
 export RENOVATE_TOKEN="${TOKEN}"
 export RENOVATE_CONFIG_FILE="${CONFIG_FILE}"

--- a/automation/renovate/runtime-config.cjs
+++ b/automation/renovate/runtime-config.cjs
@@ -1,0 +1,24 @@
+const path = require("node:path");
+
+const here = __dirname;
+const preset = require(path.join(here, "default.json"));
+const scope = require(path.join(here, "expected-scope.v1.json"));
+
+if (scope.runtime_mode !== "self-hosted-heim-pc") {
+  throw new Error(`unexpected Renovate runtime_mode: ${scope.runtime_mode}`);
+}
+if (!Array.isArray(scope.expected_renovate_repositories) || scope.expected_renovate_repositories.length === 0) {
+  throw new Error("expected_renovate_repositories must be a non-empty array");
+}
+
+module.exports = {
+  ...preset,
+  platform: "github",
+  endpoint: "https://api.github.com/",
+  repositories: scope.expected_renovate_repositories,
+  autodiscover: false,
+  onboarding: false,
+  requireConfig: "optional",
+  forkProcessing: "disabled",
+  platformCommit: "enabled",
+};

--- a/automation/renovate/systemd/renovate-fleet.service
+++ b/automation/renovate/systemd/renovate-fleet.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Heimgewebe Fleet Renovate dependency update run
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+Environment=PATH=%h/.local/bin:/usr/local/bin:/usr/bin:/bin
+WorkingDirectory=%h/.local/share/renovate-fleet/current
+ExecStart=%h/.local/share/renovate-fleet/current/automation/renovate/run-fleet.sh
+TimeoutStartSec=4h
+Nice=10
+
+[Install]
+WantedBy=default.target

--- a/automation/renovate/systemd/renovate-fleet.timer
+++ b/automation/renovate/systemd/renovate-fleet.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Run Heimgewebe Fleet Renovate daily
+
+[Timer]
+OnCalendar=*-*-* 05:17:00
+Persistent=true
+RandomizedDelaySec=15m
+Unit=renovate-fleet.service
+
+[Install]
+WantedBy=timers.target

--- a/docs/fleet/renovate-v1.md
+++ b/docs/fleet/renovate-v1.md
@@ -4,93 +4,64 @@ Stand: 2026-07-23
 
 ## Zweck
 
-Renovate V1 ist ein Fleet-gebundener Dependency-Sensor und PR-Produzent. Es ist
-keine neue Control Plane. Fleet-Mitgliedschaft bleibt ausschließlich in
-`fleet/repos.yml`; die Renovate-Policy beschreibt nur operative Rollout- und
-Provider-Zustände für eine Teilmenge dieser Fleet.
+Renovate V1 ist der Fleet-weite Produzent regulärer Dependency-Version-Update-PRs.
+Fleet-Mitgliedschaft bleibt ausschließlich in `fleet/repos.yml`; die Renovate-Policy
+projiziert daraus den aktiven Runtime-Scope und definiert keine zweite Fleet.
 
-Renovate darf in V1:
+Renovate darf Dependencies erkennen sowie Update-Branches und Pull Requests erzeugen.
+Renovate darf nicht automatisch mergen, Bureau-Tasks oder Queue-Zustand erzeugen,
+Deployments ausführen oder GitHub-/CI-/Grabowski-Merge-Gates ersetzen.
 
-- bekannte Dependency-Manager auswerten;
-- kompatible Patch-/Minor-Updates managerweise gruppieren;
-- Update-Branches und Pull Requests erzeugen.
+## Direkter Cutover
 
-Renovate darf in V1 nicht:
+Die frühere Pilotstaffelung ist aufgehoben. Die selbst gehostete Renovate-Runtime auf
+dem Heim-PC verwaltet alle 18 aktiven Fleet-Repositories. Der Scope wird deterministisch
+aus `fleet/repos.yml` und `automation/renovate/dependency-updates.v1.yml` erzeugt.
+Archivierte Referenzen und `fleet: false` bleiben ausgeschlossen.
 
-- automatisch mergen;
-- Bureau-Tasks, Queue-Einträge oder Claims erzeugen;
-- Deployments oder Task-Verifikation ausführen;
-- eine eigene Fleet-Mitgliedschaft definieren;
-- GitHub-/CI- oder Grabowski-Head-/Diff-/Review-Gates ersetzen.
+Für die fünf Repositories mit bestehenden Dependabot-Version-Updates gilt die
+Cutover-Reihenfolge weiterhin fail-closed:
+
+1. Renovate-Lookup im Dry-Run für den vollständigen Fleet-Scope belegen.
+2. Überlappende Dependabot-Version-Update-Einträge entfernen bzw. deaktivieren.
+3. Den Single-Producer-Zustand live verifizieren.
+4. Erst danach Renovate ohne Dry-Run starten.
+
+Mitschreiber hat keine Dependabot-Version-Updates; seine bestehende Renovate-Konfiguration
+wird vor dem ersten schreibenden Fleet-Lauf auf den aktuellen Custom-Manager-Vertrag
+umgestellt und sämtliches Automerge entfernt.
+
+Dependabot Security Updates und Security Alerts bleiben ein getrennter Security-Pfad.
+Der Versions-Cutover behauptet nicht, diesen Pfad zu ersetzen oder abzuschalten.
 
 ## Kanonische Dateien
 
 - `fleet/repos.yml`: einzige normative Fleet-Mitgliedschaft.
-- `automation/renovate/dependency-updates.v1.yml`: versionierte operative
-  Rollout-Policy; keine zweite Fleet-Liste.
-- `automation/renovate/default.json`: gemeinsamer Renovate-V1-Preset.
-- `automation/renovate/expected-scope.v1.json`: deterministisch erzeugte,
-  nicht-authoritative Scope-Projektion.
-- `automation/renovate/baseline-2026-06-23_2026-07-23.json`: unveränderliche
-  Vorher-Baseline für die Pilotbewertung.
-- `scripts/fleet/renovate_policy.py`: fail-closed Validierung und Projektion.
+- `automation/renovate/dependency-updates.v1.yml`: operative Provider- und Cutover-Policy.
+- `automation/renovate/default.json`: gemeinsamer Renovate-Preset mit `automerge: false`.
+- `automation/renovate/expected-scope.v1.json`: deterministische, nicht-authoritative Scope-Projektion.
+- `automation/renovate/runtime-config.cjs`: self-hosted Renovate-Konfiguration; liest die Scope-Projektion.
+- `automation/renovate/run-fleet.sh`: gepinnter Runtime-Wrapper.
+- `automation/renovate/install-local-runtime.sh`: commitgebundene lokale Runtime-Installation.
+- `automation/renovate/systemd/renovate-fleet.{service,timer}`: täglicher Fleet-Lauf.
+- `scripts/fleet/renovate_policy.py`: fail-closed Policy- und Scope-Validierung.
 
-Ein Consumer kann den zentralen Preset später beispielsweise über einen
-Repo-gehosteten Preset-Pfad referenzieren. Der konkrete Consumer-Cutover ist
-bewusst nicht Teil dieses Foundation-Tasks und benötigt eigene Repo-Claims,
-Leases, Review- und Rollback-Evidenz.
+## Runtime und Zugang
 
-## Single-Producer-Vertrag
+Die Runtime läuft lokal auf dem Heim-PC und nutzt den vorhandenen `gh`-Login nur zur
+Laufzeit. `run-fleet.sh` liest `gh auth token`, exportiert den Wert ausschließlich in die
+Renovate-Prozessumgebung und persistiert den Token weder im Repository noch in der
+Renovate-Konfiguration. Der aktuelle Runtime-Pfad ist auf eine immutable Release-Kopie
+unter `~/.local/share/renovate-fleet/releases/<commit>` gebunden; `current` ist nur ein
+atomar umschaltbarer Symlink.
 
-Pro Repository und Dependency-Scope darf genau ein aktiver Produzent regulärer
-Version-Update-PRs existieren.
+Der Runtime-Scope ist eine explizite `repositories`-Liste aus
+`expected_renovate_repositories`; `autodiscover` und Renovate-Onboarding sind deaktiviert.
+Damit kann ein Organisation-weites GitHub-Token nicht automatisch Repositories außerhalb
+der kanonischen Fleet in den Update-Scope ziehen.
 
-Der Cutover ist daher strikt geordnet:
-
-1. Renovate-Abdeckung im Zielrepo belegen.
-2. Überlappende Dependabot-Version-Updates deaktivieren.
-3. Per Readback bestätigen, dass nur ein Version-Update-Produzent aktiv ist.
-
-`renovate_version_updates: prepared` bedeutet ausdrücklich **nicht aktiv**. Der
-Foundation-Stand markiert alle geplanten Pilot-Repositories nur als `prepared`;
-die erwartete aktive Hosted-App-Scope-Projektion ist deshalb leer.
-
-Dependabot Security Updates bleiben in V1 als separater Security-Pfad bestehen.
-Eine Version-Update-Migration behauptet nicht, Security Alerts oder
-Security-Update-Verhalten zu deaktivieren oder zu ersetzen.
-
-## Rollout-Wellen
-
-1. `mitschreiber`: bestehende Custom-Pin-Erkennung modernisieren und ohne
-   Automerge validieren.
-2. `hausKI`, `hausKI-audio`: Volumenpilot gegen die 30-Tage-Baseline.
-3. `repoground`: Signalqualität und Closed-unmerged-Verhalten untersuchen.
-4. `weltgewebe`: Multi-Ecosystem-Pilot erst nach bestandenen früheren Wellen.
-5. `metarepo`: Control-Plane-Cutover zuletzt, damit die Policy sich nicht selbst
-   freigibt.
-6. Restliche geeignete aktive Fleet-Repositories werden erst nach den Piloten
-   bewertet; sie werden nicht als zweite vollständige Liste in der Policy
-   dupliziert.
-
-Zwischen automatischer Erweiterung zweier Wellen verlangt der Vertrag
-mindestens zwei beobachtete Update-Zyklen. Die konkrete Freigabe bleibt an die
-jeweiligen Repo-, Review-, CI- und Operator-Gates gebunden.
-
-## Hosted-App-Scope
-
-Für einen Mend-hosted Renovate-Pfad verlangt V1 GitHubs Auswahlmodus
-`Select repositories`. Eine All-Repositories-Installation ist im V1-Vertrag
-nicht zulässig.
-
-`expected-scope.v1.json` enthält nur Repositories mit
-`renovate_version_updates: enabled` als erwarteten aktiven App-Scope. Ein
-beobachteter App-Scope kann mit `renovate_policy.py check --observed-app-scope`
-gegen diese Git-autorisierte Erwartung geprüft werden. Eine Abweichung ist ein
-fail-closed Driftbefund.
-
-Die Projektion beweist weder, dass eine GitHub App installiert ist, noch dass
-keine externe Installation existiert. Der tatsächliche GitHub-App-Zustand muss
-live gelesen werden.
+Renovate ist auf Version `42.99.0` gepinnt. Eine spätere Versionsanhebung ist eine
+reviewte Änderung dieses Wrappers.
 
 ## Preset-Grenzen
 
@@ -100,57 +71,56 @@ Der gemeinsame Preset:
 - setzt `automerge: false`;
 - begrenzt PR-, Branch- und Stundenparallelität auf höchstens zwei;
 - hält Major-Updates getrennt;
-- gruppiert zentral nur Patch-/Minor-Updates für GitHub Actions; npm-/Cargo-Gruppen werden wegen Monorepo- und Verzeichnisgrenzen erst repo-spezifisch im jeweiligen Pilot definiert;
+- gruppiert zentral nur Patch-/Minor-Updates für GitHub Actions;
 - enthält keine Post-Upgrade-Command-Ausführung.
 
-Die lokale Validierung lehnt Automerge, gruppierte Major-Updates, zu hohe
-Parallelität und unbekannte Policy-Felder fail-closed ab.
+Repo-spezifische Konfiguration darf diese Sicherheitsgrenzen nicht durch Automerge
+unterlaufen. Vor dem ersten schreibenden Lauf werden bekannte lokale Abweichungen wie
+die alte Mitschreiber-Konfiguration korrigiert.
 
-## Baseline und Messung
+## Single-Producer-Vertrag
 
-Die eingefrorene Vergleichsbasis vom 23. Juni bis 23. Juli 2026 enthält 51
-Dependabot-PRs: 40 gemergt und 11 ohne Merge geschlossen. Die per Repository
-gespeicherten Zähler werden beim Policy-Check gegen die reviewte Baseline
-verifiziert.
+Pro Repository und Dependency-Scope darf genau ein aktiver Produzent regulärer
+Version-Update-PRs existieren. Die sechs expliziten Cutover-Repositories modellieren den
+bekannten vorherigen Producer-Zustand; der Selector `remaining-eligible-active-fleet`
+leitet die übrigen aktiven Fleet-Repositories direkt aus `fleet/repos.yml` ab. Eine
+explizite zweite Vollkopie der Fleet bleibt verboten.
 
-Diese Zahlen beweisen weder eine Ursache für Merge-/Close-Entscheidungen noch
-einen künftigen Vorteil von Renovate. Spätere Pilot-Auswertungen sollen unter
-anderem PR-Zahl, Merge-Rate, Closed-unmerged-Anteil, stale PRs,
-Duplicate-Producer-Vorfälle, Automerge-Vorfälle, Merge-Gate-Bypässe und echte
-Bureau-Eskalationen vergleichen.
+Die Scope-Projektion muss alle 18 aktiven Fleet-Repositories in
+`expected_renovate_repositories` enthalten und darf für die selbst gehostete Runtime
+keinen Hosted-App-Scope behaupten.
+
+## Scheduling
+
+Nach dem ersten erfolgreichen schreibenden Cutover-Lauf wird `renovate-fleet.timer`
+aktiviert. Der Timer läuft täglich um 05:17 Uhr mit bis zu 15 Minuten Randomisierung.
+Ein Lauf ist `oneshot`, hat ein Vier-Stunden-Limit und besitzt keine Merge-Autorität.
 
 ## Validierung
 
-`just renovate-policy-check` prüft:
+`just renovate-policy-check` prüft unter anderem:
 
 - Policy gegen die aktive Fleet aus `fleet/repos.yml`;
-- keine archivierten oder `fleet: false` Repositories;
-- keine Repo-Duplikate über Wellen;
-- keine zwei gleichzeitig aktiven Version-Update-Produzenten;
-- keinen vollständigen zweiten Fleet-Abzug in der Rollout-Policy;
-- zentrale Preset-Sicherheitsgrenzen;
-- unveränderte Baseline;
+- Ausschluss archivierter und `fleet: false` Repositories;
+- keine explizite zweite vollständige Fleet-Liste;
+- keine zwei gleichzeitig als aktiv deklarierten Version-Update-Produzenten;
+- vollständige abgeleitete Renovate-Projektion für alle 18 aktiven Fleet-Repositories;
+- `automerge: false`, Major-Isolation und begrenzte Parallelität;
+- unveränderte 30-Tage-Baseline;
 - bytegenaue Reproduzierbarkeit der Scope-Projektion.
 
-`just renovate-policy` regeneriert ausschließlich die deterministische
-Scope-Projektion. `just validate` führt den Check automatisch aus.
+Vor dem echten Cutover ist zusätzlich ein Renovate-Lookup-Dry-Run erforderlich. Danach
+werden die betroffenen Dependabot-Konfigurationen PR-gebunden geändert und der
+Single-Producer-Zustand erneut live gelesen.
 
 ## Rollback
 
-Dieser Foundation-Slice verändert keine Consumer-Dependabot-Konfiguration und
-keine GitHub-App-Berechtigung. Er ist daher durch Revert des Metarepo-Commits
-rückrollbar.
+Die lokale Runtime kann durch Stoppen/Deaktivieren von `renovate-fleet.timer` und
+`renovate-fleet.service` sofort angehalten werden. Der vorherige Runtime-Release bleibt
+unter `~/.local/share/renovate-fleet/releases/` erhalten und kann durch Rücksetzen des
+`current`-Symlinks wieder aktiviert werden.
 
-Jeder spätere Consumer-Cutover braucht zusätzlich einen eigenen Rollback:
-Renovate für das betroffene Repository stoppen, den vorherigen reviewten
-Dependabot-Version-Update-Stand wiederherstellen und anschließend live prüfen,
-dass wieder exakt ein Version-Update-Produzent aktiv ist.
-
-Bureau-, Chronik- und Git-Historie werden dabei nicht umgeschrieben.
-
-## Bekannte Folgegrenze
-
-`repo.mitschreiber` ist zum Stand dieser Entscheidung nicht als Bureau-
-Repository-Resource registriert. T046 erfindet deshalb keinen Claim. Die
-Resource-Katalog-Erweiterung und der Mitschreiber-Cutover müssen über den
-operator-native Bureau-Intake als getrennte Folgearbeit registriert werden.
+Für Repositories, deren Dependabot-Version-Updates bereits entfernt wurden, besteht der
+Rollback aus dem Revert des jeweiligen reviewten Cutover-Commits. Anschließend muss live
+belegt werden, dass wieder exakt ein Version-Update-Produzent aktiv ist. Bureau-,
+Chronik- und Git-Historie werden nicht umgeschrieben.

--- a/scripts/fleet/renovate_policy.py
+++ b/scripts/fleet/renovate_policy.py
@@ -327,17 +327,19 @@ def validate_policy(policy: dict[str, Any], *, active_fleet: set[str]) -> list[d
             "provider",
             "automerge",
             "duplicate_producer_policy",
-            "hosted_app_repository_selection",
+            "runtime_mode",
+            "credential_source",
+            "scope_selector",
             "all_repositories_allowed",
-            "minimum_observed_cycles_before_expansion",
         },
         required={
             "provider",
             "automerge",
             "duplicate_producer_policy",
-            "hosted_app_repository_selection",
+            "runtime_mode",
+            "credential_source",
+            "scope_selector",
             "all_repositories_allowed",
-            "minimum_observed_cycles_before_expansion",
         },
         label="version_update_defaults",
     )
@@ -345,9 +347,10 @@ def validate_policy(policy: dict[str, Any], *, active_fleet: set[str]) -> list[d
         "provider": "renovate",
         "automerge": False,
         "duplicate_producer_policy": "fail-closed",
-        "hosted_app_repository_selection": "selected",
+        "runtime_mode": "self-hosted-heim-pc",
+        "credential_source": "gh-auth-token-transient",
+        "scope_selector": "active-fleet",
         "all_repositories_allowed": False,
-        "minimum_observed_cycles_before_expansion": 2,
     }
     if defaults != expected_defaults:
         raise PolicyError("version_update_defaults do not match the reviewed Renovate V1 safety contract")
@@ -453,6 +456,7 @@ def build_scope_projection(
     *,
     policy: dict[str, Any],
     waves: list[dict[str, Any]],
+    active_fleet: set[str],
     fleet_path: Path,
     policy_path: Path,
 ) -> dict[str, Any]:
@@ -462,25 +466,42 @@ def build_scope_projection(
     ownership: list[dict[str, Any]] = []
     projected_waves: list[dict[str, Any]] = []
     selectors: list[str] = []
+    explicit_names = {
+        repo["name"]
+        for wave in waves
+        for repo in wave["repositories"]
+    }
+
+    def add_repo(name: str, dependabot_state: str, renovate_state: str) -> None:
+        full_name = f"{owner}/{name}"
+        if renovate_state == "prepared":
+            prepared.append(full_name)
+        elif renovate_state == "enabled":
+            enabled.append(full_name)
+        ownership.append(
+            {
+                "repository": full_name,
+                "dependabot_version_updates": dependabot_state,
+                "renovate_version_updates": renovate_state,
+            }
+        )
+
     for wave in waves:
         repo_names: list[str] = []
-        if wave["selector"] is not None:
-            selectors.append(wave["selector"])
         for repo in wave["repositories"]:
             name = repo["name"]
             repo_names.append(name)
-            renovate_state = repo["renovate_version_updates"]
-            if renovate_state == "prepared":
-                prepared.append(f"{owner}/{name}")
-            elif renovate_state == "enabled":
-                enabled.append(f"{owner}/{name}")
-            ownership.append(
-                {
-                    "repository": f"{owner}/{name}",
-                    "dependabot_version_updates": repo["dependabot_version_updates"],
-                    "renovate_version_updates": renovate_state,
-                }
+            add_repo(
+                name,
+                repo["dependabot_version_updates"],
+                repo["renovate_version_updates"],
             )
+        if wave["selector"] is not None:
+            selectors.append(wave["selector"])
+            derived = sorted(active_fleet - explicit_names)
+            repo_names.extend(derived)
+            for name in derived:
+                add_repo(name, "none", "enabled")
         projected_waves.append(
             {
                 "id": wave["id"],
@@ -489,9 +510,16 @@ def build_scope_projection(
                 "selector": wave["selector"],
             }
         )
+
+    enabled = sorted(set(enabled))
+    if set(enabled) != {f"{owner}/{name}" for name in active_fleet}:
+        raise PolicyError("direct-cutover projection must enable Renovate for the complete active Fleet")
+
     return {
         "schema_version": 1,
         "kind": "renovate-fleet-scope-projection",
+        "runtime_mode": policy["version_update_defaults"]["runtime_mode"],
+        "credential_source": policy["version_update_defaults"]["credential_source"],
         "sources": {
             "fleet": {"path": "fleet/repos.yml", "sha256": _sha256(fleet_path)},
             "policy": {
@@ -499,14 +527,15 @@ def build_scope_projection(
                 "sha256": _sha256(policy_path),
             },
         },
-        "expected_hosted_app_repositories": sorted(enabled),
-        "prepared_repositories": sorted(prepared),
+        "expected_renovate_repositories": enabled,
+        "expected_hosted_app_repositories": [],
+        "prepared_repositories": sorted(set(prepared)),
         "version_update_ownership": sorted(ownership, key=lambda item: item["repository"]),
         "waves": projected_waves,
         "deferred_selectors": selectors,
         "nonclaims": [
             "This projection is not Fleet membership truth.",
-            "Prepared repositories are not proof that the Renovate GitHub App is installed or active.",
+            "The self-hosted runtime target list is derived from fleet/repos.yml and this policy.",
             "An empty expected hosted-app scope is not proof that no external app installation exists.",
             "This projection grants no merge, queue, claim, deployment or task-verification authority.",
         ],
@@ -552,6 +581,7 @@ def validate_all(
     projection = build_scope_projection(
         policy=policy,
         waves=waves,
+        active_fleet=active,
         fleet_path=fleet_path,
         policy_path=policy_path,
     )
@@ -607,6 +637,9 @@ def main(argv: list[str] | None = None) -> int:
                 "status": "ok",
                 "active_fleet_count": summary["active_fleet_count"],
                 "explicit_rollout_count": summary["explicit_rollout_count"],
+                "expected_renovate_repositories": projection[
+                    "expected_renovate_repositories"
+                ],
                 "expected_hosted_app_repositories": projection[
                     "expected_hosted_app_repositories"
                 ],

--- a/tests/test_renovate_policy.py
+++ b/tests/test_renovate_policy.py
@@ -30,15 +30,31 @@ def _inputs():
 def test_current_policy_preset_baseline_and_projection_are_valid() -> None:
     projection, summary = renovate_policy.validate_all()
     assert summary == {"active_fleet_count": 18, "explicit_rollout_count": 6}
+    assert projection["runtime_mode"] == "self-hosted-heim-pc"
+    assert projection["credential_source"] == "gh-auth-token-transient"
     assert projection["expected_hosted_app_repositories"] == []
-    assert projection["prepared_repositories"] == [
+    assert projection["prepared_repositories"] == []
+    assert len(projection["expected_renovate_repositories"]) == 18
+    assert set(projection["expected_renovate_repositories"]) == {
+        "heimgewebe/weltgewebe",
+        "heimgewebe/metarepo",
+        "heimgewebe/wgx",
+        "heimgewebe/contracts-mirror",
         "heimgewebe/hausKI",
         "heimgewebe/hausKI-audio",
-        "heimgewebe/metarepo",
-        "heimgewebe/mitschreiber",
+        "heimgewebe/semantAH",
+        "heimgewebe/aussensensor",
+        "heimgewebe/chronik",
         "heimgewebe/repoground",
-        "heimgewebe/weltgewebe",
-    ]
+        "heimgewebe/konvergenzregelkreis",
+        "heimgewebe/mitschreiber",
+        "heimgewebe/sichter",
+        "heimgewebe/leitstand",
+        "heimgewebe/heimgeist",
+        "heimgewebe/plexer",
+        "heimgewebe/heim-pc",
+        "heimgewebe/vault-gewebe",
+    }
     committed = json.loads(
         (ROOT / "automation/renovate/expected-scope.v1.json").read_text(encoding="utf-8")
     )
@@ -59,11 +75,11 @@ def test_archived_or_non_fleet_repository_is_rejected() -> None:
 def test_repository_cannot_appear_in_multiple_waves() -> None:
     fleet, policy, _ = _inputs()
     mutated = copy.deepcopy(policy)
-    mutated["rollout"]["waves"][1]["repositories"].append(
+    mutated["rollout"]["waves"][0]["repositories"].append(
         {
             "name": "mitschreiber",
             "dependabot_version_updates": "none",
-            "renovate_version_updates": "prepared",
+            "renovate_version_updates": "enabled",
         }
     )
     with pytest.raises(renovate_policy.PolicyError, match="more than one wave"):
@@ -76,7 +92,7 @@ def test_repository_cannot_appear_in_multiple_waves() -> None:
 def test_two_active_version_update_producers_fail_closed() -> None:
     fleet, policy, _ = _inputs()
     mutated = copy.deepcopy(policy)
-    repo = mutated["rollout"]["waves"][1]["repositories"][0]
+    repo = mutated["rollout"]["waves"][0]["repositories"][1]
     repo["dependabot_version_updates"] = "enabled"
     repo["renovate_version_updates"] = "enabled"
     with pytest.raises(renovate_policy.PolicyError, match="duplicate active"):


### PR DESCRIPTION
Direct Fleet cutover to centrally self-hosted Renovate on heim-pc. The runtime derives all 18 active repositories from fleet/repos.yml, uses the existing gh authentication token only transiently, disables autodiscover/onboarding/automerge, adds an immutable local runtime + systemd timer, and sets metarepo Dependabot version updates to open-pull-requests-limit: 0 while keeping the Security Updates path separate. Full 18-repo Renovate lookup dry-run succeeded; just validate succeeded.