### PR TITLE
Fix Renovate runtime npx resolution

### DIFF
--- a/automation/renovate/run-fleet.sh
+++ b/automation/renovate/run-fleet.sh
@@ -4,13 +4,14 @@ set -euo pipefail
 RENOVATE_VERSION="42.99.0"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CONFIG_FILE="${SCRIPT_DIR}/runtime-config.cjs"
+NPX_BIN="${RENOVATE_NPX_BIN:-/usr/bin/npx}"
 
 command -v gh > /dev/null 2>&1 || {
   echo "gh is required" >&2
   exit 2
 }
-command -v npx > /dev/null 2>&1 || {
-  echo "npx is required" >&2
+[[ "${NPX_BIN}" == /* && -x "${NPX_BIN}" ]] || {
+  echo "RENOVATE_NPX_BIN must name an executable absolute path: ${NPX_BIN}" >&2
   exit 2
 }
 [[ -f "${CONFIG_FILE}" ]] || {
@@ -28,4 +29,4 @@ export RENOVATE_TOKEN="${TOKEN}"
 export RENOVATE_CONFIG_FILE="${CONFIG_FILE}"
 unset TOKEN
 
-exec npx --yes "renovate@${RENOVATE_VERSION}" "$@"
+exec "${NPX_BIN}" --yes "renovate@${RENOVATE_VERSION}" "$@"

--- a/tests/test_renovate_runtime.py
+++ b/tests/test_renovate_runtime.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import os
+import stat
+import subprocess
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+RUNNER = ROOT / "automation" / "renovate" / "run-fleet.sh"
+RUNTIME_CONFIG = ROOT / "automation" / "renovate" / "runtime-config.cjs"
+
+
+def _write_executable(path: Path, content: str) -> None:
+    path.write_text(content, encoding="utf-8")
+    path.chmod(path.stat().st_mode | stat.S_IXUSR)
+
+
+def test_runner_defaults_to_system_npx_and_forwards_runtime_contract(tmp_path: Path) -> None:
+    runner_text = RUNNER.read_text(encoding="utf-8")
+    assert 'NPX_BIN="${RENOVATE_NPX_BIN:-/usr/bin/npx}"' in runner_text
+    assert 'exec "${NPX_BIN}" --yes "renovate@${RENOVATE_VERSION}" "$@"' in runner_text
+
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    capture = tmp_path / "capture"
+    capture.mkdir()
+    fake_gh = fake_bin / "gh"
+    fake_npx = fake_bin / "npx-direct"
+
+    _write_executable(
+        fake_gh,
+        "#!/usr/bin/env bash\n"
+        "set -euo pipefail\n"
+        "[[ \"$*\" == \"auth token\" ]]\n"
+        "printf '%s\\n' 'test-token'\n",
+    )
+    _write_executable(
+        fake_npx,
+        "#!/usr/bin/env bash\n"
+        "set -euo pipefail\n"
+        "printf '%s\\n' \"${RENOVATE_TOKEN}\" > \"${CAPTURE_DIR}/token\"\n"
+        "printf '%s\\n' \"${RENOVATE_CONFIG_FILE}\" > \"${CAPTURE_DIR}/config\"\n"
+        "printf '%s\\n' \"$@\" > \"${CAPTURE_DIR}/args\"\n",
+    )
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "PATH": f"{fake_bin}:{env['PATH']}",
+            "RENOVATE_NPX_BIN": str(fake_npx),
+            "CAPTURE_DIR": str(capture),
+        }
+    )
+    subprocess.run(
+        [str(RUNNER), "--dry-run=lookup"],
+        check=True,
+        cwd=ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+    )
+
+    assert (capture / "token").read_text(encoding="utf-8") == "test-token\n"
+    assert (capture / "config").read_text(encoding="utf-8") == f"{RUNTIME_CONFIG}\n"
+    assert (capture / "args").read_text(encoding="utf-8").splitlines() == [
+        "--yes",
+        "renovate@42.99.0",
+        "--dry-run=lookup",
+    ]
+
+
+def test_runner_rejects_path_resolved_npx_override() -> None:
+    completed = subprocess.run(
+        [str(RUNNER), "--dry-run=lookup"],
+        cwd=ROOT,
+        env={**os.environ, "RENOVATE_NPX_BIN": "npx"},
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert completed.returncode == 2
+    assert "must name an executable absolute path" in completed.stderr


### PR DESCRIPTION
## Problem

The first self-hosted fleet write run created the expected 35 unmerged `renovate/*` pull requests, then remained in the Node event loop without CPU or network progress. The user service resolves `%h/.local/bin/npx`, which starts another user-systemd wrapper and withholds durable output and terminal completion.

## Change

- bind the fleet launcher to `/usr/bin/npx` by default
- permit only executable absolute-path overrides through `RENOVATE_NPX_BIN`
- preserve the service PATH for Renovate child package managers
- add focused regression coverage for token/config/argv forwarding and fail-closed relative overrides

## Validation

- `python3 -m pytest -q tests/test_renovate_runtime.py tests/test_renovate_policy.py` — 11 passed
- `shellcheck automation/renovate/run-fleet.sh` — passed
- `just validate` — 193 tests passed plus YAML, shell and actionlint validation

## Live evidence

- dry-run lookup: 18/18 repositories completed successfully
- first write pass: 35 open PRs, at most two per repository, all on `renovate/*` branches
- GitHub auto-merge requests: 0
- hung post-effect service was stopped explicitly; timer remains disabled pending deployment and a terminal rerun