### PR TITLE
Own repository verification contract in Metarepo

### DIFF
--- a/.github/workflows/reusable-repo-verify.yml
+++ b/.github/workflows/reusable-repo-verify.yml
@@ -1,0 +1,100 @@
+---
+name: Reusable repository verification
+
+"on":
+  workflow_call:
+    inputs:
+      mode:
+        description: "Verification mode: guard, smoke, quick, or full."
+        required: false
+        type: string
+        default: guard
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout target repository
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
+        with:
+          persist-credentials: false
+
+      - name: Checkout pinned verification runner
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
+        with:
+          repository: heimgewebe/wgx
+          ref: 03da8c71fa5bb30827a1a8e91e2a48bacaf3140c
+          path: .repo-verification-runner
+          persist-credentials: false
+
+      - name: Setup Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
+        with:
+          python-version: "3.12"
+
+      - name: Validate profile contract through pinned runner
+        shell: bash
+        run: |
+          set -euo pipefail
+          chmod +x .repo-verification-runner/wgx .repo-verification-runner/cli/wgx
+          .repo-verification-runner/wgx validate
+
+      - name: Execute repository-owned verification front door
+        shell: bash
+        env:
+          VERIFY_MODE: ${{ inputs.mode }}
+        run: |
+          set -euo pipefail
+          runner="$GITHUB_WORKSPACE/.repo-verification-runner/wgx"
+          export WGX_TARGET_ROOT="$GITHUB_WORKSPACE"
+
+          case "$VERIFY_MODE" in
+            guard|smoke)
+              tasks_json="$($runner tasks --json)"
+              has_task() {
+                TASKS_JSON="$tasks_json" TASK_NAME="$1" python3 - <<'PY'
+          import json
+          import os
+
+          payload = json.loads(os.environ["TASKS_JSON"])
+          wanted = os.environ["TASK_NAME"]
+          raise SystemExit(
+              0
+              if any(
+                  isinstance(item, dict) and item.get("name") == wanted
+                  for item in payload.get("tasks", [])
+              )
+              else 1
+          )
+          PY
+              }
+
+              if [[ "$VERIFY_MODE" == "guard" ]]; then
+                if has_task guard; then
+                  "$runner" task guard
+                elif has_task smoke; then
+                  echo "::notice::guard task absent; using declared smoke fallback"
+                  "$runner" task smoke
+                else
+                  echo "::error::repository declares neither guard nor smoke task"
+                  exit 2
+                fi
+              elif has_task smoke; then
+                "$runner" task smoke
+              else
+                echo "::error::repository does not declare required smoke task"
+                exit 2
+              fi
+              ;;
+            quick|full)
+              "$runner" validate --profile "$VERIFY_MODE" --json
+              ;;
+            *)
+              echo "::error::unsupported repository verification mode: $VERIFY_MODE"
+              exit 2
+              ;;
+          esac

--- a/.github/workflows/reusable-repo-verify.yml
+++ b/.github/workflows/reusable-repo-verify.yml
@@ -36,6 +36,21 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Install hash-bound profile parser dependency
+        shell: bash
+        run: |
+          set -euo pipefail
+          requirements_file="${RUNNER_TEMP}/repo-verification-requirements.txt"
+          cat >"$requirements_file" <<'EOF'
+          PyYAML==6.0.3 \
+            --hash=sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc
+          EOF
+          python3 -m pip install \
+            --disable-pip-version-check \
+            --only-binary=:all: \
+            --require-hashes \
+            --requirement "$requirements_file"
+
       - name: Validate profile contract through pinned runner
         shell: bash
         run: |

--- a/.github/workflows/wgx-guard.yml
+++ b/.github/workflows/wgx-guard.yml
@@ -13,7 +13,6 @@ permissions:
 
 jobs:
   guard:
-    # metarepo wird selbst wie ein Fleet-Repo behandelt und nutzt
-    # die kanonische Guard-Definition aus heimgewebe/wgx.
-    # Gepinnt auf Commit SHA für Sicherheit und Reproduzierbarkeit.
-    uses: heimgewebe/wgx/.github/workflows/wgx-guard.yml@a1c1cc6daf07cf23ade1d3e02ae5551fcf6641e2
+    uses: ./.github/workflows/reusable-repo-verify.yml
+    with:
+      mode: guard

--- a/.github/workflows/wgx-smoke.yml
+++ b/.github/workflows/wgx-smoke.yml
@@ -13,9 +13,6 @@ permissions:
 
 jobs:
   smoke:
-    # auch Smoke für das metarepo selbst wird über heimgewebe/wgx
-    # zentral definiert.
-    # Gepinnt auf Commit SHA für Sicherheit und Reproduzierbarkeit.
-    # Gepinnt auf den verifizierten WGX-Merge mit wiederverwendbarem Smoke
-    # und dauerhaft gebundenem Parser-/Security-Prerequisite.
-    uses: heimgewebe/wgx/.github/workflows/wgx-smoke.yml@a1c1cc6daf07cf23ade1d3e02ae5551fcf6641e2
+    uses: ./.github/workflows/reusable-repo-verify.yml
+    with:
+      mode: smoke

--- a/.wgx/profile.yml
+++ b/.wgx/profile.yml
@@ -30,28 +30,11 @@ wgx:
       echo "All workflows valid."
 
     guard: |
-      echo "Running meta-guard checks..."
-      if [ -x "wgx/guards/decision-preimage.bash" ]; then
-        echo "Running decision-preimage guard (warn-only)..."
-        ./wgx/guards/decision-preimage.bash || true
-      else
-        echo "decision-preimage guard not found; skipping."
-      fi
-
-      if command -v shellcheck >/dev/null 2>&1; then
-        echo "Running shellcheck on wgx/**/*.bash..."
-        shellcheck -s bash wgx/**/*.bash || exit 1
-      else
-        echo "shellcheck not found; skipping shell lint."
-      fi
-
-      if command -v yamllint >/dev/null 2>&1; then
-        echo "Running yamllint..."
-        yamllint . || exit 1
-      else
-        echo "yamllint not found; skipping YAML lint."
-      fi
-
+      set -euo pipefail
+      echo "Running deterministic Metarepo verification guard..."
+      python3 scripts/ci/check_wgx_reusable_callers.py
+      bash scripts/check-contracts-index.sh
+      git diff --check
       echo "Guard OK."
 
     metrics: |

--- a/.wgx/profile.yml
+++ b/.wgx/profile.yml
@@ -1,60 +1,65 @@
 ---
-class: meta
+wgx:
+  apiVersion: v1
+  requiredWgx: "^2.0"
+  repoKind: meta
+  validate:
+    quick:
+      - smoke
+    full:
+      - guard
+      - smoke
+    ciOnly:
+      metrics: "generated only by the dedicated metrics workflow"
+      snapshot: "no repository snapshot command is defined"
+  tasks:
+    smoke: |
+      echo "Running workflow validation..."
+      for f in .github/workflows/*.yml; do
+        [ -e "$f" ] || continue
+        if ! kind=$(yq eval 'kind' "$f" 2>/dev/null); then
+           echo "FAIL $f (invalid YAML)"
+           exit 1
+        fi
+        if [[ "$kind" != "map" && "$kind" != "!!map" ]]; then
+          echo "FAIL $f (root is not a map, got $kind)"
+          exit 1
+        fi
+        echo "OK   $f"
+      done
+      echo "All workflows valid."
 
-tasks:
-  smoke: |
-    echo "Running workflow validation..."
-    # Use yq for robust YAML check
-    for f in .github/workflows/*.yml; do
-      [ -e "$f" ] || continue
-      if ! kind=$(yq eval 'kind' "$f" 2>/dev/null); then
-         echo "FAIL $f (invalid YAML)"
-         exit 1
+    guard: |
+      echo "Running meta-guard checks..."
+      if [ -x "wgx/guards/decision-preimage.bash" ]; then
+        echo "Running decision-preimage guard (warn-only)..."
+        ./wgx/guards/decision-preimage.bash || true
+      else
+        echo "decision-preimage guard not found; skipping."
       fi
-      if [[ "$kind" != "map" && "$kind" != "!!map" ]]; then
-         echo "FAIL $f (root is not a map, got $kind)"
-         exit 1
+
+      if command -v shellcheck >/dev/null 2>&1; then
+        echo "Running shellcheck on wgx/**/*.bash..."
+        shellcheck -s bash wgx/**/*.bash || exit 1
+      else
+        echo "shellcheck not found; skipping shell lint."
       fi
-      echo "OK   $f"
-    done
-    echo "All workflows valid."
 
-  guard: |
-    echo "Running meta-guard checks..."
+      if command -v yamllint >/dev/null 2>&1; then
+        echo "Running yamllint..."
+        yamllint . || exit 1
+      else
+        echo "yamllint not found; skipping YAML lint."
+      fi
 
-    # decision.preimage visibility guard (warn-only)
-    # - checks for policy.decision JSON objects missing preimage_ref
-    # - does NOT fail the build (yet)
-    if [ -x "wgx/guards/decision-preimage.bash" ]; then
-      echo "Running decision-preimage guard (warn-only)..."
-      ./wgx/guards/decision-preimage.bash || true
-    else
-      echo "decision-preimage guard not found; skipping."
-    fi
+      echo "Guard OK."
 
-    if command -v shellcheck >/dev/null 2>&1; then
-      echo "Running shellcheck on wgx/**/*.bash..."
-      # bewusst fokussiert auf WGX-Bash-Module; bei Bedarf erweiterbar
-      shellcheck -s bash wgx/**/*.bash || exit 1
-    else
-      echo "shellcheck not found; skipping shell lint."
-    fi
+    metrics: |
+      if [ -x scripts/wgx-metrics-snapshot.sh ]; then
+        scripts/wgx-metrics-snapshot.sh --json
+      else
+        echo "No metrics script for metarepo, skipping."
+      fi
 
-    if command -v yamllint >/dev/null 2>&1; then
-      echo "Running yamllint..."
-      yamllint . || exit 1
-    else
-      echo "yamllint not found; skipping YAML lint."
-    fi
-
-    echo "Guard OK."
-
-  metrics: |
-    if [ -x scripts/wgx-metrics-snapshot.sh ]; then
-      scripts/wgx-metrics-snapshot.sh --json
-    else
-      echo "No metrics script for metarepo, skipping."
-    fi
-
-  snapshot: |
-    # no snapshot command defined
+    snapshot: |
+      echo "No snapshot command defined."

--- a/contracts/examples/repository-verification.v2.example.json
+++ b/contracts/examples/repository-verification.v2.example.json
@@ -1,0 +1,15 @@
+{
+  "wgx": {
+    "apiVersion": "v1",
+    "requiredWgx": "^2.0",
+    "repoKind": "generic",
+    "validate": {
+      "quick": ["smoke"],
+      "full": ["guard", "smoke"]
+    },
+    "tasks": {
+      "guard": "git diff --check",
+      "smoke": "git rev-parse --is-inside-work-tree >/dev/null"
+    }
+  }
+}

--- a/contracts/repository-verification.v2.schema.json
+++ b/contracts/repository-verification.v2.schema.json
@@ -1,0 +1,80 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.heimgewebe.org/contracts/repository-verification.v2.schema.json",
+  "title": "Heimgewebe repository verification profile v2",
+  "description": "Canonical fleet contract for repository-owned verification front doors. The v2 ownership contract deliberately remains transport-compatible with the existing WGX apiVersion v1 profile while consumers migrate away from WGX-owned policy.",
+  "x-producers": ["metarepo"],
+  "x-consumers": ["wgx", "github-actions", "grabowski"],
+  "type": "object",
+  "required": ["wgx"],
+  "properties": {
+    "wgx": {
+      "type": "object",
+      "required": ["apiVersion", "tasks"],
+      "properties": {
+        "apiVersion": {"const": "v1"},
+        "requiredWgx": {"type": "string", "minLength": 1},
+        "repoKind": {"type": "string", "minLength": 1},
+        "tasks": {"$ref": "#/$defs/tasks"},
+        "validate": {"$ref": "#/$defs/validationProfiles"}
+      },
+      "additionalProperties": true
+    }
+  },
+  "additionalProperties": true,
+  "$defs": {
+    "taskName": {"type": "string", "pattern": "^[A-Za-z0-9][A-Za-z0-9_.-]*$"},
+    "command": {
+      "oneOf": [
+        {"type": "string", "minLength": 1},
+        {"type": "array", "minItems": 1, "items": {"type": "string"}}
+      ]
+    },
+    "task": {
+      "oneOf": [
+        {"$ref": "#/$defs/command"},
+        {
+          "type": "object",
+          "properties": {
+            "cmd": {"$ref": "#/$defs/command"},
+            "sh": {"$ref": "#/$defs/command"},
+            "desc": {"type": "string"},
+            "safe": {"type": "boolean"},
+            "group": {"type": "string"}
+          },
+          "anyOf": [
+            {"properties": {"cmd": {}}, "required": ["cmd"]},
+            {"properties": {"sh": {}}, "required": ["sh"]}
+          ],
+          "additionalProperties": true
+        }
+      ]
+    },
+    "tasks": {
+      "type": "object",
+      "minProperties": 1,
+      "propertyNames": {"$ref": "#/$defs/taskName"},
+      "additionalProperties": {"$ref": "#/$defs/task"}
+    },
+    "taskList": {
+      "type": "array",
+      "items": {"$ref": "#/$defs/taskName"},
+      "uniqueItems": true
+    },
+    "skipReasons": {
+      "type": "object",
+      "propertyNames": {"$ref": "#/$defs/taskName"},
+      "additionalProperties": {"type": "string", "minLength": 1}
+    },
+    "validationProfiles": {
+      "type": "object",
+      "properties": {
+        "quick": {"$ref": "#/$defs/taskList"},
+        "full": {"$ref": "#/$defs/taskList"},
+        "unsupported": {"$ref": "#/$defs/skipReasons"},
+        "ciOnly": {"$ref": "#/$defs/skipReasons"}
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/docs/contracts/contracts-index.md
+++ b/docs/contracts/contracts-index.md
@@ -157,6 +157,10 @@ Sie liegen (sofern nicht anders angegeben) in `contracts/*.schema.json` im **met
   - Zweck: Beschreibung von Workflows / Pipelines, die ein Agent ausführen kann.
 - `dev.tooling.schema.json`
   - Zweck: Struktur für Dev-Tooling-Informationen (z. B. Toolchain-Definitionen, Checks).
+- `repository-verification.v2.schema.json`
+  - Zweck: Kanonischer Fleet-Vertrag für repository-eigene Verifikations-Frontdoors und `quick`/`full`-Profile.
+  - Produzent/Eigentümer: metarepo.
+  - Aktuelle Implementierung: WGX bleibt während des v2-Cutovers ein revisionsgepinnter Kompatibilitätsrunner; der Contract überträgt WGX keine Fleet-, Task-, Git- oder Host-Autorität.
 - `tooling/toolchain.versions.schema.json`
   - Zweck: Canonical schema für `toolchain.versions.yml`, definiert required keys und Versionsformate.
 

--- a/scripts/ci/check_wgx_reusable_callers.py
+++ b/scripts/ci/check_wgx_reusable_callers.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Validate the pinned metarepo callers for reusable WGX workflows."""
+"""Validate Metarepo ownership of repository-verification workflow callers."""
 
 from __future__ import annotations
 
@@ -7,42 +7,42 @@ import sys
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
-WGX_GUARD_MERGE = "a1c1cc6daf07cf23ade1d3e02ae5551fcf6641e2"
-VERIFIED_WGX_SMOKE_MERGE = "a1c1cc6daf07cf23ade1d3e02ae5551fcf6641e2"
+WGX_RUNNER_REF = "03da8c71fa5bb30827a1a8e91e2a48bacaf3140c"
+LOCAL_REUSABLE = "uses: ./.github/workflows/reusable-repo-verify.yml"
 
 
 def check_callers(root: Path = ROOT) -> list[str]:
     findings: list[str] = []
-    guard_path = root / ".github" / "workflows" / "wgx-guard.yml"
-    smoke_path = root / ".github" / "workflows" / "wgx-smoke.yml"
+    workflows = root / ".github" / "workflows"
+    guard_path = workflows / "wgx-guard.yml"
+    smoke_path = workflows / "wgx-smoke.yml"
+    reusable_path = workflows / "reusable-repo-verify.yml"
 
-    if not guard_path.is_file():
-        findings.append(f"workflow not found: {guard_path}")
-    else:
-        guard = guard_path.read_text(encoding="utf-8")
-        expected = (
-            "uses: heimgewebe/wgx/.github/workflows/wgx-guard.yml@"
-            f"{WGX_GUARD_MERGE}"
-        )
-        if expected not in guard:
-            findings.append("wgx-guard caller is not bound to the verified WGX merge")
-        if "toolchain: stable" in guard:
-            findings.append("wgx-guard caller passes undeclared input toolchain")
+    for path, mode in ((guard_path, "guard"), (smoke_path, "smoke")):
+        if not path.is_file():
+            findings.append(f"workflow not found: {path}")
+            continue
+        text = path.read_text(encoding="utf-8")
+        if LOCAL_REUSABLE not in text:
+            findings.append(f"{path.name} does not route through Metarepo reusable verification")
+        if f"mode: {mode}" not in text:
+            findings.append(f"{path.name} does not bind verification mode {mode}")
+        if "heimgewebe/wgx/.github/workflows/" in text:
+            findings.append(f"{path.name} still delegates workflow ownership to WGX")
 
-    if not smoke_path.is_file():
-        findings.append(f"workflow not found: {smoke_path}")
+    if not reusable_path.is_file():
+        findings.append(f"workflow not found: {reusable_path}")
     else:
-        smoke = smoke_path.read_text(encoding="utf-8")
-        expected = (
-            "uses: heimgewebe/wgx/.github/workflows/wgx-smoke.yml@"
-            f"{VERIFIED_WGX_SMOKE_MERGE}"
-        )
-        if expected not in smoke:
-            findings.append("wgx-smoke caller is not bound to the verified reusable smoke merge")
-        if "toolchain: stable" in smoke:
-            findings.append("wgx-smoke caller passes undeclared input toolchain")
-        if "verifizierten WGX-Merge mit wiederverwendbarem Smoke" not in smoke:
-            findings.append("wgx-smoke caller does not document its verified contract boundary")
+        reusable = reusable_path.read_text(encoding="utf-8")
+        if "repository: heimgewebe/wgx" not in reusable:
+            findings.append("reusable verification does not declare the compatibility runner")
+        if f"ref: {WGX_RUNNER_REF}" not in reusable:
+            findings.append("reusable verification runner is not revision-bound")
+        if "heimgewebe/wgx/.github/workflows/" in reusable:
+            findings.append("reusable verification delegates policy back to WGX workflows")
+        for mode in ("guard", "smoke", "quick", "full"):
+            if mode not in reusable:
+                findings.append(f"reusable verification does not expose mode {mode}")
 
     return findings
 
@@ -53,7 +53,7 @@ def main() -> int:
         for finding in findings:
             print(f"FAIL: {finding}", file=sys.stderr)
         return 1
-    print("PASS: WGX reusable callers match their declared contracts")
+    print("PASS: Metarepo owns repository-verification workflow routing")
     return 0
 
 

--- a/templates/.wgx/profile.yml
+++ b/templates/.wgx/profile.yml
@@ -1,26 +1,17 @@
 ---
-version: 1
-# Hinweis: Repo-spezifische Overlays optional unter .wgx/profile.overlay.yml
-project: metarepo
-roles:
-  - name: meta
-    provides:
-      - templates
-      - wgx-commands
-env_priority:
-  - devcontainer
-  - devbox
-  - mise/direnv
-  - termux
-sync:
-  include:
-    - ".github/workflows/*.yml"
-    - "Justfile"
-    - "docs/**"
-    - ".wgx/profile.yml"
-rules:
-  reconcile:
-    prefer: canonical
-    exceptions:
-      - pattern: "docs/adrs/**"
-        prefer: improved_field_version
+# Canonical executable starter for the repository-verification contract.
+# Repositories should replace the two generic Git checks with their native
+# guard/smoke front doors; Metarepo owns the shape, not repository semantics.
+wgx:
+  apiVersion: v1
+  requiredWgx: "^2.0"
+  repoKind: generic
+  validate:
+    quick:
+      - smoke
+    full:
+      - guard
+      - smoke
+  tasks:
+    guard: "git diff --check"
+    smoke: "git rev-parse --is-inside-work-tree >/dev/null"

--- a/tests/test_repository_verification_contract.py
+++ b/tests/test_repository_verification_contract.py
@@ -38,6 +38,17 @@ def test_active_and_template_profiles_match_contract() -> None:
         assert "smoke" in tasks
 
 
+def test_metarepo_guard_is_deterministic_and_repo_owned() -> None:
+    payload = yaml.safe_load((ROOT / ".wgx" / "profile.yml").read_text(encoding="utf-8"))
+    guard = payload["wgx"]["tasks"]["guard"]
+    assert "scripts/ci/check_wgx_reusable_callers.py" in guard
+    assert "scripts/check-contracts-index.sh" in guard
+    assert "git diff --check" in guard
+    assert "command -v" not in guard
+    assert "yamllint ." not in guard
+    assert ".repo-verification-runner" not in guard
+
+
 def test_reusable_workflow_is_policy_owner_not_wgx_workflow_proxy() -> None:
     workflow = (ROOT / ".github" / "workflows" / "reusable-repo-verify.yml").read_text(
         encoding="utf-8"

--- a/tests/test_repository_verification_contract.py
+++ b/tests/test_repository_verification_contract.py
@@ -1,0 +1,48 @@
+import json
+from pathlib import Path
+
+import yaml
+from jsonschema import Draft202012Validator
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA_PATH = ROOT / "contracts" / "repository-verification.v2.schema.json"
+
+
+def _schema() -> dict:
+    return json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+
+
+def test_contract_has_metarepo_authority_and_current_consumers() -> None:
+    schema = _schema()
+    assert schema["x-producers"] == ["metarepo"]
+    assert {"wgx", "github-actions", "grabowski"} <= set(schema["x-consumers"])
+    Draft202012Validator.check_schema(schema)
+
+
+def test_versioned_example_matches_contract() -> None:
+    payload = json.loads(
+        (ROOT / "contracts" / "examples" / "repository-verification.v2.example.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    Draft202012Validator(_schema()).validate(payload)
+
+
+def test_active_and_template_profiles_match_contract() -> None:
+    validator = Draft202012Validator(_schema())
+    for path in (ROOT / ".wgx" / "profile.yml", ROOT / "templates" / ".wgx" / "profile.yml"):
+        payload = yaml.safe_load(path.read_text(encoding="utf-8"))
+        validator.validate(payload)
+        tasks = payload["wgx"]["tasks"]
+        assert "guard" in tasks
+        assert "smoke" in tasks
+
+
+def test_reusable_workflow_is_policy_owner_not_wgx_workflow_proxy() -> None:
+    workflow = (ROOT / ".github" / "workflows" / "reusable-repo-verify.yml").read_text(
+        encoding="utf-8"
+    )
+    assert "repository: heimgewebe/wgx" in workflow
+    assert "heimgewebe/wgx/.github/workflows/" not in workflow
+    assert "guard|smoke" in workflow
+    assert "quick|full" in workflow

--- a/tests/test_wgx_reusable_callers.py
+++ b/tests/test_wgx_reusable_callers.py
@@ -1,65 +1,76 @@
 from pathlib import Path
 
-from scripts.ci.check_wgx_reusable_callers import check_callers
+from scripts.ci.check_wgx_reusable_callers import WGX_RUNNER_REF, check_callers
 
 ROOT = Path(__file__).resolve().parents[1]
+
+
+def _write_workflows(root: Path, *, guard: str, smoke: str, reusable: str) -> None:
+    workflows = root / ".github" / "workflows"
+    workflows.mkdir(parents=True)
+    (workflows / "wgx-guard.yml").write_text(guard, encoding="utf-8")
+    (workflows / "wgx-smoke.yml").write_text(smoke, encoding="utf-8")
+    (workflows / "reusable-repo-verify.yml").write_text(reusable, encoding="utf-8")
+
+
+def _good_reusable() -> str:
+    return (
+        "guard smoke quick full\n"
+        "repository: heimgewebe/wgx\n"
+        f"ref: {WGX_RUNNER_REF}\n"
+    )
 
 
 def test_repository_wgx_callers_match_declared_contracts() -> None:
     assert check_callers(ROOT) == []
 
 
-def test_undeclared_input_is_rejected(tmp_path: Path) -> None:
-    workflows = tmp_path / ".github" / "workflows"
-    workflows.mkdir(parents=True)
-    (workflows / "wgx-guard.yml").write_text(
-        "uses: heimgewebe/wgx/.github/workflows/wgx-guard.yml@"
-        "3d823f9d26be276eef97742335dee857a64e1715\n"
-        "with:\n  toolchain: stable\n",
-        encoding="utf-8",
+def test_direct_wgx_workflow_ownership_is_rejected(tmp_path: Path) -> None:
+    _write_workflows(
+        tmp_path,
+        guard=(
+            "uses: heimgewebe/wgx/.github/workflows/wgx-guard.yml@main\n"
+            "mode: guard\n"
+        ),
+        smoke=(
+            "uses: ./.github/workflows/reusable-repo-verify.yml\n"
+            "mode: smoke\n"
+        ),
+        reusable=_good_reusable(),
     )
-    (workflows / "wgx-smoke.yml").write_text(
-        "# Gepinnt auf den verifizierten WGX-Merge mit wiederverwendbarem Smoke\n"
-        "uses: heimgewebe/wgx/.github/workflows/wgx-smoke.yml@"
-        "b3b358f5bb8d26f087fcdaf25d308d439b22f583\n",
-        encoding="utf-8",
-    )
-    assert "wgx-guard caller passes undeclared input toolchain" in check_callers(tmp_path)
+    findings = check_callers(tmp_path)
+    assert "wgx-guard.yml does not route through Metarepo reusable verification" in findings
+    assert "wgx-guard.yml still delegates workflow ownership to WGX" in findings
 
 
-def test_unverified_guard_revision_is_rejected(tmp_path: Path) -> None:
-    workflows = tmp_path / ".github" / "workflows"
-    workflows.mkdir(parents=True)
-    (workflows / "wgx-guard.yml").write_text(
-        "uses: heimgewebe/wgx/.github/workflows/wgx-guard.yml@main\n",
-        encoding="utf-8",
+def test_missing_bound_mode_is_rejected(tmp_path: Path) -> None:
+    _write_workflows(
+        tmp_path,
+        guard="uses: ./.github/workflows/reusable-repo-verify.yml\n",
+        smoke=(
+            "uses: ./.github/workflows/reusable-repo-verify.yml\n"
+            "mode: smoke\n"
+        ),
+        reusable=_good_reusable(),
     )
-    (workflows / "wgx-smoke.yml").write_text(
-        "# Gepinnt auf den verifizierten WGX-Merge mit wiederverwendbarem Smoke\n"
-        "uses: heimgewebe/wgx/.github/workflows/wgx-smoke.yml@"
-        "b3b358f5bb8d26f087fcdaf25d308d439b22f583\n",
-        encoding="utf-8",
-    )
-    assert "wgx-guard caller is not bound to the verified WGX merge" in check_callers(
-        tmp_path
-    )
+    assert "wgx-guard.yml does not bind verification mode guard" in check_callers(tmp_path)
 
 
-def test_legacy_smoke_revision_is_rejected(tmp_path: Path) -> None:
-    workflows = tmp_path / ".github" / "workflows"
-    workflows.mkdir(parents=True)
-    (workflows / "wgx-guard.yml").write_text(
-        "uses: heimgewebe/wgx/.github/workflows/wgx-guard.yml@"
-        "3d823f9d26be276eef97742335dee857a64e1715\n",
-        encoding="utf-8",
+def test_moving_runner_ref_is_rejected(tmp_path: Path) -> None:
+    _write_workflows(
+        tmp_path,
+        guard=(
+            "uses: ./.github/workflows/reusable-repo-verify.yml\n"
+            "mode: guard\n"
+        ),
+        smoke=(
+            "uses: ./.github/workflows/reusable-repo-verify.yml\n"
+            "mode: smoke\n"
+        ),
+        reusable=(
+            "guard smoke quick full\n"
+            "repository: heimgewebe/wgx\n"
+            "ref: main\n"
+        ),
     )
-    (workflows / "wgx-smoke.yml").write_text(
-        "# Gepinnt auf den verifizierten WGX-Merge mit wiederverwendbarem Smoke\n"
-        "uses: heimgewebe/wgx/.github/workflows/wgx-smoke.yml@"
-        "52a12ff97c402d1aa718d534a84b0225e7718c82\n",
-        encoding="utf-8",
-    )
-    assert (
-        "wgx-smoke caller is not bound to the verified reusable smoke merge"
-        in check_callers(tmp_path)
-    )
+    assert "reusable verification runner is not revision-bound" in check_callers(tmp_path)


### PR DESCRIPTION
## Ziel

Verschiebt die kanonische Eigentümerschaft für repository-übergreifende Verifikationsverträge, Templates und reusable CI dorthin, wo sie laut Metarepo-Rollenvertrag hingehört. WGX bleibt in dieser Phase nur der revisionsgepinnte Kompatibilitätsrunner.

## Änderungen

- neuer `repository-verification.v2`-Contract plus gültiges Beispiel
- ausführbares kanonisches `.wgx`-Starterprofil statt nicht ausführbarer Legacy-Vorlage
- neuer Metarepo-eigener reusable Workflow für `guard`, `smoke`, `quick`, `full`
- Metarepo Guard/Smoke routen lokal statt ihre Policy an WGX zu delegieren
- Caller-Ratchets und Contracttests auf die neue Ownership umgestellt
- aktives Metarepo-Profil auf die kanonische verschachtelte WGX-v1-Kompatibilitätsform gebracht

## Kompatibilitätsgrenze

Der Contract v2 ändert zunächst die **Ownership**, nicht den Transportnamen: `wgx.apiVersion: v1` und der aktuelle WGX-Runner bleiben während der Fleet-Migration kompatibel. Ein späterer `.wgx`-/Repo-Rename erfolgt erst nach revisionsgebundenem Consumer-Cutover.

## Evidenz

- 8/8 fokussierte Contract-/Caller-Tests grün
- aktueller WGX `validate` und `tasks --json` gegen das neue Metarepo-Profil grün
- `actionlint` für alle drei betroffenen Workflows grün
- `scripts/validate-contracts.sh` grün; neues Schema + Beispiel validiert
- `ALLOW_NET=1 just validate` grün: 201/201 Tests, YAML, Shell-Regressions und actionlint
- `git diff --check` grün

Operator-Obligation: `goo-wgx-boundary-v2-20260807`