### PR TITLE
fix: route major Renovate upgrades through migrations

### DIFF
--- a/automation/renovate/default.json
+++ b/automation/renovate/default.json
@@ -27,6 +27,13 @@
       "groupName": "github-actions non-major updates"
     },
     {
+      "description": "Major dependency upgrades require an explicit migration path",
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "enabled": false
+    },
+    {
       "description": "Python runtime-line migrations must stay aligned with repository locks and runtime policy",
       "matchManagers": [
         "github-actions"

--- a/docs/fleet/renovate-v1.md
+++ b/docs/fleet/renovate-v1.md
@@ -72,6 +72,7 @@ Der gemeinsame Preset:
 - begrenzt PR-, Branch- und Stundenparallelität auf höchstens zwei;
 - hält Major-Updates getrennt;
 - gruppiert zentral nur Patch-/Minor-Updates für GitHub Actions;
+- erzeugt keine generischen Major-Upgrade-PRs; Major-Sprünge gelten als explizite Migrationen, weil sie Breaking Changes, Peer-Abhängigkeiten, Lockfiles und Runtime-Verträge koordinieren können;
 - behandelt Python-Runtime-Linien in `actions/setup-python` nicht als gewöhnliche Dependency-Updates, weil Interpreter, Locks und Runtime-Policy gemeinsam migriert werden müssen;
 - lässt `heimgewebe/metarepo`-Reusable-Workflow-Pins aus generischen Renovate-PRs heraus, solange deren Contract-/Evidenzdaten nicht atomar mitaktualisiert werden;
 - lässt GitHub-Action-Pins in WGX aus generischen Renovate-PRs heraus, solange sie an eingecheckte Capability-/Source-Evidenz gebunden sind;

--- a/scripts/fleet/renovate_policy.py
+++ b/scripts/fleet/renovate_policy.py
@@ -234,14 +234,15 @@ def validate_preset(preset: dict[str, Any]) -> None:
                 "matchRepositories",
                 "enabled",
             },
-            required={"matchManagers"},
+            required=set(),
             label=f"packageRules[{index}]",
         )
-        managers = rule["matchManagers"]
-        if not isinstance(managers, list) or not managers or not all(
-            isinstance(item, str) and item.strip() for item in managers
-        ):
-            raise PolicyError(f"packageRules[{index}].matchManagers must be non-empty strings")
+        if "matchManagers" in rule:
+            managers = rule["matchManagers"]
+            if not isinstance(managers, list) or not managers or not all(
+                isinstance(item, str) and item.strip() for item in managers
+            ):
+                raise PolicyError(f"packageRules[{index}].matchManagers must be non-empty strings")
 
         for field in ("matchPackageNames", "matchDepNames", "matchRepositories"):
             if field not in rule:
@@ -257,15 +258,20 @@ def validate_preset(preset: dict[str, Any]) -> None:
 
         has_group_name = "groupName" in rule
         has_update_types = "matchUpdateTypes" in rule
-        if has_group_name != has_update_types:
+        if has_group_name and not has_update_types:
             raise PolicyError(
-                f"packageRules[{index}] must define groupName and matchUpdateTypes together"
+                f"packageRules[{index}] grouping rules must define matchUpdateTypes"
             )
-        if has_group_name:
+        if has_group_name and "matchManagers" not in rule:
+            raise PolicyError(
+                f"packageRules[{index}] grouping rules must define matchManagers"
+            )
+        if has_update_types:
             update_types = rule["matchUpdateTypes"]
-            group_name = rule["groupName"]
             if not isinstance(update_types, list) or not update_types:
                 raise PolicyError(f"packageRules[{index}].matchUpdateTypes must be non-empty")
+        if has_group_name:
+            group_name = rule["groupName"]
             if set(update_types) - {"minor", "patch"}:
                 raise PolicyError(
                     f"packageRules[{index}] groups unsupported update types; major updates must remain isolated"
@@ -287,6 +293,7 @@ def validate_preset(preset: dict[str, Any]) -> None:
         raise PolicyError("Renovate preset may group only GitHub Actions minor/patch updates")
 
     required_protections = (
+        {"matchUpdateTypes": ["major"], "enabled": False},
         {"matchManagers": ["github-actions"], "matchDepNames": ["python"], "enabled": False},
         {
             "matchManagers": ["github-actions"],

--- a/tests/test_renovate_policy.py
+++ b/tests/test_renovate_policy.py
@@ -114,6 +114,7 @@ def test_shared_preset_keeps_governed_dependency_lanes_out_of_generic_renovate()
     _, _, preset = _inputs()
     rules = preset["packageRules"]
     expected = (
+        {"matchUpdateTypes": ["major"], "enabled": False},
         {"matchManagers": ["github-actions"], "matchDepNames": ["python"], "enabled": False},
         {
             "matchManagers": ["github-actions"],
@@ -180,3 +181,11 @@ def test_complete_fleet_copy_is_rejected_as_second_membership_list() -> None:
     )
     with pytest.raises(renovate_policy.PolicyError, match="complete active Fleet"):
         renovate_policy.validate_policy(mutated, active_fleet=active)
+
+
+def test_shared_preset_disables_generic_major_updates() -> None:
+    _, _, preset = _inputs()
+    assert any(
+        rule.get("matchUpdateTypes") == ["major"] and rule.get("enabled") is False
+        for rule in preset["packageRules"]
+    )


### PR DESCRIPTION
## Problem
Der zentrale Renovate-Lauf erzeugt weiterhin Major-Upgrade-PRs, obwohl diese häufig Breaking Changes, Peer-Abhängigkeiten, Lockfiles und Runtime-Verträge koordinieren müssen.

Konkreter Live-Fund: Sichter #283 aktualisierte `@vitejs/plugin-react` auf v6, obwohl npm bereits bei der Lockfile-Erzeugung mit `ERESOLVE` scheiterte, weil die neue Version Vite 8 verlangt, das Repo aber Vite 7 nutzt.

## Fix
- generische Renovate-Major-Updates zentral mit `matchUpdateTypes: ["major"]` + `enabled: false` sperren;
- Major-Sprünge ausdrücklich als eigene Migrationslane dokumentieren;
- Renovate-Policy-Validator so erweitern, dass die globale Major-Sperre fail-closed Pflicht ist, während Gruppierungsregeln weiterhin `matchManagers` benötigen;
- Regressionstest für die Major-Sperre ergänzen.

## Verifikation
- `python3 -m pytest -q tests/test_renovate_policy.py` -> 11 passed
- `just renovate-policy-check` -> ok, 18 Fleet-Repos
- `git diff --check` -> grün
- Renovate 42.99.0 `--dry-run=full heimgewebe/sichter` -> `branches: []`; bestehende Major-PRs #282/#283 werden nur noch als aufgegebene Alt-Branches behandelt und kein neuer Major-Branch wird geplant.

Commit unter Review: `c3da76abd2595a8bb22d5d0e878de49e3aa4a1ab`.