### PR TITLE
docs: align ai context verification ownership

### DIFF
--- a/ai-contexts/README.md
+++ b/ai-contexts/README.md
@@ -6,12 +6,12 @@ Diese Dateien sind **nicht** die Lang-Doku. Sie sind der Einstieg: Wo anfangen? 
 ## Prinzipien
 - **Kurz & prüfbar**: lieber wenige Felder, die stimmen, als viele, die driften.
 - **Contracts-first**: Wenn es ein Schema/Interface gibt, verweise darauf.
-- **WGX-Erwartung sichtbar**: Fleet-Repos sollen WGX-Profil/Guard/Smoke implizieren.
+- **Verifikations-Eigentum sichtbar**: Fleet-Repos sollen ihren repository-eigenen Verifikations-Frontdoor deklarieren; Metarepo besitzt die gemeinsame Policy, WGX bleibt nur ein kompatibler Runner/Consumer.
 - **Grenzen explizit**: Was dieses Repo *nicht* macht (damit Agenten nicht “kreativ falsch” werden).
 
 ## Version
 - v1.0 hatte bereits: project / dependencies / architecture / conventions / documentation / ai_guidance.
-- v1.1 ergänzt: heimgewebe (Achse/Fleet/WGX), interfaces (produces/consumes), contracts, boundaries.
+- v1.1 ergänzt: heimgewebe (Achse/Fleet/Verifikation), interfaces (produces/consumes), contracts, boundaries.
 
 ## Rollout-Regel (wichtig)
 Dieses Verzeichnis `ai-contexts/` ist **metarepo-zentriert** gedacht: hier liegen Templates und Beispiele.

--- a/ai-contexts/_template.ai-context.yml
+++ b/ai-contexts/_template.ai-context.yml
@@ -58,7 +58,8 @@ boundaries:
   not_responsible_for:
     - "Doing network ingest without aussensensor"
   dangerous_assumptions:
-    - "Assume repo is Fleet-enabled without checking .wgx/"
+    - "Assume repo is Fleet-enabled without checking its repository verification declaration/profile."
+    - "Treat WGX as the owner of verification policy instead of a compatibility runner/consumer."
 
 conventions:
   branching: "main, feature/*"

--- a/tests/test_repository_verification_contract.py
+++ b/tests/test_repository_verification_contract.py
@@ -64,3 +64,14 @@ def test_reusable_workflow_passes_read_token_to_repository_verifier() -> None:
     assert "GITHUB_TOKEN: ${{ github.token }}" in workflow
     assert "guard|smoke" in workflow
     assert "quick|full" in workflow
+
+
+def test_ai_context_guidance_keeps_verification_policy_ownership_in_metarepo() -> None:
+    readme = (ROOT / "ai-contexts" / "README.md").read_text(encoding="utf-8")
+    template = (ROOT / "ai-contexts" / "_template.ai-context.yml").read_text(encoding="utf-8")
+
+    assert "Metarepo besitzt die gemeinsame Policy" in readme
+    assert "WGX bleibt nur ein kompatibler Runner/Consumer" in readme
+    assert "Fleet-Repos sollen WGX-Profil/Guard/Smoke implizieren" not in readme
+    assert "Treat WGX as the owner of verification policy" in template
+    assert "without checking .wgx/" not in template


### PR DESCRIPTION
## Änderung
- richtet die AI-Context-Einstiegsdokumentation am aktuellen Repository-Verification-v2-Vertrag aus
- stellt Metarepo als Eigentümer der gemeinsamen Verifikations-Policy klar
- beschreibt WGX nur noch als kompatiblen Runner/Consumer statt als Policy-Eigentümer
- ergänzt einen Regressionstest gegen erneute WGX-Ownership-Drift

## Verifikation
- `python3 scripts/ai_context/validate_ai_context.py --templates-dir ai-contexts`
- `pytest -q tests/test_repository_verification_contract.py` (7 passed)
- `git diff --check`