### PR TITLE
docs: make pre-merge diff artifacts optional

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,7 +74,7 @@ Die früheren Organismus-, Zielbild-, Rollen- und Diagrammdokumente sind keine a
 
 - Fremde Dirty-States, Worktrees, Branches, Prozesse und Leases nie resetten oder übernehmen.
 - Änderungen in einem isolierten, sauberen Worktree ausführen.
-- Vor nichttrivialem Merge vollständigen Diff bereitstellen und an Head sowie Diff-SHA-256 binden.
+- Vor nichttrivialem Merge den exakten Head intern an vollständigen Diff-SHA-256, Review und grüne Pflichtchecks binden. Ein benutzerseitiges Diff-Artefakt ist optional und nur auf ausdrücklichen Wunsch oder bei begründetem Sonderrisiko bereitzustellen.
 - Kein Shared Asset ohne belegte Consumer-Auswirkung mergen.
 - Keine Secrets in Templates, Fixtures, Reports oder Workflow-Ausgaben schreiben.
 


### PR DESCRIPTION
## Änderung

- entfernt die Pflicht, vor nichttrivialen Merges ein benutzerseitiges Diff-Artefakt bereitzustellen
- behält exakten Head, vollständigen internen Diff-SHA-256, Review und grüne Pflichtchecks bei
- erlaubt ein externes Artefakt nur noch auf ausdrücklichen Wunsch oder bei begründetem Sonderrisiko

## Validierung

- `env ALLOW_NET=1 just validate`
- `git diff --check`
- exakter Self-Review des vollständigen Diffs