### PR TITLE
fix: govern Weltgewebe deployment image updates

### DIFF
--- a/automation/renovate/default.json
+++ b/automation/renovate/default.json
@@ -72,6 +72,21 @@
         "heimgewebe/weltgewebe"
       ],
       "enabled": false
+    },
+    {
+      "description": "Weltgewebe deployment image updates require OCI, drift and R3 review evidence",
+      "matchManagers": [
+        "dockerfile",
+        "docker-compose"
+      ],
+      "matchRepositories": [
+        "heimgewebe/weltgewebe"
+      ],
+      "enabled": false,
+      "matchFileNames": [
+        "apps/**/Dockerfile",
+        "infra/compose/**"
+      ]
     }
   ]
 }

--- a/docs/fleet/renovate-v1.md
+++ b/docs/fleet/renovate-v1.md
@@ -133,3 +133,7 @@ Für Repositories, deren Dependabot-Version-Updates bereits entfernt wurden, bes
 Rollback aus dem Revert des jeweiligen reviewten Cutover-Commits. Anschließend muss live
 belegt werden, dass wieder exakt ein Version-Update-Produzent aktiv ist. Bureau-,
 Chronik- und Git-Historie werden nicht umgeschrieben.
+
+### Governed Weltgewebe deployment images
+
+Weltgewebe-Image-Abhängigkeiten in `apps/**/Dockerfile` und `infra/compose/**` laufen nicht über generische Renovate-PRs. Diese Pfade sind an kontrollierte OCI-Basen, Deployment-Drift-Prüfung und R3-Review-Evidenz gebunden. Ein reiner Image-Tag- oder Digest-Tausch kann diese Verträge nicht atomar erfüllen; solche Updates brauchen einen expliziten, revisionsgebundenen Migrationspfad.

--- a/scripts/fleet/renovate_policy.py
+++ b/scripts/fleet/renovate_policy.py
@@ -232,6 +232,7 @@ def validate_preset(preset: dict[str, Any]) -> None:
                 "matchPackageNames",
                 "matchDepNames",
                 "matchRepositories",
+                "matchFileNames",
                 "enabled",
             },
             required=set(),
@@ -244,7 +245,7 @@ def validate_preset(preset: dict[str, Any]) -> None:
             ):
                 raise PolicyError(f"packageRules[{index}].matchManagers must be non-empty strings")
 
-        for field in ("matchPackageNames", "matchDepNames", "matchRepositories"):
+        for field in ("matchPackageNames", "matchDepNames", "matchRepositories", "matchFileNames"):
             if field not in rule:
                 continue
             values = rule[field]
@@ -308,6 +309,12 @@ def validate_preset(preset: dict[str, Any]) -> None:
         {
             "matchManagers": ["github-actions"],
             "matchRepositories": ["heimgewebe/weltgewebe"],
+            "enabled": False,
+        },
+        {
+            "matchManagers": ["dockerfile", "docker-compose"],
+            "matchRepositories": ["heimgewebe/weltgewebe"],
+            "matchFileNames": ["apps/**/Dockerfile", "infra/compose/**"],
             "enabled": False,
         },
     )

--- a/tests/test_renovate_policy.py
+++ b/tests/test_renovate_policy.py
@@ -131,6 +131,12 @@ def test_shared_preset_keeps_governed_dependency_lanes_out_of_generic_renovate()
             "matchRepositories": ["heimgewebe/weltgewebe"],
             "enabled": False,
         },
+        {
+            "matchManagers": ["dockerfile", "docker-compose"],
+            "matchRepositories": ["heimgewebe/weltgewebe"],
+            "matchFileNames": ["apps/**/Dockerfile", "infra/compose/**"],
+            "enabled": False,
+        },
     )
     for required in expected:
         assert any(all(rule.get(key) == value for key, value in required.items()) for rule in rules)
@@ -187,5 +193,16 @@ def test_shared_preset_disables_generic_major_updates() -> None:
     _, _, preset = _inputs()
     assert any(
         rule.get("matchUpdateTypes") == ["major"] and rule.get("enabled") is False
+        for rule in preset["packageRules"]
+    )
+
+
+def test_shared_preset_disables_weltgewebe_deployment_image_managers() -> None:
+    _, _, preset = _inputs()
+    assert any(
+        rule.get("matchManagers") == ["dockerfile", "docker-compose"]
+        and rule.get("matchRepositories") == ["heimgewebe/weltgewebe"]
+        and rule.get("matchFileNames") == ["apps/**/Dockerfile", "infra/compose/**"]
+        and rule.get("enabled") is False
         for rule in preset["packageRules"]
     )


### PR DESCRIPTION
## Problem
Die verbleibenden roten Renovate-PRs in Weltgewebe sind keine normalen Digest-Updates:

- Weltgewebe #1740 ändert nur `apps/api/Dockerfile`; der Kubernetes-/OCI-Vertrag verlangt kontrollierte OCI-Basen statt eines nackten öffentlichen `debian`-Digest-Tauschs.
- Weltgewebe #1741 ändert nur `infra/compose/compose.ops.override.yml`; der Deploy-Drift-Guard verlangt eine gekoppelte Snapshot-/Doku-Mitigation und der Review-Evidence-Gate stuft den Pfad als R3 mit revisionsgebundener Review-Evidenz ein.

Generisches Renovate kann diese gekoppelten Verträge nicht atomar erfüllen.

## Fix
- generische Renovate-Updates für Weltgewebe auf exakt `apps/**/Dockerfile` und `infra/compose/**` deaktivieren;
- die Regel im zentralen Renovate-Policy-Validator fail-closed verpflichtend machen;
- Regressionstest ergänzen;
- Migrationspfad dokumentieren.

Die Regel ist absichtlich nicht managerweit für ganz Weltgewebe: `.devcontainer/Dockerfile.extended` bleibt außerhalb des Schutzes und wird im echten Renovate-Dry-Run weiterhin als normales Update erkannt.

## Verifikation
- `python3 -m pytest -q tests/test_renovate_policy.py` -> 12 passed
- `just renovate-policy-check` -> ok für 18 Fleet-Repos
- `git diff --check` -> grün
- Renovate 42.99.0 `--dry-run=full heimgewebe/weltgewebe` auf exakt `157d6656aa01da76072021fea59aa599d718fe9c`:
  - `apps/api/Dockerfile`/`debian` -> `skipReason: disabled`
  - `infra/compose/compose.ops.override.yml`/`nats` -> `skipReason: disabled`
  - `renovate/debian-bookworm-slim` und `renovate/nats-2` fehlen in der gewünschten `branchList`
  - `.devcontainer/Dockerfile.extended` bleibt aktiv (`docker/dockerfile` 1.4 -> 1.26)

Commit unter Review: `157d6656aa01da76072021fea59aa599d718fe9c`.