### PR TITLE
fix(ci): make reusable Just setup caller-independent

### DIFF
--- a/.github/workflows/reusable-ci.yml
+++ b/.github/workflows/reusable-ci.yml
@@ -21,6 +21,11 @@ defaults:
         required: false
         default: true
         type: boolean
+      just_version:
+        description: "Exact Just version for callers without a repository-local pin"
+        required: false
+        default: "1.43.0"
+        type: string
 
 jobs:
   reusable-ci:
@@ -30,11 +35,28 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
 
-      - name: Setup Just
+      - name: Setup Just from caller repository pin
+        if: ${{ hashFiles('scripts/tools/just-pin.sh') != '' && hashFiles('scripts/lib/semver.sh') != '' && hashFiles('scripts/lib/installer.bash') != '' && hashFiles('toolchain.versions.yml') != '' }}
         run: |
           chmod +x scripts/tools/just-pin.sh
           scripts/tools/just-pin.sh ensure
           echo "${PWD}/tools/bin" >> "$GITHUB_PATH"
+
+      - name: Verify preinstalled Just in Agent Mode
+        if: ${{ !(hashFiles('scripts/tools/just-pin.sh') != '' && hashFiles('scripts/lib/semver.sh') != '' && hashFiles('scripts/lib/installer.bash') != '' && hashFiles('toolchain.versions.yml') != '') && env.AGENT_MODE != '' }}
+        run: |
+          command -v just >/dev/null
+          actual_version="$(just --version | awk '{print $2}')"
+          test "$actual_version" = "${{ inputs.just_version }}" || {
+            echo "::error::Just version mismatch: expected ${{ inputs.just_version }}, got $actual_version"
+            exit 1
+          }
+
+      - name: Setup Just fallback
+        if: ${{ !(hashFiles('scripts/tools/just-pin.sh') != '' && hashFiles('scripts/lib/semver.sh') != '' && hashFiles('scripts/lib/installer.bash') != '' && hashFiles('toolchain.versions.yml') != '') && env.AGENT_MODE == '' }}
+        uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3  # v4.0.0
+        with:
+          just-version: ${{ inputs.just_version }}
 
       - name: Install Dependencies (optional)
         if: ${{ env.AGENT_MODE == '' }}

--- a/tests/test_reusable_ci_contract.py
+++ b/tests/test_reusable_ci_contract.py
@@ -1,0 +1,90 @@
+from copy import deepcopy
+from pathlib import Path
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / ".github" / "workflows" / "reusable-ci.yml"
+LOCAL_PIN_CONDITION = (
+    "${{ hashFiles('scripts/tools/just-pin.sh') != '' "
+    "&& hashFiles('scripts/lib/semver.sh') != '' "
+    "&& hashFiles('scripts/lib/installer.bash') != '' "
+    "&& hashFiles('toolchain.versions.yml') != '' }}"
+)
+MISSING_PIN_STACK = (
+    "!(hashFiles('scripts/tools/just-pin.sh') != '' "
+    "&& hashFiles('scripts/lib/semver.sh') != '' "
+    "&& hashFiles('scripts/lib/installer.bash') != '' "
+    "&& hashFiles('toolchain.versions.yml') != '')"
+)
+AGENT_FALLBACK_CONDITION = f"${{{{ {MISSING_PIN_STACK} && env.AGENT_MODE != '' }}}}"
+NETWORK_FALLBACK_CONDITION = f"${{{{ {MISSING_PIN_STACK} && env.AGENT_MODE == '' }}}}"
+SETUP_JUST_SHA = "53165ef7e734c5c07cb06b3c8e7b647c5aa16db3"
+
+
+def _document() -> dict:
+    return yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+
+
+def _steps(document: dict) -> dict[str, dict]:
+    steps = document["jobs"]["reusable-ci"]["steps"]
+    return {step["name"]: step for step in steps if "name" in step}
+
+
+def _portability_errors(document: dict) -> list[str]:
+    errors: list[str] = []
+    inputs = document["on"]["workflow_call"]["inputs"]
+    steps = _steps(document)
+    local = steps.get("Setup Just from caller repository pin")
+    agent = steps.get("Verify preinstalled Just in Agent Mode")
+    fallback = steps.get("Setup Just fallback")
+
+    if inputs.get("just_version", {}).get("default") != "1.43.0":
+        errors.append("missing exact default Just version")
+    if local is None or local.get("if") != LOCAL_PIN_CONDITION:
+        errors.append("repository-local installer is not presence-guarded")
+    if agent is None or agent.get("if") != AGENT_FALLBACK_CONDITION:
+        errors.append("Agent Mode lacks a no-download fallback")
+    if fallback is None or fallback.get("if") != NETWORK_FALLBACK_CONDITION:
+        errors.append("callers without installer lack a network fallback")
+    expected_action = f"extractions/setup-just@{SETUP_JUST_SHA}"
+    if fallback is None or fallback.get("uses") != expected_action:
+        errors.append("fallback action is not revision-pinned")
+    if fallback is None or fallback.get("with", {}).get("just-version") != "${{ inputs.just_version }}":
+        errors.append("fallback does not consume the exact version input")
+    return errors
+
+
+def test_reusable_ci_is_caller_independent_and_revision_pinned() -> None:
+    assert _portability_errors(_document()) == []
+
+
+def test_unconditional_caller_local_installer_regression_is_rejected() -> None:
+    document = deepcopy(_document())
+    steps = document["jobs"]["reusable-ci"]["steps"]
+    steps[:] = [
+        step
+        for step in steps
+        if step.get("name")
+        not in {"Verify preinstalled Just in Agent Mode", "Setup Just fallback"}
+    ]
+    local = next(
+        step
+        for step in steps
+        if step.get("name") == "Setup Just from caller repository pin"
+    )
+    local.pop("if")
+
+    errors = _portability_errors(document)
+    assert "repository-local installer is not presence-guarded" in errors
+    assert "callers without installer lack a network fallback" in errors
+
+
+def test_partial_repository_pin_stack_uses_fallback() -> None:
+    document = deepcopy(_document())
+    local = _steps(document)["Setup Just from caller repository pin"]
+    local["if"] = "${{ hashFiles('scripts/tools/just-pin.sh') != '' }}"
+
+    errors = _portability_errors(document)
+    assert "repository-local installer is not presence-guarded" in errors


### PR DESCRIPTION
## Ursache

Der zentrale `reusable-ci`-Workflow führt derzeit bedingungslos `scripts/tools/just-pin.sh ensure` im ausgecheckten Caller-Repository aus. Caller wie `heimgewebe/mitschreiber` besitzen diesen Metarepo-internen Installer-Stack nicht; dadurch scheitert unter anderem Mitschreiber PR #86 vor den eigentlichen Prüfungen.

## Änderung

- Nutzt den lokalen Pin-Stack nur, wenn `just-pin.sh`, beide Bibliotheken und `toolchain.versions.yml` vollständig vorhanden sind.
- Prüft in Agent Mode eine bereits installierte, exakt passende Just-Version ohne Download.
- Nutzt sonst `extractions/setup-just` revisionsgepinnt auf `53165ef7e734c5c07cb06b3c8e7b647c5aa16db3` (v4.0.0).
- Fügt einen exakten `just_version`-Input mit Default `1.43.0` hinzu.
- Ergänzt positive und negative Vertragstests, einschließlich eines unvollständigen lokalen Pin-Stacks.

## Validierung

- `actionlint -no-color .github/workflows/reusable-ci.yml`
- vollständige Python-Suite: `196 passed`
- `git diff --check`
- revisionsgebundener Self-Review: PASS
- Head: `2b6c06606fe80239af5a29db35879eb2679ec37b`
- Diff-SHA-256: `60739e9456e88aa70b42590e6baa2438ed61db1ff9a657dfb43161c9219b9a4a`

## Abbruchgrenze

Kein Merge bei verändertem Head, offenen Reviewbefunden, roter Pflicht-CI oder fehlender Mergebarkeit.