### PR TITLE
fix(contracts): replace vulnerable ajv cli

### DIFF
--- a/contracts/package-lock.json
+++ b/contracts/package-lock.json
@@ -9,8 +9,8 @@
       "version": "0.1.0",
       "license": "MIT",
       "devDependencies": {
-        "ajv-cli": "^5.0.0",
-        "ajv-formats": "^3.0.1"
+        "ajv": "8.20.0",
+        "ajv-formats": "3.0.1"
       }
     },
     "node_modules/ajv": {
@@ -28,33 +28,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/ajv-cli": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ajv-cli/-/ajv-cli-5.0.0.tgz",
-      "integrity": "sha512-LY4m6dUv44HTyhV+u2z5uX4EhPYTM38Iv1jdgDJJJCyOOuqB8KtZEGjPZ2T+sh5ZIJrXUfgErYx/j3gLd3+PlQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "^8.0.0",
-        "fast-json-patch": "^2.0.0",
-        "glob": "^7.1.0",
-        "js-yaml": "^3.14.0",
-        "json-schema-migrate": "^2.0.0",
-        "json5": "^2.1.3",
-        "minimist": "^1.2.0"
-      },
-      "bin": {
-        "ajv": "dist/index.js"
-      },
-      "peerDependencies": {
-        "ts-node": ">=9.0.0"
-      },
-      "peerDependenciesMeta": {
-        "ts-node": {
-          "optional": true
-        }
       }
     },
     "node_modules/ajv-formats": {
@@ -75,79 +48,10 @@
         }
       }
     },
-    "node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
-    },
-    "node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/brace-expansion": {
-      "version": "1.1.18",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
-      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/esprima": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "bin": {
-        "esparse": "bin/esparse.js",
-        "esvalidate": "bin/esvalidate.js"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/fast-json-patch": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/fast-json-patch/-/fast-json-patch-2.2.1.tgz",
-      "integrity": "sha512-4j5uBaTnsYAV5ebkidvxiLUYOwjQ+JSFljeqfTxCrH9bDmlCQaOJFS84oDJ2rAXZq2yskmk3ORfoP9DCwqFNig==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^2.0.1"
-      },
-      "engines": {
-        "node": ">= 0.4.0"
-      }
-    },
-    "node_modules/fast-json-patch/node_modules/fast-deep-equal": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-      "integrity": "sha512-bCK/2Z4zLidyB4ReuIsvALH6w31YfAQDmXMqMx6FyfHqvBxtjC0eRumeSu4Bs3XtXwpyIywtSTrVT99BxY1f9w==",
       "dev": true,
       "license": "MIT"
     },
@@ -168,140 +72,12 @@
       ],
       "license": "BSD-3-Clause"
     },
-    "node_modules/fs.realpath": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/inflight": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
-      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "once": "^1.3.0",
-        "wrappy": "1"
-      }
-    },
-    "node_modules/inherits": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
-    "node_modules/json-schema-migrate": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-migrate/-/json-schema-migrate-2.0.0.tgz",
-      "integrity": "sha512-r38SVTtojDRp4eD6WsCqiE0eNDt4v1WalBXb9cyZYw9ai5cGtBwzRNWjHzJl38w6TxFkXAIA7h+fyX3tnrAFhQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "^8.0.0"
-      }
-    },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/json5": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
-      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "json5": "lib/cli.js"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/minimist": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/once": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "wrappy": "1"
-      }
-    },
-    "node_modules/path-is-absolute": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/require-from-string": {
       "version": "2.0.2",
@@ -312,20 +88,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/sprintf-js": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/wrappy": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true,
-      "license": "ISC"
     }
   }
 }

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -13,7 +13,7 @@
     "README.md"
   ],
   "scripts": {
-    "validate": "ajv compile -s '**/*.schema.json' -r '**/*.schema.json' -c ajv-formats --spec=draft2020 --strict=log"
+    "validate": "bash ../scripts/validate-contracts.sh"
   },
   "keywords": [
     "heimgewebe",
@@ -23,7 +23,7 @@
   "author": "Heimgewebe Fleet",
   "license": "MIT",
   "devDependencies": {
-    "ajv-cli": "^5.0.0",
-    "ajv-formats": "^3.0.1"
+    "ajv": "8.20.0",
+    "ajv-formats": "3.0.1"
   }
 }

--- a/scripts/contracts/ajv_validate.cjs
+++ b/scripts/contracts/ajv_validate.cjs
@@ -1,0 +1,266 @@
+#!/usr/bin/env node
+"use strict";
+
+const fs = require("node:fs");
+const path = require("node:path");
+const { createRequire } = require("node:module");
+const { pathToFileURL } = require("node:url");
+
+function usage(message) {
+  if (message) {
+    console.error(`error: ${message}`);
+  }
+  console.error(
+    "usage: ajv_validate.cjs <compile|validate> --modules DIR --schema FILE " +
+      "[--ref FILE ...] [--data FILE] [--strict log|true|false] [--all-errors]",
+  );
+  process.exit(2);
+}
+
+function parseArguments(argv) {
+  if (argv.length === 0) {
+    usage("mode is required");
+  }
+
+  const mode = argv[0];
+  if (mode !== "compile" && mode !== "validate") {
+    usage(`unsupported mode: ${mode}`);
+  }
+
+  const options = {
+    mode,
+    modules: "",
+    schema: "",
+    data: "",
+    refs: [],
+    strict: mode === "compile" ? "log" : "false",
+    allErrors: false,
+  };
+
+  for (let index = 1; index < argv.length; index += 1) {
+    const argument = argv[index];
+    if (argument === "--all-errors") {
+      options.allErrors = true;
+      continue;
+    }
+
+    if (!["--modules", "--schema", "--data", "--ref", "--strict"].includes(argument)) {
+      usage(`unsupported argument: ${argument}`);
+    }
+    if (index + 1 >= argv.length) {
+      usage(`${argument} requires a value`);
+    }
+    const value = argv[index + 1];
+    index += 1;
+
+    switch (argument) {
+      case "--modules":
+        options.modules = value;
+        break;
+      case "--schema":
+        options.schema = value;
+        break;
+      case "--data":
+        options.data = value;
+        break;
+      case "--ref":
+        options.refs.push(value);
+        break;
+      case "--strict":
+        if (!["log", "true", "false"].includes(value)) {
+          usage("--strict must be log, true or false");
+        }
+        options.strict = value;
+        break;
+      default:
+        usage(`unsupported argument: ${argument}`);
+    }
+  }
+
+  if (!options.modules) {
+    usage("--modules is required");
+  }
+  if (!options.schema) {
+    usage("--schema is required");
+  }
+  if (mode === "validate" && !options.data) {
+    usage("--data is required for validate mode");
+  }
+  if (mode === "compile" && options.data) {
+    usage("--data is only valid in validate mode");
+  }
+
+  return options;
+}
+
+function defaultExport(value) {
+  return value && value.default ? value.default : value;
+}
+
+function loadValidator(modulesDirectory) {
+  const absoluteModules = path.resolve(modulesDirectory);
+  const resolver = createRequire(path.join(absoluteModules, ".ajv-validator-resolver.cjs"));
+
+  let Ajv2020;
+  let addFormats;
+  try {
+    Ajv2020 = defaultExport(resolver("ajv/dist/2020"));
+    addFormats = defaultExport(resolver("ajv-formats"));
+  } catch (error) {
+    console.error(`error: unable to load pinned AJV modules from ${absoluteModules}`);
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(2);
+  }
+
+  return { Ajv2020, addFormats };
+}
+
+function readJson(filePath, label) {
+  const absolutePath = path.resolve(filePath);
+  let text;
+  try {
+    text = fs.readFileSync(absolutePath, "utf8");
+  } catch (error) {
+    console.error(`error: unable to read ${label}: ${filePath}`);
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(2);
+  }
+
+  try {
+    return JSON.parse(text);
+  } catch (error) {
+    console.error(`error: invalid JSON in ${label}: ${filePath}`);
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  }
+}
+
+function schemaKey(filePath) {
+  return pathToFileURL(path.resolve(filePath)).href;
+}
+
+function strictValue(value) {
+  if (value === "true") {
+    return true;
+  }
+  if (value === "false") {
+    return false;
+  }
+  return "log";
+}
+
+function createValidator(options) {
+  const { Ajv2020, addFormats } = loadValidator(options.modules);
+  const ajv = new Ajv2020({
+    strict: strictValue(options.strict),
+    allErrors: options.allErrors,
+    validateFormats: true,
+  });
+  addFormats(ajv);
+
+  const currentSchema = path.resolve(options.schema);
+  const uniqueReferences = [...new Set(options.refs.map((reference) => path.resolve(reference)))].sort();
+  for (const reference of uniqueReferences) {
+    if (reference === currentSchema) {
+      continue;
+    }
+    const schema = readJson(reference, "reference schema");
+    try {
+      ajv.addSchema(schema, schemaKey(reference));
+    } catch (error) {
+      console.error(`error: unable to register reference schema: ${reference}`);
+      console.error(error instanceof Error ? error.message : String(error));
+      process.exit(1);
+    }
+  }
+
+  const schema = readJson(currentSchema, "schema");
+  const key = schemaKey(currentSchema);
+  try {
+    ajv.addSchema(schema, key);
+  } catch (error) {
+    console.error(`error: unable to compile schema: ${options.schema}`);
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  }
+
+  const validate = ajv.getSchema(key) || (schema.$id ? ajv.getSchema(schema.$id) : undefined);
+  if (typeof validate !== "function") {
+    console.error(`error: AJV did not expose a validator for schema: ${options.schema}`);
+    process.exit(1);
+  }
+  return { ajv, validate };
+}
+
+function printValidationErrors(ajv, validate, dataPath, lineNumber = 0) {
+  const location = lineNumber > 0 ? `${dataPath}:${lineNumber}` : dataPath;
+  console.error(`${location} invalid`);
+  if (validate.errors && validate.errors.length > 0) {
+    console.error(ajv.errorsText(validate.errors, { separator: "\n", dataVar: location }));
+  }
+}
+
+function validateJsonFile(ajv, validate, dataPath) {
+  const data = readJson(dataPath, "data");
+  if (!validate(data)) {
+    printValidationErrors(ajv, validate, dataPath);
+    return false;
+  }
+  console.log(`${dataPath} valid`);
+  return true;
+}
+
+function validateJsonLines(ajv, validate, dataPath) {
+  let text;
+  try {
+    text = fs.readFileSync(path.resolve(dataPath), "utf8");
+  } catch (error) {
+    console.error(`error: unable to read data: ${dataPath}`);
+    console.error(error instanceof Error ? error.message : String(error));
+    return false;
+  }
+
+  let records = 0;
+  const lines = text.split(/\r?\n/);
+  for (let index = 0; index < lines.length; index += 1) {
+    const raw = lines[index].trim();
+    if (!raw) {
+      continue;
+    }
+    records += 1;
+
+    let data;
+    try {
+      data = JSON.parse(raw);
+    } catch (error) {
+      console.error(`error: invalid JSON in data: ${dataPath}:${index + 1}`);
+      console.error(error instanceof Error ? error.message : String(error));
+      return false;
+    }
+
+    if (!validate(data)) {
+      printValidationErrors(ajv, validate, dataPath, index + 1);
+      return false;
+    }
+  }
+
+  if (records === 0) {
+    console.error(`error: no JSON records found in data: ${dataPath}`);
+    return false;
+  }
+  console.log(`${dataPath} valid (${records} JSONL records)`);
+  return true;
+}
+
+const options = parseArguments(process.argv.slice(2));
+const { ajv, validate } = createValidator(options);
+
+if (options.mode === "compile") {
+  console.log(`schema ${options.schema} is valid`);
+  process.exit(0);
+}
+
+const valid = options.data.endsWith(".jsonl")
+  ? validateJsonLines(ajv, validate, options.data)
+  : validateJsonFile(ajv, validate, options.data);
+process.exit(valid ? 0 : 1);

--- a/scripts/validate-contracts.sh
+++ b/scripts/validate-contracts.sh
@@ -1,12 +1,19 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+ROOT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)
+cd "$ROOT_DIR"
+
 if [[ ! -d contracts ]]; then
   echo "contracts directory not found – nothing to validate"
   exit 0
 fi
 if ! command -v npm > /dev/null 2>&1; then
   echo "::error::npm is required to validate contracts"
+  exit 1
+fi
+if ! command -v node > /dev/null 2>&1; then
+  echo "::error::node is required to validate contracts"
   exit 1
 fi
 
@@ -16,34 +23,49 @@ if ! command -v python3 > /dev/null 2>&1; then
 fi
 python3 scripts/check-contract-json.py contracts
 
-# --- Optimization: Setup local AJV ---
+# --- Setup direct AJV runtime ---
 echo "::group::Setup Validator"
 # Robust mktemp for Linux/macOS/BSD
 TMP_DIR=$(mktemp -d 2> /dev/null || mktemp -d -t 'ajv')
 trap 'rm -rf "$TMP_DIR"' EXIT
 
-echo "Installing ajv-cli@5 and ajv-formats..."
+AJV_VERSION=8.20.0
+AJV_FORMATS_VERSION=3.0.1
+AJV_MODULES="$TMP_DIR/node_modules"
+AJV_RUNNER="$ROOT_DIR/scripts/contracts/ajv_validate.cjs"
+AJV_PACKAGE_JSON="$ROOT_DIR/contracts/package.json"
+AJV_PACKAGE_LOCK="$ROOT_DIR/contracts/package-lock.json"
+
+for validator_input in "$AJV_RUNNER" "$AJV_PACKAGE_JSON" "$AJV_PACKAGE_LOCK"; do
+  if [[ ! -f "$validator_input" ]]; then
+    echo "::error::Required validator input not found at $validator_input"
+    exit 1
+  fi
+done
+
+echo "Installing lock-bound AJV runtime..."
+cp "$AJV_PACKAGE_JSON" "$TMP_DIR/package.json"
+cp "$AJV_PACKAGE_LOCK" "$TMP_DIR/package-lock.json"
 # --loglevel error suppresses warnings but keeps errors
 # --ignore-scripts prevents execution of malicious/unnecessary lifecycle scripts
 # --no-fund hides funding messages
-# --no-package-lock prevents lockfile generation (IO reduction)
-# Pinned versions: ajv-cli@5.0.0, ajv-formats@3.0.1 (ensure determinism)
-if ! npm install --prefix "$TMP_DIR" --no-save --no-audit --ignore-scripts --no-fund --no-package-lock --loglevel error ajv-cli@5.0.0 ajv-formats@3.0.1; then
-  echo "::error::Failed to install ajv-cli"
+if ! npm ci --prefix "$TMP_DIR" --no-audit --ignore-scripts --no-fund --loglevel error; then
+  echo "::error::Failed to install lock-bound AJV runtime"
   exit 1
 fi
 
-AJV="$TMP_DIR/node_modules/.bin/ajv"
-if [[ ! -x "$AJV" ]]; then
-  echo "::error::Validator binary not found or not executable at $AJV"
+actual_ajv=$(node -p 'require(process.argv[1]).version' "$AJV_MODULES/ajv/package.json")
+actual_formats=$(node -p 'require(process.argv[1]).version' "$AJV_MODULES/ajv-formats/package.json")
+if [[ "$actual_ajv" != "$AJV_VERSION" || "$actual_formats" != "$AJV_FORMATS_VERSION" ]]; then
+  echo "::error::Installed AJV runtime does not match pinned versions"
+  echo "Expected ajv=$AJV_VERSION ajv-formats=$AJV_FORMATS_VERSION"
+  echo "Found ajv=$actual_ajv ajv-formats=$actual_formats"
   exit 1
 fi
 
-echo "Validator installed at $AJV"
-# ajv-cli v5 does not support --version, so we list the package instead
-npm list --prefix "$TMP_DIR" ajv-cli --depth=0 || true
+echo "Direct validator ready: ajv=$actual_ajv ajv-formats=$actual_formats"
 echo "::endgroup::"
-# -------------------------------------
+# ----------------------------------
 
 shopt -s nullglob globstar 2> /dev/null || true
 
@@ -108,14 +130,13 @@ else
       fi
     done
 
-    # Construct args array
-    args=("--strict=log" "--spec=draft2020" "-c" "ajv-formats" "-s" "${schema}")
+    # Construct args array for the direct, pinned AJV runner.
+    args=("compile" "--modules" "$AJV_MODULES" "--strict" "log" "--schema" "${schema}")
     for r in "${refs[@]}"; do
-      args+=("-r" "$r")
+      args+=("--ref" "$r")
     done
 
-    # Optimized: use local AJV binary
-    if ! output=$("$AJV" compile "${args[@]}" 2>&1); then
+    if ! output=$(node "$AJV_RUNNER" "${args[@]}" 2>&1); then
       echo "::error::Validation failed for schema: ${schema}"
       echo "Command args: ${args[*]}"
       echo "$output"
@@ -231,13 +252,12 @@ else
         fi
       done
 
-      args=("--strict=false" "--spec=draft2020" "-c" "ajv-formats" "-s" "${schema}" "-d" "${example}")
+      args=("validate" "--modules" "$AJV_MODULES" "--strict" "false" "--schema" "${schema}" "--data" "${example}")
       for r in "${refs[@]}"; do
-        args+=("-r" "$r")
+        args+=("--ref" "$r")
       done
 
-      # Optimized call
-      "$AJV" validate "${args[@]}"
+      node "$AJV_RUNNER" "${args[@]}"
     else
       echo "::notice::No matching schema found for $example (searched contracts/**/${filename}.schema.json)"
     fi
@@ -287,13 +307,12 @@ if ((${#fixtures[@]} > 0)); then
         fi
       done
 
-      args=("--strict=log" "--spec=draft2020" "-c" "ajv-formats" "--errors=line" "--all-errors" "-s" "${schema}" "-d" "${fixture}")
+      args=("validate" "--modules" "$AJV_MODULES" "--strict" "log" "--all-errors" "--schema" "${schema}" "--data" "${fixture}")
       for r in "${refs[@]}"; do
-        args+=("-r" "$r")
+        args+=("--ref" "$r")
       done
 
-      # Optimized call
-      "$AJV" validate "${args[@]}"
+      node "$AJV_RUNNER" "${args[@]}"
     elif ((${#found[@]} > 1)); then
       echo "::error::Ambiguous schema match for ${fixture}. Found multiple candidates:"
       printf '  - %s\n' "${found[@]}"

--- a/tests/test_contract_validator_toolchain.py
+++ b/tests/test_contract_validator_toolchain.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import subprocess
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PACKAGE_JSON = ROOT / "contracts" / "package.json"
+PACKAGE_LOCK = ROOT / "contracts" / "package-lock.json"
+VALIDATE_SCRIPT = ROOT / "scripts" / "validate-contracts.sh"
+AJV_RUNNER = ROOT / "scripts" / "contracts" / "ajv_validate.cjs"
+
+EXPECTED_DEPENDENCIES = {
+    "ajv": "8.20.0",
+    "ajv-formats": "3.0.1",
+}
+FORBIDDEN_PACKAGES = {
+    "ajv-cli",
+    "brace-expansion",
+    "fast-json-patch",
+    "glob",
+    "inflight",
+    "json-schema-migrate",
+    "minimatch",
+}
+
+
+def _load_json(path: Path) -> dict[str, object]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _locked_package_names(lock: dict[str, object]) -> set[str]:
+    packages = lock.get("packages")
+    assert isinstance(packages, dict)
+
+    names: set[str] = set()
+    marker = "node_modules/"
+    for package_path in packages:
+        if not isinstance(package_path, str) or marker not in package_path:
+            continue
+        names.add(package_path.rsplit(marker, maxsplit=1)[1])
+    return names
+
+
+def test_contract_manifest_uses_direct_pinned_ajv_runtime() -> None:
+    package = _load_json(PACKAGE_JSON)
+
+    assert package["devDependencies"] == EXPECTED_DEPENDENCIES
+    assert package["scripts"] == {"validate": "bash ../scripts/validate-contracts.sh"}
+
+
+def test_contract_lock_excludes_legacy_cli_dependency_chain() -> None:
+    lock = _load_json(PACKAGE_LOCK)
+    root_package = lock["packages"][""]
+
+    assert root_package["devDependencies"] == EXPECTED_DEPENDENCIES
+    assert _locked_package_names(lock).isdisjoint(FORBIDDEN_PACKAGES)
+
+
+def test_contract_orchestrator_invokes_lock_bound_direct_runner() -> None:
+    script = VALIDATE_SCRIPT.read_text(encoding="utf-8")
+
+    assert "ajv-cli" not in script
+    assert "AJV_VERSION=8.20.0" in script
+    assert "AJV_FORMATS_VERSION=3.0.1" in script
+    assert 'AJV_RUNNER="$ROOT_DIR/scripts/contracts/ajv_validate.cjs"' in script
+    assert 'AJV_PACKAGE_LOCK="$ROOT_DIR/contracts/package-lock.json"' in script
+    assert "npm ci --prefix" in script
+    assert "npm install --prefix" not in script
+    assert 'node "$AJV_RUNNER"' in script
+
+
+def test_direct_ajv_runner_is_valid_javascript() -> None:
+    completed = subprocess.run(
+        ["node", "--check", str(AJV_RUNNER)],
+        cwd=ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+
+
+def test_direct_ajv_runner_fails_closed_without_pinned_modules(tmp_path: Path) -> None:
+    schema = tmp_path / "schema.json"
+    schema.write_text('{"$schema":"https://json-schema.org/draft/2020-12/schema"}', encoding="utf-8")
+
+    completed = subprocess.run(
+        [
+            "node",
+            str(AJV_RUNNER),
+            "compile",
+            "--modules",
+            str(tmp_path / "missing-node-modules"),
+            "--schema",
+            str(schema),
+        ],
+        cwd=ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode == 2
+    assert "unable to load pinned AJV modules" in completed.stderr

--- a/tests/test_dependency_security_locks.py
+++ b/tests/test_dependency_security_locks.py
@@ -49,10 +49,14 @@ def _pnpm_versions(lock_path: Path, package_name: str) -> set[str]:
 def _assert_patched_versions(
     lock_path: Path,
     floors: dict[str, tuple[int, int, int]],
+    *,
+    allow_absent: bool = False,
 ) -> None:
     for package_name, patched_floor in floors.items():
         versions = _npm_versions(lock_path, package_name)
-        assert versions, f"{package_name} missing from {lock_path}"
+        if not versions:
+            assert allow_absent, f"{package_name} missing from {lock_path}"
+            continue
         assert all(_version_tuple(version) >= patched_floor for version in versions), (
             package_name,
             versions,
@@ -61,7 +65,11 @@ def _assert_patched_versions(
 
 
 def test_contracts_lock_excludes_selected_high_severity_ranges() -> None:
-    _assert_patched_versions(CONTRACTS_LOCK, CONTRACTS_PATCHED_FLOORS)
+    _assert_patched_versions(
+        CONTRACTS_LOCK,
+        CONTRACTS_PATCHED_FLOORS,
+        allow_absent=True,
+    )
 
 
 def test_local_mcp_npm_lock_excludes_selected_high_severity_ranges() -> None:


### PR DESCRIPTION
## Summary
- remove `ajv-cli` and its vulnerable legacy dependency chain
- validate schemas, examples and JSONL fixtures through a direct AJV 8 runner
- install the temporary validator exactly from the audited Contracts lockfile
- preserve existing discovery, strictness and consumer-registry checks

## Validation
- `just validate`: 191 tests passed
- `just contracts-validate`: 93 schemas and all matched examples passed
- focused security/toolchain tests: 9 passed
- Contracts npm audit: 0 findings