### PR TITLE
ci: isolate readiness report generation

### DIFF
--- a/.github/workflows/fleet-doctor.yml
+++ b/.github/workflows/fleet-doctor.yml
@@ -43,8 +43,7 @@ jobs:
           python scripts/fleet/generate_readiness.py \
             --fleet-file fleet/repos.yml \
             --repos-yml repos.yml \
-            --out-json reports/heimgewebe-readiness.json \
-            --write-repos-txt fleet/repos.txt
+            --out-json reports/heimgewebe-readiness.json
       - name: Display readiness report
         run: cat reports/heimgewebe-readiness.json
       - name: Run hg-doctor (CI mode)

--- a/.github/workflows/readiness.yml
+++ b/.github/workflows/readiness.yml
@@ -17,8 +17,10 @@ jobs:
       - uses: actions/setup-python@v7
         with:
           python-version: '3.x'
-      - name: Generate readiness
-        run: python scripts/fleet/generate_readiness.py
+      - name: Generate readiness report only
+        run: >-
+          python scripts/fleet/generate_readiness.py
+          --out-json reports/heimgewebe-readiness.json
       - name: Upload artifact
         uses: actions/upload-artifact@v6
         with:

--- a/scripts/fleet/generate_readiness.py
+++ b/scripts/fleet/generate_readiness.py
@@ -15,7 +15,8 @@ ROOT = Path(__file__).resolve().parents[2]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-from wgx import repo_config
+# Import must follow the repository-root path bootstrap above.
+from wgx import repo_config  # noqa: E402
 
 WgxProfileKind = Literal["profile", "no_profile", "missing"]
 
@@ -75,7 +76,10 @@ def main() -> int:
     parser.add_argument("--fleet-file", default="fleet/repos.yml")
     parser.add_argument("--repos-yml", default="repos.yml")
     parser.add_argument("--out-json", default="reports/heimgewebe-readiness.json")
-    parser.add_argument("--write-repos-txt", default="fleet/repos.txt")
+    parser.add_argument(
+        "--write-repos-txt",
+        help="optional path for explicitly generating the fleet repos.txt projection",
+    )
     args = parser.parse_args()
 
     metarepo_root = ROOT

--- a/tests/test_readiness_projection_sideeffect.py
+++ b/tests/test_readiness_projection_sideeffect.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "fleet" / "generate_readiness.py"
+REPOS_TXT = ROOT / "fleet" / "repos.txt"
+READINESS_WORKFLOW = ROOT / ".github" / "workflows" / "readiness.yml"
+DOCTOR_WORKFLOW = ROOT / ".github" / "workflows" / "fleet-doctor.yml"
+MAKEFILE = ROOT / "Makefile"
+
+
+def _run(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), *args],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def test_default_readiness_generation_does_not_rewrite_repos_txt(tmp_path: Path) -> None:
+    before = REPOS_TXT.read_bytes()
+    report = tmp_path / "readiness.json"
+
+    result = _run("--out-json", str(report))
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert report.exists()
+    assert REPOS_TXT.read_bytes() == before
+
+
+def test_explicit_repos_txt_generation_remains_supported(tmp_path: Path) -> None:
+    report = tmp_path / "readiness.json"
+    projection = tmp_path / "repos.txt"
+
+    result = _run(
+        "--out-json",
+        str(report),
+        "--write-repos-txt",
+        str(projection),
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert projection.read_bytes() == REPOS_TXT.read_bytes()
+
+
+def test_ci_readiness_paths_are_report_only_and_fleet_generation_is_explicit() -> None:
+    readiness_workflow = READINESS_WORKFLOW.read_text(encoding="utf-8")
+    doctor_workflow = DOCTOR_WORKFLOW.read_text(encoding="utf-8")
+    makefile = MAKEFILE.read_text(encoding="utf-8")
+
+    assert "--out-json reports/heimgewebe-readiness.json" in readiness_workflow
+    assert "--write-repos-txt" not in readiness_workflow
+    assert "--out-json reports/heimgewebe-readiness.json" in doctor_workflow
+    assert "--write-repos-txt" not in doctor_workflow
+    assert "--write-repos-txt fleet/repos.txt" in makefile


### PR DESCRIPTION
## Änderung
- `generate_readiness.py` schreibt `fleet/repos.txt` nicht mehr implizit; `--write-repos-txt` ist jetzt opt-in
- `readiness.yml` und `fleet-doctor.yml` erzeugen nur noch den gewünschten Readiness-Report
- `make fleet` behält die explizite `--write-repos-txt fleet/repos.txt`-Generierung und damit die bestehende Projektion
- Regressionstests belegen Default-Read-only-Verhalten für `fleet/repos.txt`, explizite Kompatibilität und die beiden CI-Verträge

## Verifikation
- `uv run pytest tests/test_readiness_projection_sideeffect.py` — 3 passed
- `uv run ruff check scripts/fleet/generate_readiness.py tests/test_readiness_projection_sideeffect.py` — passed
- beide Workflow-YAML-Dateien via PyYAML geparst — passed
- realer Defaultlauf mit temporärem Report — passed
- `fleet/repos.txt` vor/nach realem Defaultlauf unverändert: SHA-256 `336ad772f94ca33100e1498c7f3777b6f31e1c4daf334e4e02b0bfcdb83737c2`

Bureau-Folgefund: `candidate-f615476ecb75cdf8030d0081`, Event 4679.