### PR TITLE
Self-test smoke workflow template changes

### DIFF
--- a/templates/.github/workflows/wgx-smoke.yml
+++ b/templates/.github/workflows/wgx-smoke.yml
@@ -7,6 +7,7 @@ name: wgx-smoke
     paths:
       - ".wgx/**"
       - "docs/wgx-konzept.md"
+      - ".github/workflows/wgx-smoke.yml"
 
 permissions:
   contents: read

--- a/tests/test_wgx_reusable_callers.py
+++ b/tests/test_wgx_reusable_callers.py
@@ -40,6 +40,13 @@ def test_metarepo_templates_do_not_reintroduce_wgx_workflow_ownership() -> None:
         assert "@main" not in text
 
 
+def test_metarepo_smoke_template_self_triggers_workflow_changes() -> None:
+    smoke = (
+        ROOT / "templates" / ".github" / "workflows" / "wgx-smoke.yml"
+    ).read_text(encoding="utf-8")
+    assert '- ".github/workflows/wgx-smoke.yml"' in smoke
+
+
 def test_direct_wgx_workflow_ownership_is_rejected(tmp_path: Path) -> None:
     _write_workflows(
         tmp_path,


### PR DESCRIPTION
## Summary
- make the canonical `wgx-smoke.yml` compatibility template trigger when its own workflow file changes
- add a regression test so future template edits always produce a real smoke proof

## Validation
- focused caller tests: 6 passed
- `just validate`: 205 passed plus YAML/Fleet/Shell/actionlint
- `git diff --check`: pass

This addresses the testability gap exposed by the Mitschreiber consumer migration without changing the reusable workflow implementation or its revision pin.