### PR TITLE
fix(fleet): restore generated docs after failed checks

### DIFF
--- a/scripts/fleet/check_docs_drift.sh
+++ b/scripts/fleet/check_docs_drift.sh
@@ -18,8 +18,32 @@ if [ ! -f "$GENERATED_FILE" ]; then
 fi
 
 ORIGINAL=$(mktemp)
-trap 'rm -f "$ORIGINAL"' EXIT
+BACKUP_READY=0
+
+# Invoked indirectly by the EXIT trap below.
+# shellcheck disable=SC2317
+restore_generated_file() {
+  rc=$?
+  trap - EXIT
+
+  if [ "$BACKUP_READY" -eq 1 ] && { [ ! -f "$GENERATED_FILE" ] || ! cmp -s "$ORIGINAL" "$GENERATED_FILE"; }; then
+    if ! cp "$ORIGINAL" "$GENERATED_FILE"; then
+      echo "❌ Failed to restore $GENERATED_FILE after drift check." >&2
+      rc=1
+    fi
+  fi
+
+  if ! rm -f "$ORIGINAL"; then
+    echo "❌ Failed to remove temporary drift-check backup." >&2
+    rc=1
+  fi
+
+  exit "$rc"
+}
+
+trap restore_generated_file EXIT
 cp "$GENERATED_FILE" "$ORIGINAL"
+BACKUP_READY=1
 
 python3 "$GENERATOR" > /dev/null
 
@@ -27,7 +51,6 @@ if ! cmp -s "$GENERATED_FILE" "$ORIGINAL"; then
   echo "❌ Drift detected in $GENERATED_FILE. Content does not match fleet/repos.yml."
   echo "Diff (committed/current -> generated):"
   diff -u "$ORIGINAL" "$GENERATED_FILE" || true
-  cp "$ORIGINAL" "$GENERATED_FILE"
   exit 1
 fi
 

--- a/tests/test_check_docs_drift.py
+++ b/tests/test_check_docs_drift.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import shutil
+import subprocess
+import textwrap
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "fleet" / "check_docs_drift.sh"
+BASH = shutil.which("bash")
+assert BASH is not None
+
+
+def _fixture(tmp_path: Path, generator_body: str) -> tuple[Path, Path, bytes]:
+    repo = tmp_path / "repo"
+    script = repo / "scripts" / "fleet" / "check_docs_drift.sh"
+    generator = repo / "scripts" / "fleet" / "generate_fleet_docs.py"
+    generated = repo / "docs" / "_generated" / "fleet.md"
+
+    script.parent.mkdir(parents=True)
+    generated.parent.mkdir(parents=True)
+    shutil.copy2(SCRIPT, script)
+
+    original = b"committed fleet documentation\n"
+    generated.write_bytes(original)
+    generator.write_text(textwrap.dedent(generator_body), encoding="utf-8")
+
+    return repo, generated, original
+
+
+def _run_guard(repo: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [BASH, "scripts/fleet/check_docs_drift.sh"],
+        cwd=repo,
+        stdin=subprocess.DEVNULL,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def test_generator_failure_restores_partially_written_file(tmp_path: Path) -> None:
+    repo, generated, original = _fixture(
+        tmp_path,
+        """
+        from pathlib import Path
+
+        output = Path("docs/_generated/fleet.md")
+        output.write_text("partial regenerated content\\n", encoding="utf-8")
+        raise SystemExit(7)
+        """,
+    )
+
+    result = _run_guard(repo)
+
+    assert result.returncode == 7
+    assert generated.read_bytes() == original
+
+
+def test_detected_drift_is_reported_and_restored(tmp_path: Path) -> None:
+    repo, generated, original = _fixture(
+        tmp_path,
+        """
+        from pathlib import Path
+
+        Path("docs/_generated/fleet.md").write_text(
+            "complete but different generated content\\n",
+            encoding="utf-8",
+        )
+        """,
+    )
+
+    result = _run_guard(repo)
+
+    assert result.returncode == 1
+    assert "Drift detected" in result.stdout
+    assert generated.read_bytes() == original


### PR DESCRIPTION
## Änderung
- stellt `docs/_generated/fleet.md` bei jedem Fehlerpfad des Drift-Checks exakt wieder her
- bewahrt den ursprünglichen Exit-Code, sofern die Wiederherstellung selbst gelingt
- ergänzt Regressionstests für Teil-Write plus Generatorfehler und normalen Drift

## Prüfung
- `just validate`
- 180 Tests bestanden
- Shell-Regressionen und Actionlint grün

Self-Review auf Head `0691b6a7673200b5574e44e90d9f1410f1f23418`: keine offenen Befunde.