### PR TITLE
ci: pin checkout v7 action refs

### DIFF
--- a/.github/workflows/adr-lint.yml
+++ b/.github/workflows/adr-lint.yml
@@ -24,7 +24,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
 
       - name: Run ADR lint script
         run: |

--- a/.github/workflows/agent-mode-guard.yml
+++ b/.github/workflows/agent-mode-guard.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
 
       - name: Show environment
         run: |

--- a/.github/workflows/agents-ci.yml
+++ b/.github/workflows/agents-ci.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v7  # v7 (major tag)
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
       - name: Setup Python
         uses: actions/setup-python@v7  # v5 (major tag)
         with:

--- a/.github/workflows/ai-context-guard.yml
+++ b/.github/workflows/ai-context-guard.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
 
       - name: Setup Python
         uses: actions/setup-python@v7
@@ -44,7 +44,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
 
       - name: Setup Python
         uses: actions/setup-python@v7

--- a/.github/workflows/ci-shellcheck.yml
+++ b/.github/workflows/ci-shellcheck.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
 
       - name: Install ShellCheck
         run: sudo apt-get update -yqq && sudo apt-get install -yqq shellcheck

--- a/.github/workflows/contracts-index-guard.yml
+++ b/.github/workflows/contracts-index-guard.yml
@@ -23,7 +23,7 @@ jobs:
       run:
         shell: bash --noprofile --norc -euo pipefail {0}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
       - name: Check contracts index
         run: |
           bash ./scripts/check-contracts-index.sh

--- a/.github/workflows/contracts-validate.yml
+++ b/.github/workflows/contracts-validate.yml
@@ -52,7 +52,7 @@ jobs:
       GH_PUSH_BEFORE: ${{ github.event.before }}
       PROTECTED_REGEX: '^(contracts|fixtures)/'
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -127,7 +127,7 @@ jobs:
     needs: [guard]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           persist-credentials: false
 

--- a/.github/workflows/docs-linkcheck.yml
+++ b/.github/workflows/docs-linkcheck.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v7  # v7 (major tag)
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
       - name: Cache lychee URL state
         uses: actions/cache@v6  # v6 (major tag)
         with:

--- a/.github/workflows/fleet-doctor.yml
+++ b/.github/workflows/fleet-doctor.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
       - name: Setup Python
         uses: actions/setup-python@v7
         with:

--- a/.github/workflows/fleet-drift-check.yml
+++ b/.github/workflows/fleet-drift-check.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
       - name: Setup Python
         uses: actions/setup-python@v7
         with:

--- a/.github/workflows/fleet-generated-check.yml
+++ b/.github/workflows/fleet-generated-check.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
       - name: Setup Python
         uses: actions/setup-python@v7
         with:

--- a/.github/workflows/heavy.yml
+++ b/.github/workflows/heavy.yml
@@ -22,7 +22,7 @@ jobs:
       ASK_ENDPOINT_URL: ${{ secrets.ASK_ENDPOINT_URL }}
       METRICS_SNAPSHOT_URL: ${{ secrets.METRICS_SNAPSHOT_URL }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
 
       - name: Query /ask endpoint (optional)
         if: ${{ env.ASK_ENDPOINT_URL != '' && env.AGENT_MODE == '' }}

--- a/.github/workflows/impact-check.yml
+++ b/.github/workflows/impact-check.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
 
       - name: Detect changes (contracts + manifest)
         id: changed

--- a/.github/workflows/metarepo-analyze.yml
+++ b/.github/workflows/metarepo-analyze.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
 
       - name: Setup Python
         uses: actions/setup-python@v7

--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -27,7 +27,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
 
       - name: Ensure Node for ajv-cli
         uses: actions/setup-node@v7

--- a/.github/workflows/net-probe.yml
+++ b/.github/workflows/net-probe.yml
@@ -25,7 +25,7 @@ jobs:
     timeout-minutes: 7
     if: ${{ vars.AGENT_MODE == '' }}
     steps:
-      - uses: actions/checkout@v7  # v7 (major tag)
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
       - name: Check outbound HTTPS access (GitHub, PyPI, crates.io)
         run: |

--- a/.github/workflows/org-assets.yml
+++ b/.github/workflows/org-assets.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v7  # v7 (major tag)
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           fetch-depth: 0
       - uses: actions/setup-python@v7  # v5 (major tag)

--- a/.github/workflows/readiness.yml
+++ b/.github/workflows/readiness.yml
@@ -13,7 +13,7 @@ jobs:
   readiness:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
       - uses: actions/setup-python@v7
         with:
           python-version: '3.x'

--- a/.github/workflows/render-diagrams.yml
+++ b/.github/workflows/render-diagrams.yml
@@ -23,7 +23,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           fetch-depth: 0
 

--- a/.github/workflows/reusable-check-action-refs.yml
+++ b/.github/workflows/reusable-check-action-refs.yml
@@ -8,7 +8,7 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
       - name: Scan workflow refs
         run: |
           shopt -s nullglob

--- a/.github/workflows/reusable-ci.yml
+++ b/.github/workflows/reusable-ci.yml
@@ -33,7 +33,7 @@ jobs:
     timeout-minutes: 40
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
 
       - name: Setup Just from caller repository pin
         if: ${{ hashFiles('scripts/tools/just-pin.sh') != '' && hashFiles('scripts/lib/semver.sh') != '' && hashFiles('scripts/lib/installer.bash') != '' && hashFiles('toolchain.versions.yml') != '' }}

--- a/.github/workflows/reusable-validate-jsonl.yml
+++ b/.github/workflows/reusable-validate-jsonl.yml
@@ -50,7 +50,7 @@ jobs:
     timeout-minutes: 40
     steps:
       - name: Checkout caller repo
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
 
       - name: Setup Node
         uses: actions/setup-node@v7

--- a/.github/workflows/reusable-wgx-metrics.yml
+++ b/.github/workflows/reusable-wgx-metrics.yml
@@ -12,7 +12,7 @@ jobs:
   metrics:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
       - name: Try just wgx metrics snapshot
         run: |
           set -euo pipefail

--- a/.github/workflows/toolchain-guard.yml
+++ b/.github/workflows/toolchain-guard.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
 
       - name: Setup Node (for ajv-cli)
         uses: actions/setup-node@v7

--- a/.github/workflows/wgx-metrics.yml
+++ b/.github/workflows/wgx-metrics.yml
@@ -62,7 +62,7 @@ jobs:
       METRICS_POST_URL: ${{ secrets.post_url || inputs.post_url }}
       METRICS_POST_TOKEN: ${{ secrets.post_token }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
 
       - name: Setup Node
         uses: actions/setup-node@v7

--- a/tests/test_action_ref_pinning.py
+++ b/tests/test_action_ref_pinning.py
@@ -1,0 +1,26 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+CHECKOUT_V7_SHA = "9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"
+
+
+def _workflow_files():
+    roots = [ROOT / ".github" / "workflows", ROOT / "templates" / ".github" / "workflows"]
+    for root in roots:
+        if root.exists():
+            yield from sorted(root.rglob("*.yml"))
+
+
+def test_actions_checkout_v7_is_immutably_pinned() -> None:
+    offenders = []
+    expected = f"actions/checkout@{CHECKOUT_V7_SHA}"
+    for path in _workflow_files():
+        text = path.read_text(encoding="utf-8")
+        if "actions/checkout@v7" in text:
+            offenders.append(str(path.relative_to(ROOT)))
+        for line in text.splitlines():
+            if "actions/checkout@" in line and "# v4" not in line and expected not in line:
+                ref = line.split("actions/checkout@", 1)[1].split()[0]
+                if ref == "v7":
+                    offenders.append(str(path.relative_to(ROOT)))
+    assert offenders == []


### PR DESCRIPTION
## Änderung
- pinnt alle Metarepo-eigenen `actions/checkout@v7`-Verwendungen auf den bereits kanonisch verwendeten v7.0.0-Commit `9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0`
- verhindert bewegliche Major-Tags für Checkout in den eigenen Workflows
- ergänzt einen Regressionstest, der `actions/checkout@v7` in Workflow- und Template-Pfaden künftig ablehnt

## Verifikation
- `pytest -q tests/test_action_ref_pinning.py tests/test_repository_verification_contract.py` — 8 passed
- `git diff --check`
- keine verbleibenden `actions/checkout@v7` in `.github/workflows` oder `templates/.github/workflows`