### PR TITLE
Stop templates recreating WGX workflow ownership

### DIFF
--- a/templates/.github/workflows/wgx-guard.yml
+++ b/templates/.github/workflows/wgx-guard.yml
@@ -13,6 +13,9 @@ permissions:
 
 jobs:
   guard:
-    # Fleet-Repos, die von metarepo aus via wgx up Templates beziehen,
-    # werden auf den kanonischen Guard-Workflow aus heimgewebe/wgx gesetzt.
-    uses: heimgewebe/wgx/.github/workflows/wgx-guard.yml@main
+    # Compatibility filename only: verification policy is owned by Metarepo.
+    uses: heimgewebe/metarepo/.github/workflows/reusable-repo-verify.yml@65db582ee20fe77c49cc052be14b4fe3349eed57
+    with:
+      mode: guard
+    permissions:
+      contents: read

--- a/templates/.github/workflows/wgx-smoke.yml
+++ b/templates/.github/workflows/wgx-smoke.yml
@@ -8,8 +8,14 @@ name: wgx-smoke
       - ".wgx/**"
       - "docs/wgx-konzept.md"
 
+permissions:
+  contents: read
+
 jobs:
   smoke:
-    # auch hier: statt eigener CI-Logik nur noch Forwarder auf das
-    # kanonische wgx-Workflow-Repo.
-    uses: heimgewebe/wgx/.github/workflows/wgx-smoke.yml@main
+    # Compatibility filename only: verification policy is owned by Metarepo.
+    uses: heimgewebe/metarepo/.github/workflows/reusable-repo-verify.yml@65db582ee20fe77c49cc052be14b4fe3349eed57
+    with:
+      mode: smoke
+    permissions:
+      contents: read

--- a/tests/test_wgx_reusable_callers.py
+++ b/tests/test_wgx_reusable_callers.py
@@ -3,6 +3,11 @@ from pathlib import Path
 from scripts.ci.check_wgx_reusable_callers import WGX_RUNNER_REF, check_callers
 
 ROOT = Path(__file__).resolve().parents[1]
+METAREPO_VERIFY_REF = "65db582ee20fe77c49cc052be14b4fe3349eed57"
+METAREPO_VERIFY_USES = (
+    "uses: heimgewebe/metarepo/.github/workflows/reusable-repo-verify.yml@"
+    f"{METAREPO_VERIFY_REF}"
+)
 
 
 def _write_workflows(root: Path, *, guard: str, smoke: str, reusable: str) -> None:
@@ -23,6 +28,16 @@ def _good_reusable() -> str:
 
 def test_repository_wgx_callers_match_declared_contracts() -> None:
     assert check_callers(ROOT) == []
+
+
+def test_metarepo_templates_do_not_reintroduce_wgx_workflow_ownership() -> None:
+    templates = ROOT / "templates" / ".github" / "workflows"
+    for filename, mode in (("wgx-guard.yml", "guard"), ("wgx-smoke.yml", "smoke")):
+        text = (templates / filename).read_text(encoding="utf-8")
+        assert METAREPO_VERIFY_USES in text
+        assert f"mode: {mode}" in text
+        assert "heimgewebe/wgx/.github/workflows/" not in text
+        assert "@main" not in text
 
 
 def test_direct_wgx_workflow_ownership_is_rejected(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- route Metarepo guard/smoke templates directly to the canonical reusable repository-verification workflow
- pin the template caller to Metarepo commit 65db582ee20fe77c49cc052be14b4fe3349eed57
- add a regression ratchet rejecting WGX workflow ownership and moving @main refs in templates

## Validation
- `python3 -m pytest -q tests/test_wgx_reusable_callers.py` → 5 passed
- `just validate` → 204 passed plus YAML/Fleet/Shell/actionlint checks
- `git diff --check` → clean