### PR TITLE
Fix repository verifier token propagation

### DIFF
--- a/.github/workflows/reusable-repo-verify.yml
+++ b/.github/workflows/reusable-repo-verify.yml
@@ -62,6 +62,7 @@ jobs:
         shell: bash
         env:
           VERIFY_MODE: ${{ inputs.mode }}
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           runner="$GITHUB_WORKSPACE/.repo-verification-runner/wgx"

--- a/tests/test_repository_verification_contract.py
+++ b/tests/test_repository_verification_contract.py
@@ -55,5 +55,12 @@ def test_reusable_workflow_is_policy_owner_not_wgx_workflow_proxy() -> None:
     )
     assert "repository: heimgewebe/wgx" in workflow
     assert "heimgewebe/wgx/.github/workflows/" not in workflow
+
+
+def test_reusable_workflow_passes_read_token_to_repository_verifier() -> None:
+    workflow = (ROOT / ".github" / "workflows" / "reusable-repo-verify.yml").read_text(
+        encoding="utf-8"
+    )
+    assert "GITHUB_TOKEN: ${{ github.token }}" in workflow
     assert "guard|smoke" in workflow
     assert "quick|full" in workflow


### PR DESCRIPTION
## Summary

- pass the workflow-scoped `github.token` into the canonical reusable repository verifier as `GITHUB_TOKEN`
- add a regression test that binds the reusable workflow contract to that read token

## Evidence

- `uv run pytest -q tests/test_repository_verification_contract.py`
- `just validate`
- `git diff --check`

This is the focused follow-up to the WGX boundary-v2 migration and addresses the reproduced 403 source-auth path without weakening verification.