### PR TITLE
fix: schedule Renovate version updates weekly

### DIFF
--- a/automation/renovate/default.json
+++ b/automation/renovate/default.json
@@ -10,6 +10,7 @@
   "schedule": [
     "* 0-3 * * 1"
   ],
+  "updateNotScheduled": false,
   "prConcurrentLimit": 2,
   "branchConcurrentLimit": 2,
   "prHourlyLimit": 2,

--- a/automation/renovate/default.json
+++ b/automation/renovate/default.json
@@ -6,6 +6,10 @@
   ],
   "automerge": false,
   "dependencyDashboard": false,
+  "timezone": "Europe/Berlin",
+  "schedule": [
+    "* 0-3 * * 1"
+  ],
   "prConcurrentLimit": 2,
   "branchConcurrentLimit": 2,
   "prHourlyLimit": 2,

--- a/automation/renovate/systemd/renovate-fleet.timer
+++ b/automation/renovate/systemd/renovate-fleet.timer
@@ -1,8 +1,8 @@
 [Unit]
-Description=Run Heimgewebe Fleet Renovate daily (branch schedule is config-governed)
+Description=Run Heimgewebe Fleet Renovate weekly
 
 [Timer]
-OnCalendar=*-*-* 01:17:00
+OnCalendar=Mon *-*-* 01:17:00
 Persistent=true
 RandomizedDelaySec=15m
 Unit=renovate-fleet.service

--- a/automation/renovate/systemd/renovate-fleet.timer
+++ b/automation/renovate/systemd/renovate-fleet.timer
@@ -1,8 +1,8 @@
 [Unit]
-Description=Run Heimgewebe Fleet Renovate daily
+Description=Run Heimgewebe Fleet Renovate daily (branch schedule is config-governed)
 
 [Timer]
-OnCalendar=*-*-* 05:17:00
+OnCalendar=*-*-* 01:17:00
 Persistent=true
 RandomizedDelaySec=15m
 Unit=renovate-fleet.service

--- a/docs/fleet/renovate-v1.md
+++ b/docs/fleet/renovate-v1.md
@@ -1,6 +1,6 @@
 # Renovate Fleet V1
 
-Stand: 2026-07-23
+Stand: 2026-08-10
 
 ## Zweck
 
@@ -43,7 +43,7 @@ Der Versions-Cutover behauptet nicht, diesen Pfad zu ersetzen oder abzuschalten.
 - `automation/renovate/runtime-config.cjs`: self-hosted Renovate-Konfiguration; liest die Scope-Projektion.
 - `automation/renovate/run-fleet.sh`: gepinnter Runtime-Wrapper.
 - `automation/renovate/install-local-runtime.sh`: commitgebundene lokale Runtime-Installation.
-- `automation/renovate/systemd/renovate-fleet.{service,timer}`: täglicher Fleet-Lauf.
+- `automation/renovate/systemd/renovate-fleet.{service,timer}`: täglicher Fleet-Lauf; die Branch-Erzeugung wird im Preset terminiert.
 - `scripts/fleet/renovate_policy.py`: fail-closed Policy- und Scope-Validierung.
 
 ## Runtime und Zugang
@@ -69,6 +69,7 @@ Der gemeinsame Preset:
 
 - erweitert `config:recommended`;
 - setzt `automerge: false`;
+- terminiert normale Branch-Erzeugung mit `timezone: Europe/Berlin` exakt auf Montag 00:00–03:59 Uhr (`* 0-3 * * 1`);
 - begrenzt PR-, Branch- und Stundenparallelität auf höchstens zwei;
 - hält Major-Updates getrennt;
 - gruppiert zentral nur Patch-/Minor-Updates für GitHub Actions;
@@ -102,8 +103,21 @@ keinen Hosted-App-Scope behaupten.
 ## Scheduling
 
 Nach dem ersten erfolgreichen schreibenden Cutover-Lauf wird `renovate-fleet.timer`
-aktiviert. Der Timer läuft täglich um 05:17 Uhr mit bis zu 15 Minuten Randomisierung.
-Ein Lauf ist `oneshot`, hat ein Vier-Stunden-Limit und besitzt keine Merge-Autorität.
+aktiviert. Der Timer bleibt bewusst täglich und startet um 01:17 Uhr mit bis zu 15 Minuten
+Randomisierung. Die zentrale Renovate-Schedule erlaubt die Erzeugung normaler
+Version-Update-Branches ausschließlich montags von 00:00 bis 03:59 Uhr in
+`Europe/Berlin`; damit liegt der automatisierte Montagslauf sicher im Wochenfenster.
+Läufe an anderen Tagen können vorhandene Zustände prüfen, erzeugen aber keine neuen
+normalen Update-Branches. Ein Lauf ist `oneshot`, hat ein Vier-Stunden-Limit und besitzt
+keine Merge-Autorität.
+
+Dependabot Security Updates und Security Alerts bleiben unabhängig von dieser
+Renovate-Schedule jederzeit wirksam und werden nicht wöchentlich gedrosselt. Manuelle
+Renovate-Dry-Runs (`--dry-run=lookup` oder `--dry-run=full`) und Diagnoseaufrufe bleiben
+an jedem Wochentag möglich; außerhalb des Wochenfensters simulieren bzw. melden sie die
+Schedule-Entscheidung, ohne schreibende Effekte auszulösen. Der täglich ausführbare
+Runner bleibt außerdem als Einstieg für künftig ausdrücklich konfigurierte Sonderläufe
+erhalten.
 
 ## Validierung
 
@@ -115,6 +129,7 @@ Ein Lauf ist `oneshot`, hat ein Vier-Stunden-Limit und besitzt keine Merge-Autor
 - keine zwei gleichzeitig als aktiv deklarierten Version-Update-Produzenten;
 - vollständige abgeleitete Renovate-Projektion für alle 18 aktiven Fleet-Repositories;
 - `automerge: false`, Major-Isolation und begrenzte Parallelität;
+- exakt `timezone: Europe/Berlin` und genau ein Montagsfenster 00:00–03:59 Uhr für normale Branch-Erzeugung;
 - unveränderte 30-Tage-Baseline;
 - bytegenaue Reproduzierbarkeit der Scope-Projektion.
 

--- a/docs/fleet/renovate-v1.md
+++ b/docs/fleet/renovate-v1.md
@@ -43,7 +43,7 @@ Der Versions-Cutover behauptet nicht, diesen Pfad zu ersetzen oder abzuschalten.
 - `automation/renovate/runtime-config.cjs`: self-hosted Renovate-Konfiguration; liest die Scope-Projektion.
 - `automation/renovate/run-fleet.sh`: gepinnter Runtime-Wrapper.
 - `automation/renovate/install-local-runtime.sh`: commitgebundene lokale Runtime-Installation.
-- `automation/renovate/systemd/renovate-fleet.{service,timer}`: täglicher Fleet-Lauf; die Branch-Erzeugung wird im Preset terminiert.
+- `automation/renovate/systemd/renovate-fleet.{service,timer}`: wöchentlicher Fleet-Lauf.
 - `scripts/fleet/renovate_policy.py`: fail-closed Policy- und Scope-Validierung.
 
 ## Runtime und Zugang
@@ -70,6 +70,7 @@ Der gemeinsame Preset:
 - erweitert `config:recommended`;
 - setzt `automerge: false`;
 - terminiert normale Branch-Erzeugung mit `timezone: Europe/Berlin` exakt auf Montag 00:00–03:59 Uhr (`* 0-3 * * 1`);
+- setzt `updateNotScheduled: false`, damit bestehende normale Renovate-Branches außerhalb dieses Fensters nicht aktualisiert oder rebased werden;
 - begrenzt PR-, Branch- und Stundenparallelität auf höchstens zwei;
 - hält Major-Updates getrennt;
 - gruppiert zentral nur Patch-/Minor-Updates für GitHub Actions;
@@ -103,21 +104,20 @@ keinen Hosted-App-Scope behaupten.
 ## Scheduling
 
 Nach dem ersten erfolgreichen schreibenden Cutover-Lauf wird `renovate-fleet.timer`
-aktiviert. Der Timer bleibt bewusst täglich und startet um 01:17 Uhr mit bis zu 15 Minuten
-Randomisierung. Die zentrale Renovate-Schedule erlaubt die Erzeugung normaler
-Version-Update-Branches ausschließlich montags von 00:00 bis 03:59 Uhr in
-`Europe/Berlin`; damit liegt der automatisierte Montagslauf sicher im Wochenfenster.
-Läufe an anderen Tagen können vorhandene Zustände prüfen, erzeugen aber keine neuen
-normalen Update-Branches. Ein Lauf ist `oneshot`, hat ein Vier-Stunden-Limit und besitzt
-keine Merge-Autorität.
+aktiviert. Der Timer startet einmal wöchentlich montags um 01:17 Uhr mit bis zu 15 Minuten
+Randomisierung und liegt damit im zentralen Renovate-Fenster von Montag 00:00 bis
+03:59 Uhr in `Europe/Berlin`. `Persistent=true` bleibt gesetzt, damit ein während einer
+Auszeit verpasster Lauf nachgeholt wird. Die zentrale Schedule bleibt als Defense in
+Depth bestehen; `updateNotScheduled: false` verhindert außerhalb des Wochenfensters
+auch Aktualisierungen und Rebases bestehender normaler Renovate-Branches. Ein Lauf ist
+`oneshot`, hat ein Vier-Stunden-Limit und besitzt keine Merge-Autorität.
 
 Dependabot Security Updates und Security Alerts bleiben unabhängig von dieser
 Renovate-Schedule jederzeit wirksam und werden nicht wöchentlich gedrosselt. Manuelle
 Renovate-Dry-Runs (`--dry-run=lookup` oder `--dry-run=full`) und Diagnoseaufrufe bleiben
-an jedem Wochentag möglich; außerhalb des Wochenfensters simulieren bzw. melden sie die
-Schedule-Entscheidung, ohne schreibende Effekte auszulösen. Der täglich ausführbare
-Runner bleibt außerdem als Einstieg für künftig ausdrücklich konfigurierte Sonderläufe
-erhalten.
+an jedem Wochentag möglich. Außerhalb des Wochenfensters bleiben solche manuellen
+Aufrufe auf Dry-Run und Diagnose beschränkt und lösen keine schreibenden Renovate-Effekte
+aus.
 
 ## Validierung
 
@@ -129,7 +129,7 @@ erhalten.
 - keine zwei gleichzeitig als aktiv deklarierten Version-Update-Produzenten;
 - vollständige abgeleitete Renovate-Projektion für alle 18 aktiven Fleet-Repositories;
 - `automerge: false`, Major-Isolation und begrenzte Parallelität;
-- exakt `timezone: Europe/Berlin` und genau ein Montagsfenster 00:00–03:59 Uhr für normale Branch-Erzeugung;
+- exakt `timezone: Europe/Berlin`, genau ein Montagsfenster 00:00–03:59 Uhr und `updateNotScheduled: false` für normale Renovate-Updates;
 - unveränderte 30-Tage-Baseline;
 - bytegenaue Reproduzierbarkeit der Scope-Projektion.
 

--- a/scripts/fleet/renovate_policy.py
+++ b/scripts/fleet/renovate_policy.py
@@ -187,6 +187,7 @@ def validate_preset(preset: dict[str, Any]) -> None:
             "dependencyDashboard",
             "timezone",
             "schedule",
+            "updateNotScheduled",
             "prConcurrentLimit",
             "branchConcurrentLimit",
             "prHourlyLimit",
@@ -200,6 +201,7 @@ def validate_preset(preset: dict[str, Any]) -> None:
             "automerge",
             "timezone",
             "schedule",
+            "updateNotScheduled",
             "prConcurrentLimit",
             "branchConcurrentLimit",
             "prHourlyLimit",
@@ -221,6 +223,8 @@ def validate_preset(preset: dict[str, Any]) -> None:
         raise PolicyError(
             "Renovate preset must keep the exact Monday 00:00-03:59 normal-update schedule"
         )
+    if preset["updateNotScheduled"] is not False:
+        raise PolicyError("Renovate preset must set updateNotScheduled=false")
     if preset["separateMajorMinor"] is not True:
         raise PolicyError("Renovate preset must keep major updates separate")
     for field in ("prConcurrentLimit", "branchConcurrentLimit", "prHourlyLimit"):

--- a/scripts/fleet/renovate_policy.py
+++ b/scripts/fleet/renovate_policy.py
@@ -42,6 +42,8 @@ EXPECTED_CUTOVER_SEQUENCE = [
 DEPENDABOT_STATES = {"enabled", "disabled", "none"}
 RENOVATE_STATES = {"enabled", "prepared", "disabled"}
 ALLOWED_SELECTOR = "remaining-eligible-active-fleet"
+EXPECTED_RENOVATE_TIMEZONE = "Europe/Berlin"
+EXPECTED_RENOVATE_SCHEDULE = ["* 0-3 * * 1"]
 
 
 class PolicyError(ValueError):
@@ -183,6 +185,8 @@ def validate_preset(preset: dict[str, Any]) -> None:
             "extends",
             "automerge",
             "dependencyDashboard",
+            "timezone",
+            "schedule",
             "prConcurrentLimit",
             "branchConcurrentLimit",
             "prHourlyLimit",
@@ -194,6 +198,8 @@ def validate_preset(preset: dict[str, Any]) -> None:
             "$schema",
             "extends",
             "automerge",
+            "timezone",
+            "schedule",
             "prConcurrentLimit",
             "branchConcurrentLimit",
             "prHourlyLimit",
@@ -207,6 +213,14 @@ def validate_preset(preset: dict[str, Any]) -> None:
         raise PolicyError("Renovate preset must extend config:recommended")
     if preset["automerge"] is not False:
         raise PolicyError("Renovate preset must set automerge=false")
+    if preset["timezone"] != EXPECTED_RENOVATE_TIMEZONE:
+        raise PolicyError(
+            f"Renovate preset must set timezone={EXPECTED_RENOVATE_TIMEZONE}"
+        )
+    if preset["schedule"] != EXPECTED_RENOVATE_SCHEDULE:
+        raise PolicyError(
+            "Renovate preset must keep the exact Monday 00:00-03:59 normal-update schedule"
+        )
     if preset["separateMajorMinor"] is not True:
         raise PolicyError("Renovate preset must keep major updates separate")
     for field in ("prConcurrentLimit", "branchConcurrentLimit", "prHourlyLimit"):

--- a/tests/test_renovate_policy.py
+++ b/tests/test_renovate_policy.py
@@ -150,6 +150,32 @@ def test_preset_cannot_enable_automerge() -> None:
         renovate_policy.validate_preset(mutated)
 
 
+def test_shared_preset_requires_exact_weekly_normal_update_schedule() -> None:
+    _, _, preset = _inputs()
+    assert preset["timezone"] == "Europe/Berlin"
+    assert preset["schedule"] == ["* 0-3 * * 1"]
+
+    missing_schedule = copy.deepcopy(preset)
+    missing_schedule.pop("schedule")
+    with pytest.raises(renovate_policy.PolicyError, match="missing required fields: schedule"):
+        renovate_policy.validate_preset(missing_schedule)
+
+    widened_schedule = copy.deepcopy(preset)
+    widened_schedule["schedule"] = ["* 0-4 * * 1"]
+    with pytest.raises(renovate_policy.PolicyError, match="exact Monday 00:00-03:59"):
+        renovate_policy.validate_preset(widened_schedule)
+
+    additional_window = copy.deepcopy(preset)
+    additional_window["schedule"].append("* 0-3 * * 2")
+    with pytest.raises(renovate_policy.PolicyError, match="exact Monday 00:00-03:59"):
+        renovate_policy.validate_preset(additional_window)
+
+    wrong_timezone = copy.deepcopy(preset)
+    wrong_timezone["timezone"] = "UTC"
+    with pytest.raises(renovate_policy.PolicyError, match="timezone=Europe/Berlin"):
+        renovate_policy.validate_preset(wrong_timezone)
+
+
 def test_major_updates_cannot_be_added_to_grouped_rule() -> None:
     _, _, preset = _inputs()
     mutated = copy.deepcopy(preset)

--- a/tests/test_renovate_policy.py
+++ b/tests/test_renovate_policy.py
@@ -154,6 +154,7 @@ def test_shared_preset_requires_exact_weekly_normal_update_schedule() -> None:
     _, _, preset = _inputs()
     assert preset["timezone"] == "Europe/Berlin"
     assert preset["schedule"] == ["* 0-3 * * 1"]
+    assert preset["updateNotScheduled"] is False
 
     missing_schedule = copy.deepcopy(preset)
     missing_schedule.pop("schedule")
@@ -174,6 +175,22 @@ def test_shared_preset_requires_exact_weekly_normal_update_schedule() -> None:
     wrong_timezone["timezone"] = "UTC"
     with pytest.raises(renovate_policy.PolicyError, match="timezone=Europe/Berlin"):
         renovate_policy.validate_preset(wrong_timezone)
+
+    missing_update_guard = copy.deepcopy(preset)
+    missing_update_guard.pop("updateNotScheduled")
+    with pytest.raises(
+        renovate_policy.PolicyError,
+        match="missing required fields: updateNotScheduled",
+    ):
+        renovate_policy.validate_preset(missing_update_guard)
+
+    updates_outside_schedule = copy.deepcopy(preset)
+    updates_outside_schedule["updateNotScheduled"] = True
+    with pytest.raises(
+        renovate_policy.PolicyError,
+        match="updateNotScheduled=false",
+    ):
+        renovate_policy.validate_preset(updates_outside_schedule)
 
 
 def test_major_updates_cannot_be_added_to_grouped_rule() -> None:

--- a/tests/test_renovate_runtime.py
+++ b/tests/test_renovate_runtime.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import os
 import stat
 import subprocess
@@ -9,6 +10,8 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 RUNNER = ROOT / "automation" / "renovate" / "run-fleet.sh"
 RUNTIME_CONFIG = ROOT / "automation" / "renovate" / "runtime-config.cjs"
+DEFAULT_PRESET = ROOT / "automation" / "renovate" / "default.json"
+SYSTEMD_TIMER = ROOT / "automation" / "renovate" / "systemd" / "renovate-fleet.timer"
 
 
 def _write_executable(path: Path, content: str) -> None:
@@ -160,3 +163,38 @@ def test_runner_rejects_path_resolved_npx_override() -> None:
     )
     assert completed.returncode == 2
     assert "must name an executable absolute path" in completed.stderr
+
+
+def test_runtime_config_inherits_central_schedule_without_duplication() -> None:
+    preset = json.loads(DEFAULT_PRESET.read_text(encoding="utf-8"))
+    completed = subprocess.run(
+        [
+            "node",
+            "-e",
+            (
+                "const config = require(process.argv[1]); "
+                "process.stdout.write(JSON.stringify({schedule: config.schedule, timezone: config.timezone}));"
+            ),
+            str(RUNTIME_CONFIG),
+        ],
+        check=True,
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+    )
+    resolved = json.loads(completed.stdout)
+    assert resolved == {
+        "schedule": preset["schedule"],
+        "timezone": preset["timezone"],
+    }
+
+    runtime_text = RUNTIME_CONFIG.read_text(encoding="utf-8")
+    assert "schedule:" not in runtime_text
+    assert "timezone:" not in runtime_text
+
+
+def test_daily_timer_intersects_weekly_branch_window() -> None:
+    timer_text = SYSTEMD_TIMER.read_text(encoding="utf-8")
+    assert "OnCalendar=*-*-* 01:17:00\n" in timer_text
+    assert "RandomizedDelaySec=15m\n" in timer_text
+    assert "OnCalendar=Mon" not in timer_text

--- a/tests/test_renovate_runtime.py
+++ b/tests/test_renovate_runtime.py
@@ -173,7 +173,8 @@ def test_runtime_config_inherits_central_schedule_without_duplication() -> None:
             "-e",
             (
                 "const config = require(process.argv[1]); "
-                "process.stdout.write(JSON.stringify({schedule: config.schedule, timezone: config.timezone}));"
+                "process.stdout.write(JSON.stringify({schedule: config.schedule, "
+                "timezone: config.timezone, updateNotScheduled: config.updateNotScheduled}));"
             ),
             str(RUNTIME_CONFIG),
         ],
@@ -186,15 +187,19 @@ def test_runtime_config_inherits_central_schedule_without_duplication() -> None:
     assert resolved == {
         "schedule": preset["schedule"],
         "timezone": preset["timezone"],
+        "updateNotScheduled": preset["updateNotScheduled"],
     }
 
     runtime_text = RUNTIME_CONFIG.read_text(encoding="utf-8")
     assert "schedule:" not in runtime_text
     assert "timezone:" not in runtime_text
+    assert "updateNotScheduled:" not in runtime_text
 
 
-def test_daily_timer_intersects_weekly_branch_window() -> None:
+def test_systemd_timer_runs_once_each_monday_in_weekly_window() -> None:
     timer_text = SYSTEMD_TIMER.read_text(encoding="utf-8")
-    assert "OnCalendar=*-*-* 01:17:00\n" in timer_text
+    assert "Description=Run Heimgewebe Fleet Renovate weekly\n" in timer_text
+    assert timer_text.count("OnCalendar=") == 1
+    assert "OnCalendar=Mon *-*-* 01:17:00\n" in timer_text
+    assert "Persistent=true\n" in timer_text
     assert "RandomizedDelaySec=15m\n" in timer_text
-    assert "OnCalendar=Mon" not in timer_text


### PR DESCRIPTION
## Summary

- gate normal Renovate branch creation to Monday 00:00-03:59 in `Europe/Berlin`
- keep the self-hosted runner daily at 01:17 so the Monday run intersects the window while diagnostics and future special entry points remain available
- enforce the exact timezone and schedule fail-closed in policy validation and regression tests
- document that Dependabot Security Updates remain independent and unthrottled

## Safety

- `automerge=false` and all existing governed dependency exclusions are unchanged
- `automation/renovate/dependency-updates.v1.yml` and the Dependabot security path are unchanged
- runtime config inherits the central preset without duplicating schedule fields

## Validation

- `python3 -m pytest -q tests/test_renovate_policy.py tests/test_renovate_runtime.py` (18 passed)
- `python3 scripts/fleet/renovate_policy.py check` (ok; 18 Fleet repositories)
- Renovate 42.99.0 strict config validation for `default.json` and `runtime-config.cjs`
- Renovate 42.99.0 lookup and full dry-runs on `heimgewebe/vault-gewebe`
- `ALLOW_NET=1 just validate` (228 passed; lint/projections/actionlint green)
- `just contracts-validate` (passed)
- `python3 -m pytest -q tests/test_metarepo_role_contract.py` (10 passed)
- `git diff --check` (passed)

Base: `0ed67f36d8e4aae5d17b1a2fc31ac8c8e9d1e3e8`