### PR TITLE
ci: make integrity drift guard read-only

### DIFF
--- a/scripts/check-integrity-drift.sh
+++ b/scripts/check-integrity-drift.sh
@@ -10,20 +10,46 @@ OUTPUT_FILE="${REPO_ROOT}/reports/integrity/sources.v1.json"
 
 echo "Checking for drift in integrity sources..."
 
-# Run the generator
+if [ ! -f "$OUTPUT_FILE" ]; then
+  echo "Error: $OUTPUT_FILE is missing. Generate and commit it before running the drift check."
+  exit 1
+fi
+
+CANDIDATE=$(mktemp)
+
+# Invoked indirectly by the EXIT trap below.
+# shellcheck disable=SC2317
+cleanup_candidate() {
+  rc=$?
+  trap - EXIT
+  if ! rm -f "$CANDIDATE"; then
+    echo "Error: Failed to remove temporary integrity candidate." >&2
+    rc=1
+  fi
+  exit "$rc"
+}
+
+trap cleanup_candidate EXIT
+
+# Generate a candidate without ever rewriting the tracked report.
 CMD=("python3")
 if command -v uv > /dev/null 2>&1; then
   CMD=("uv" "run" "--" "python3")
 fi
 
-if ! "${CMD[@]}" "$SCRIPT_PATH"; then
+set +e
+"${CMD[@]}" "$SCRIPT_PATH" --output "$CANDIDATE"
+rc=$?
+set -e
+if [ "$rc" -ne 0 ]; then
   echo "Error: Generator script failed."
-  exit 1
+  exit "$rc"
 fi
 
-# Check for diffs
-if ! git diff --exit-code "$OUTPUT_FILE"; then
+if ! cmp -s "$OUTPUT_FILE" "$CANDIDATE"; then
   echo "Error: Drift detected in $OUTPUT_FILE."
+  echo "Diff (committed/current -> generated):"
+  diff -u "$OUTPUT_FILE" "$CANDIDATE" || true
   echo "Please run 'python3 scripts/generate_integrity_sources.py' and commit the changes."
   exit 1
 fi

--- a/scripts/generate_integrity_sources.py
+++ b/scripts/generate_integrity_sources.py
@@ -10,9 +10,11 @@ Compatibility fallback:
   - repos.yml is read only when the canonical metadata file is absent.
 
 Output:
-  - reports/integrity/sources.v1.json
+  - reports/integrity/sources.v1.json by default
+  - an alternate path with --output for read-only drift validation
 """
 
+import argparse
 import json
 import os
 import sys
@@ -25,7 +27,10 @@ _REPO_ROOT = Path(__file__).resolve().parents[1]
 if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPO_ROOT))
 
-from wgx import repo_config
+# Import must follow the repository-root path bootstrap above.
+from wgx import repo_config  # noqa: E402
+
+DEFAULT_OUTPUT = Path("reports/integrity/sources.v1.json")
 
 
 def load_yaml(yaml_mod: Any, path: Path) -> Any:
@@ -58,7 +63,30 @@ def detect_repo_root() -> Path:
     return _REPO_ROOT
 
 
-def main():
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Generate integrity source metadata.")
+    parser.add_argument(
+        "--output",
+        type=Path,
+        help=(
+            "alternate output path; timestamp idempotence remains bound to the "
+            f"canonical {DEFAULT_OUTPUT} report"
+        ),
+    )
+    return parser.parse_args(argv)
+
+
+def selected_output(repo_root: Path, override: Path | None) -> Path:
+    if override is None:
+        return repo_root / DEFAULT_OUTPUT
+    if override.is_absolute():
+        return override
+    return repo_root / override
+
+
+def main(argv: list[str] | None = None) -> None:
+    args = parse_args(argv)
+
     try:
         import yaml
     except ModuleNotFoundError:
@@ -72,7 +100,8 @@ def main():
     fleet_repos_file = repo_root / "fleet/repos.yml"
     metadata_file = repo_root / "fleet/repo-metadata.yml"
     legacy_repos_yml_file = repo_root / "repos.yml"
-    output_file = repo_root / "reports/integrity/sources.v1.json"
+    canonical_output_file = repo_root / DEFAULT_OUTPUT
+    output_file = selected_output(repo_root, args.output)
 
     # Load Fleet Membership
     if not fleet_repos_file.exists():
@@ -168,11 +197,13 @@ def main():
             }
         )
 
-    # Check for idempotence to avoid drift in timestamps
+    # Timestamp stability is always derived from the canonical tracked report,
+    # even when --output points at a temporary candidate. This lets validators
+    # compare bytes without ever rewriting the tracked artifact.
     existing_data = None
-    if output_file.exists():
+    if canonical_output_file.exists():
         try:
-            with open(output_file, "r", encoding="utf-8") as f:
+            with open(canonical_output_file, "r", encoding="utf-8") as f:
                 existing_data = json.load(f)
         except Exception:
             pass
@@ -180,11 +211,16 @@ def main():
     new_generated_at = utc_now_iso()
 
     if existing_data and existing_data.get("sources") == sources:
-        # Content didn't change, preserve timestamp to avoid noise
+        # Content didn't change, preserve timestamp to avoid noise.
         new_generated_at = existing_data.get("generated_at", new_generated_at)
-        print(f"No changes detected for {output_file}, preserving timestamp.")
+        print(
+            f"No changes detected for {canonical_output_file}, preserving timestamp."
+        )
     else:
-        print(f"Changes detected, updating {output_file}")
+        print(
+            f"Changes detected relative to {canonical_output_file}; "
+            f"writing {output_file}"
+        )
 
     output_data = {
         "apiVersion": "integrity.sources.v1",

--- a/tests/test_integrity_drift_readonly.py
+++ b/tests/test_integrity_drift_readonly.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+GENERATOR = ROOT / "scripts" / "generate_integrity_sources.py"
+GUARD = ROOT / "scripts" / "check-integrity-drift.sh"
+BASH = shutil.which("bash")
+assert BASH is not None
+
+
+def _run_generator(repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["HG_ROOT"] = str(repo)
+    return subprocess.run(
+        [sys.executable, str(GENERATOR), *args],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def _generator_fixture(tmp_path: Path) -> Path:
+    repo = tmp_path / "generator-repo"
+    (repo / "fleet").mkdir(parents=True)
+    (repo / "fleet" / "repos.yml").write_text(
+        yaml.safe_dump({"repos": ["repo1"]}),
+        encoding="utf-8",
+    )
+    return repo
+
+
+def test_generator_alternate_output_preserves_canonical_artifact(tmp_path: Path) -> None:
+    repo = _generator_fixture(tmp_path)
+    initial = _run_generator(repo)
+    assert initial.returncode == 0, initial.stderr
+
+    canonical = repo / "reports" / "integrity" / "sources.v1.json"
+    before = canonical.read_bytes()
+    candidate = tmp_path / "candidate.json"
+
+    result = _run_generator(repo, "--output", str(candidate))
+
+    assert result.returncode == 0, result.stderr
+    assert candidate.read_bytes() == before
+    assert canonical.read_bytes() == before
+
+
+def _guard_fixture(
+    tmp_path: Path,
+    generator_body: str,
+) -> tuple[Path, Path, bytes]:
+    repo = tmp_path / "guard-repo"
+    script = repo / "scripts" / "check-integrity-drift.sh"
+    generator = repo / "scripts" / "generate_integrity_sources.py"
+    report = repo / "reports" / "integrity" / "sources.v1.json"
+
+    script.parent.mkdir(parents=True)
+    report.parent.mkdir(parents=True)
+    shutil.copy2(GUARD, script)
+    generator.write_text(textwrap.dedent(generator_body), encoding="utf-8")
+
+    original = b"committed integrity report\n"
+    report.write_bytes(original)
+    return repo, report, original
+
+
+def _run_guard(repo: Path) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    # Keep the fixture deterministic and exercise the portable python3 path,
+    # independent of whether the development machine has uv in ~/.local/bin.
+    env["PATH"] = "/usr/bin:/bin"
+    return subprocess.run(
+        [BASH, "scripts/check-integrity-drift.sh"],
+        cwd=repo,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def test_drift_guard_success_is_read_only(tmp_path: Path) -> None:
+    repo, report, original = _guard_fixture(
+        tmp_path,
+        """
+        import argparse
+        from pathlib import Path
+
+        parser = argparse.ArgumentParser()
+        parser.add_argument("--output", required=True)
+        args = parser.parse_args()
+        source = Path("reports/integrity/sources.v1.json")
+        Path(args.output).write_bytes(source.read_bytes())
+        """,
+    )
+
+    result = _run_guard(repo)
+
+    assert result.returncode == 0, result.stderr
+    assert "Success: No drift detected." in result.stdout
+    assert report.read_bytes() == original
+
+
+def test_drift_guard_reports_drift_without_mutating_tracked_report(
+    tmp_path: Path,
+) -> None:
+    repo, report, original = _guard_fixture(
+        tmp_path,
+        """
+        import argparse
+        from pathlib import Path
+
+        parser = argparse.ArgumentParser()
+        parser.add_argument("--output", required=True)
+        args = parser.parse_args()
+        Path(args.output).write_text("different generated report\\n", encoding="utf-8")
+        """,
+    )
+
+    result = _run_guard(repo)
+
+    assert result.returncode == 1
+    assert "Drift detected" in result.stdout
+    assert report.read_bytes() == original
+
+
+def test_drift_guard_propagates_generator_failure_without_mutating_tracked_report(
+    tmp_path: Path,
+) -> None:
+    repo, report, original = _guard_fixture(
+        tmp_path,
+        """
+        import argparse
+        from pathlib import Path
+
+        parser = argparse.ArgumentParser()
+        parser.add_argument("--output", required=True)
+        args = parser.parse_args()
+        Path(args.output).write_text("partial candidate\\n", encoding="utf-8")
+        raise SystemExit(7)
+        """,
+    )
+
+    result = _run_guard(repo)
+
+    assert result.returncode == 7
+    assert "Generator script failed" in result.stdout
+    assert report.read_bytes() == original


### PR DESCRIPTION
## Änderung
- `generate_integrity_sources.py` unterstützt einen additiven `--output`-Pfad; das Default-Ziel bleibt unverändert
- Zeitstempel-Idempotenz bleibt bewusst an den kanonischen Report gebunden, auch bei temporärer Ausgabe
- `check-integrity-drift.sh` erzeugt nur noch eine Temp-Kandidaten-Datei und vergleicht per `cmp`/`diff`; der getrackte Report wird beim Check nicht mehr überschrieben
- Generator-Exitcodes werden erhalten
- Regressionstests decken erfolgreichen read-only Check, echten Drift, Generatorfehler und alternative Ausgabe ab

## Verifikation
- `uv run pytest tests/test_integrity_drift_readonly.py tests/test_generate_integrity_sources.py` — 16 passed auf Head `2e4b34938bd5826827b6e757b4555357581efc30`
- `uv run ruff check scripts/generate_integrity_sources.py tests/test_integrity_drift_readonly.py` — passed
- `shellcheck scripts/check-integrity-drift.sh` — passed
- realer `bash scripts/check-integrity-drift.sh` via Grabowski-Durable-Task — passed
- SHA-256 von `reports/integrity/sources.v1.json` vor/nach realem Guard identisch: `d96e9c0d45adcf9caaba4cbca75e68e93d21132bfb1b546517c52069870194a5`

Bureau-Folgefund: `candidate-a404f42a0c2b6900f8d9771c`, Event 4631.