### PR TITLE
ci: make org asset validation read-only

### DIFF
--- a/.github/workflows/org-assets.yml
+++ b/.github/workflows/org-assets.yml
@@ -50,9 +50,10 @@ jobs:
             ${{ runner.os }}-py311-uv-
       - uses: astral-sh/setup-uv@v7
       - run: uv sync --frozen
-      - run: uv run scripts/generate_org_assets.py --repos-file repos.yml --index docs/org-index.md --graph docs/org-graph.mmd
-      - name: Fail PR if org assets drift
-        if: ${{ github.event_name == 'pull_request' }}
-        run: |
-          git add -N docs/org-index.md docs/org-graph.mmd
-          git diff --exit-code -- docs/org-index.md docs/org-graph.mmd || (echo "::warning::Org assets changed – commit in this PR" && exit 1)
+      - name: Verify org assets are current
+        run: >-
+          uv run scripts/generate_org_assets.py
+          --repos-file repos.yml
+          --index docs/org-index.md
+          --graph docs/org-graph.mmd
+          --check

--- a/scripts/generate_org_assets.py
+++ b/scripts/generate_org_assets.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import difflib
 import sys
 from pathlib import Path
 from typing import Dict, List, Mapping, Sequence
@@ -12,7 +13,8 @@ _REPO_ROOT = Path(__file__).resolve().parents[1]
 if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPO_ROOT))
 
-from wgx import repo_config
+# Import must follow the repository-root path bootstrap above.
+from wgx import repo_config  # noqa: E402
 
 
 def _as_sequence(value: object) -> List[str]:
@@ -188,12 +190,40 @@ def determine_order(repos: Sequence[Mapping[str, object]]) -> List[str]:
     return repo_config.ordered_repo_names([dict(repo) for repo in repos])
 
 
-def main() -> None:
+def _write_or_check(path: Path, expected: str, *, check: bool) -> bool:
+    if check:
+        actual = path.read_text(encoding="utf-8") if path.exists() else ""
+        if actual == expected:
+            return True
+        sys.stdout.writelines(
+            difflib.unified_diff(
+                actual.splitlines(keepends=True),
+                expected.splitlines(keepends=True),
+                fromfile=str(path),
+                tofile="generated",
+            )
+        )
+        return False
+
+    _ensure_parent(path)
+    path.write_text(expected, encoding="utf-8")
+    return True
+
+
+def main() -> int:
     parser = argparse.ArgumentParser(description="Generate Org index and graph from repos.yml")
     parser.add_argument("--repos-file", default="repos.yml", help="Path to repos.yml")
     parser.add_argument("--index", dest="index_output", help="Path to write org index markdown")
     parser.add_argument("--graph", dest="graph_output", help="Path to write org dependency mermaid graph")
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="compare requested outputs without modifying them",
+    )
     args = parser.parse_args()
+
+    if args.check and not (args.index_output or args.graph_output):
+        parser.error("--check requires --index and/or --graph")
 
     repos_path = Path(args.repos_file)
     if not repos_path.exists():
@@ -202,19 +232,31 @@ def main() -> None:
     repos = load_repos(repos_path)
     archived_references = load_archived_references(repos_path)
     ordered_names = determine_order(repos)
+    outputs_current = True
 
     if args.index_output:
         index_path = Path(args.index_output)
-        _ensure_parent(index_path)
         index_content = render_index(repos, ordered_names, archived_references)
-        index_path.write_text(index_content, encoding="utf-8")
+        outputs_current = (
+            _write_or_check(index_path, index_content, check=args.check)
+            and outputs_current
+        )
 
     if args.graph_output:
         graph_path = Path(args.graph_output)
-        _ensure_parent(graph_path)
         graph_content = render_graph(repos, ordered_names, archived_references)
-        graph_path.write_text(graph_content, encoding="utf-8")
+        outputs_current = (
+            _write_or_check(graph_path, graph_content, check=args.check)
+            and outputs_current
+        )
+
+    if args.check:
+        if outputs_current:
+            print("org assets: PASS")
+            return 0
+        return 1
+    return 0
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/tests/test_org_assets_readonly.py
+++ b/tests/test_org_assets_readonly.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "generate_org_assets.py"
+REPOS = ROOT / "repos.yml"
+INDEX = ROOT / "docs" / "org-index.md"
+GRAPH = ROOT / "docs" / "org-graph.mmd"
+WORKFLOW = ROOT / ".github" / "workflows" / "org-assets.yml"
+
+
+def _run(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), *args],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def test_check_mode_accepts_current_assets_without_mutation() -> None:
+    index_before = INDEX.read_bytes()
+    graph_before = GRAPH.read_bytes()
+
+    result = _run(
+        "--repos-file",
+        str(REPOS),
+        "--index",
+        str(INDEX),
+        "--graph",
+        str(GRAPH),
+        "--check",
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "org assets: PASS" in result.stdout
+    assert INDEX.read_bytes() == index_before
+    assert GRAPH.read_bytes() == graph_before
+
+
+def test_check_mode_reports_drift_without_mutation(tmp_path: Path) -> None:
+    index = tmp_path / "org-index.md"
+    graph = tmp_path / "org-graph.mmd"
+    index.write_bytes(INDEX.read_bytes() + b"unexpected drift\n")
+    graph.write_bytes(GRAPH.read_bytes())
+    index_before = index.read_bytes()
+    graph_before = graph.read_bytes()
+
+    result = _run(
+        "--repos-file",
+        str(REPOS),
+        "--index",
+        str(index),
+        "--graph",
+        str(graph),
+        "--check",
+    )
+
+    assert result.returncode == 1
+    assert str(index) in result.stdout
+    assert "generated" in result.stdout
+    assert index.read_bytes() == index_before
+    assert graph.read_bytes() == graph_before
+
+
+def test_check_mode_reports_missing_output_without_creating_it(tmp_path: Path) -> None:
+    index = tmp_path / "org-index.md"
+    graph = tmp_path / "missing-org-graph.mmd"
+    index.write_bytes(INDEX.read_bytes())
+    index_before = index.read_bytes()
+
+    result = _run(
+        "--repos-file",
+        str(REPOS),
+        "--index",
+        str(index),
+        "--graph",
+        str(graph),
+        "--check",
+    )
+
+    assert result.returncode == 1
+    assert str(graph) in result.stdout
+    assert index.read_bytes() == index_before
+    assert not graph.exists()
+
+
+def test_generation_mode_still_writes_requested_outputs(tmp_path: Path) -> None:
+    index = tmp_path / "nested" / "org-index.md"
+    graph = tmp_path / "nested" / "org-graph.mmd"
+
+    result = _run(
+        "--repos-file",
+        str(REPOS),
+        "--index",
+        str(index),
+        "--graph",
+        str(graph),
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert index.read_bytes() == INDEX.read_bytes()
+    assert graph.read_bytes() == GRAPH.read_bytes()
+
+
+def test_org_assets_workflow_uses_read_only_check_mode() -> None:
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "--check" in workflow
+    assert "git diff --exit-code" not in workflow
+    assert "git add -N" not in workflow


### PR DESCRIPTION
## Änderung
- `generate_org_assets.py` erhält einen erstklassigen `--check`-Modus mit Unified Diff und ohne Dateimutationen
- normaler Schreibmodus für `--index`/`--graph` bleibt kompatibel
- `org-assets.yml` prüft Org-Artefakte nun direkt per `--check` statt sie erst zu überschreiben und anschließend `git diff` auszuführen
- derselbe Drift-Gate gilt jetzt auch auf `main`-Pushes, nicht nur in Pull Requests
- Regressionstests sichern Erfolg, Drift, fehlende Outputs, Schreibmodus und Workflow-Vertrag ab

## Verifikation
- `uv run pytest tests/test_org_assets_readonly.py tests/test_leitwerk_archived_reference.py tests/test_repoground_consumer_registration.py` — 12 passed auf Head `726b6d81924ed5b1c84215264c664138a140cf41`
- `uv run ruff check scripts/generate_org_assets.py tests/test_org_assets_readonly.py` — passed
- Workflow-YAML via PyYAML geparst — passed
- realer `uv run scripts/generate_org_assets.py --repos-file repos.yml --index docs/org-index.md --graph docs/org-graph.mmd --check` — `org assets: PASS`
- `docs/org-index.md` vor/nach Check: SHA-256 `02b69ed8061deb9ed1f43edbefe48ceccb0b6515039fcd9359950126ff05cd17`
- `docs/org-graph.mmd` vor/nach Check: SHA-256 `c1e394c439f3dbb2042a08c479fb8591db8029c25897ac138d135ac8fadd06c5`

Lokales `actionlint` ist auf dem Host nicht installiert; GitHub-CI bleibt dafür maßgeblich.