### PR TITLE
fix: keep Renovate out of governed dependency lanes

### DIFF
--- a/automation/renovate/default.json
+++ b/automation/renovate/default.json
@@ -16,7 +16,7 @@
   ],
   "packageRules": [
     {
-      "description": "Group compatible non-major GitHub Actions updates",
+      "description": "Group non-major GitHub Actions updates",
       "matchManagers": [
         "github-actions"
       ],
@@ -24,7 +24,47 @@
         "minor",
         "patch"
       ],
-      "groupName": "github-actions non-major"
+      "groupName": "github-actions non-major updates"
+    },
+    {
+      "description": "Python runtime-line migrations must stay aligned with repository locks and runtime policy",
+      "matchManagers": [
+        "github-actions"
+      ],
+      "enabled": false,
+      "matchDepNames": [
+        "python"
+      ]
+    },
+    {
+      "description": "Metarepo reusable-workflow pins require an atomic contract and evidence refresh",
+      "matchManagers": [
+        "github-actions"
+      ],
+      "matchPackageNames": [
+        "heimgewebe/metarepo"
+      ],
+      "enabled": false
+    },
+    {
+      "description": "WGX GitHub Action pins are bound to checked-in operator capability source evidence",
+      "matchManagers": [
+        "github-actions"
+      ],
+      "matchRepositories": [
+        "heimgewebe/wgx"
+      ],
+      "enabled": false
+    },
+    {
+      "description": "Weltgewebe GitHub Action changes require review evidence that generic Renovate cannot supply",
+      "matchManagers": [
+        "github-actions"
+      ],
+      "matchRepositories": [
+        "heimgewebe/weltgewebe"
+      ],
+      "enabled": false
     }
   ]
 }

--- a/docs/fleet/renovate-v1.md
+++ b/docs/fleet/renovate-v1.md
@@ -72,7 +72,15 @@ Der gemeinsame Preset:
 - begrenzt PR-, Branch- und Stundenparallelität auf höchstens zwei;
 - hält Major-Updates getrennt;
 - gruppiert zentral nur Patch-/Minor-Updates für GitHub Actions;
+- behandelt Python-Runtime-Linien in `actions/setup-python` nicht als gewöhnliche Dependency-Updates, weil Interpreter, Locks und Runtime-Policy gemeinsam migriert werden müssen;
+- lässt `heimgewebe/metarepo`-Reusable-Workflow-Pins aus generischen Renovate-PRs heraus, solange deren Contract-/Evidenzdaten nicht atomar mitaktualisiert werden;
+- lässt GitHub-Action-Pins in WGX aus generischen Renovate-PRs heraus, solange sie an eingecheckte Capability-/Source-Evidenz gebunden sind;
+- lässt GitHub-Action-Pins in Weltgewebe aus generischen Renovate-PRs heraus, solange Workflow-Änderungen dort R3-Review-Evidenz verlangen, die Renovate nicht selbst liefern kann;
 - enthält keine Post-Upgrade-Command-Ausführung.
+
+Diese Ausschlüsse sind kein Update-Verbot. Sie trennen semantische Runtime- bzw.
+Evidenzmigrationen von blindem Versions-Pinning: Solche Updates brauchen einen eigenen,
+reviewbaren Pfad, der die jeweils gekoppelten Verträge und Nachweise atomar aktualisiert.
 
 Repo-spezifische Konfiguration darf diese Sicherheitsgrenzen nicht durch Automerge
 unterlaufen. Vor dem ersten schreibenden Lauf werden bekannte lokale Abweichungen wie

--- a/scripts/fleet/renovate_policy.py
+++ b/scripts/fleet/renovate_policy.py
@@ -217,30 +217,96 @@ def validate_preset(preset: dict[str, Any]) -> None:
     rules = preset["packageRules"]
     if not isinstance(rules, list) or not rules:
         raise PolicyError("Renovate preset packageRules must be a non-empty list")
+
+    grouping_rules: list[dict[str, Any]] = []
     for index, rule in enumerate(rules):
         if not isinstance(rule, dict):
             raise PolicyError(f"packageRules[{index}] must be an object")
         _exact_keys(
             rule,
-            allowed={"description", "matchManagers", "matchUpdateTypes", "groupName"},
-            required={"matchManagers", "matchUpdateTypes", "groupName"},
+            allowed={
+                "description",
+                "matchManagers",
+                "matchUpdateTypes",
+                "groupName",
+                "matchPackageNames",
+                "matchDepNames",
+                "matchRepositories",
+                "enabled",
+            },
+            required={"matchManagers"},
             label=f"packageRules[{index}]",
         )
         managers = rule["matchManagers"]
-        update_types = rule["matchUpdateTypes"]
-        group_name = rule["groupName"]
         if not isinstance(managers, list) or not managers or not all(
             isinstance(item, str) and item.strip() for item in managers
         ):
             raise PolicyError(f"packageRules[{index}].matchManagers must be non-empty strings")
-        if not isinstance(update_types, list) or not update_types:
-            raise PolicyError(f"packageRules[{index}].matchUpdateTypes must be non-empty")
-        if set(update_types) - {"minor", "patch"}:
+
+        for field in ("matchPackageNames", "matchDepNames", "matchRepositories"):
+            if field not in rule:
+                continue
+            values = rule[field]
+            if not isinstance(values, list) or not values or not all(
+                isinstance(item, str) and item.strip() for item in values
+            ):
+                raise PolicyError(f"packageRules[{index}].{field} must be non-empty strings")
+
+        if "enabled" in rule and not isinstance(rule["enabled"], bool):
+            raise PolicyError(f"packageRules[{index}].enabled must be boolean")
+
+        has_group_name = "groupName" in rule
+        has_update_types = "matchUpdateTypes" in rule
+        if has_group_name != has_update_types:
             raise PolicyError(
-                f"packageRules[{index}] groups unsupported update types; major updates must remain isolated"
+                f"packageRules[{index}] must define groupName and matchUpdateTypes together"
             )
-        if not isinstance(group_name, str) or not group_name.strip():
-            raise PolicyError(f"packageRules[{index}].groupName must be non-empty")
+        if has_group_name:
+            update_types = rule["matchUpdateTypes"]
+            group_name = rule["groupName"]
+            if not isinstance(update_types, list) or not update_types:
+                raise PolicyError(f"packageRules[{index}].matchUpdateTypes must be non-empty")
+            if set(update_types) - {"minor", "patch"}:
+                raise PolicyError(
+                    f"packageRules[{index}] groups unsupported update types; major updates must remain isolated"
+                )
+            if not isinstance(group_name, str) or not group_name.strip():
+                raise PolicyError(f"packageRules[{index}].groupName must be non-empty")
+            grouping_rules.append(rule)
+        elif rule.get("enabled") is not False:
+            raise PolicyError(
+                f"packageRules[{index}] non-grouping rules must be explicit enabled=false protections"
+            )
+
+    if len(grouping_rules) != 1:
+        raise PolicyError("Renovate preset must contain exactly one grouping rule")
+    grouping_rule = grouping_rules[0]
+    if grouping_rule["matchManagers"] != ["github-actions"] or grouping_rule[
+        "matchUpdateTypes"
+    ] != ["minor", "patch"]:
+        raise PolicyError("Renovate preset may group only GitHub Actions minor/patch updates")
+
+    required_protections = (
+        {"matchManagers": ["github-actions"], "matchDepNames": ["python"], "enabled": False},
+        {
+            "matchManagers": ["github-actions"],
+            "matchPackageNames": ["heimgewebe/metarepo"],
+            "enabled": False,
+        },
+        {
+            "matchManagers": ["github-actions"],
+            "matchRepositories": ["heimgewebe/wgx"],
+            "enabled": False,
+        },
+        {
+            "matchManagers": ["github-actions"],
+            "matchRepositories": ["heimgewebe/weltgewebe"],
+            "enabled": False,
+        },
+    )
+    for expected in required_protections:
+        if not any(all(rule.get(key) == value for key, value in expected.items()) for rule in rules):
+            raise PolicyError(f"Renovate preset is missing governed dependency protection: {expected}")
 
 
 def validate_baseline(baseline: dict[str, Any]) -> None:

--- a/tests/test_renovate_policy.py
+++ b/tests/test_renovate_policy.py
@@ -104,8 +104,35 @@ def test_two_active_version_update_producers_fail_closed() -> None:
 
 def test_shared_preset_groups_only_github_actions_non_major_updates() -> None:
     _, _, preset = _inputs()
-    assert [rule["matchManagers"] for rule in preset["packageRules"]] == [["github-actions"]]
-    assert preset["packageRules"][0]["matchUpdateTypes"] == ["minor", "patch"]
+    grouped = [rule for rule in preset["packageRules"] if "groupName" in rule]
+    assert len(grouped) == 1
+    assert grouped[0]["matchManagers"] == ["github-actions"]
+    assert grouped[0]["matchUpdateTypes"] == ["minor", "patch"]
+
+
+def test_shared_preset_keeps_governed_dependency_lanes_out_of_generic_renovate() -> None:
+    _, _, preset = _inputs()
+    rules = preset["packageRules"]
+    expected = (
+        {"matchManagers": ["github-actions"], "matchDepNames": ["python"], "enabled": False},
+        {
+            "matchManagers": ["github-actions"],
+            "matchPackageNames": ["heimgewebe/metarepo"],
+            "enabled": False,
+        },
+        {
+            "matchManagers": ["github-actions"],
+            "matchRepositories": ["heimgewebe/wgx"],
+            "enabled": False,
+        },
+        {
+            "matchManagers": ["github-actions"],
+            "matchRepositories": ["heimgewebe/weltgewebe"],
+            "enabled": False,
+        },
+    )
+    for required in expected:
+        assert any(all(rule.get(key) == value for key, value in required.items()) for rule in rules)
 
 
 def test_preset_cannot_enable_automerge() -> None:


### PR DESCRIPTION
## Problem
Renovate erzeugt wiederholt mechanisch plausible, aber systemisch ungültige PRs, wenn ein Versions-Pin an zusätzliche Verträge, Evidenz oder Runtime-Policy gekoppelt ist.

Belegte aktuelle Fälle:
- RepoGround: `actions/setup-python` wurde von der unterstützten/gelockten Python-3.12-Linie auf 3.14 verschoben.
- RepoGround/andere Repos: `heimgewebe/metarepo`-Workflow-SHAs wurden geändert, ohne `.github/reusable-workflow-contracts.json` atomar nachzuführen.
- WGX: Action-SHAs sind an eingecheckte Capability-/Source-Evidenz gebunden.
- Weltgewebe: Workflow-Änderungen benötigen R3-Review-Evidenz, die generisches Renovate nicht liefern kann.

## Fix
- GitHub-Actions-`depName=python` aus generischen Renovate-Updates herausnehmen.
- `heimgewebe/metarepo`-Reusable-Workflow-Pins aus generischen Renovate-Updates herausnehmen.
- GitHub-Actions-Updates in WGX und Weltgewebe aus der generischen Lane herausnehmen.
- Renovate-Policy-Validator fail-closed erweitern: genau diese Schutzregeln sind jetzt Pflichtbestandteil des zentralen Presets.
- Architekturgrund und Grenzen dokumentieren.

Diese Regeln verbieten Updates nicht; sie routen semantische Runtime-/Evidenzmigrationen in einen separaten, atomaren Pfad statt bekannte rote PRs zu produzieren.

## Verifikation
- `python3 -m pytest -q tests/test_renovate_policy.py` -> 10 passed
- `just renovate-policy-check` -> ok, 18 Fleet-Repos
- `git diff --check` -> grün
- echter Renovate 42.99.0 `--dry-run=lookup` gegen Problem-Repos -> erfolgreich
- RepoGround-Debug-Readback: `python-version: 3.12` und `heimgewebe/metarepo` zeigen `updates: []` + `skipReason: disabled`

Commit unter Review: `0ef1bbc7e6f733d813fe0f8b2c500d6910eaa8c6`.