### PR TITLE
feat(contracts): identitätsgebundener Produzent für Contract-Source-Manifeste

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -352,27 +352,6 @@ jobs:
             echo "just not installed"
           fi
 
-      - name: Cache lychee URL state
-        if: runner.os == 'Linux' && hashFiles('.lychee.toml') != ''
-        uses: actions/cache@v6  # v6 (major tag)
-        with:
-          path: ~/.cache/lychee
-          key: ${{ runner.os }}-lychee-${{ hashFiles('.lychee.toml', 'README.md', 'docs/**/*.md') }}
-          restore-keys: |
-            ${{ runner.os }}-lychee-
-
-      - name: Link check with Lychee (Linux)
-        if: runner.os == 'Linux' && hashFiles('.lychee.toml') != ''
-        uses: lycheeverse/lychee-action@v2.9.0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          LYCHEE_CACHE_DIR: ~/.cache/lychee
-        with:
-          # nutzt deine .lychee.toml (inkl. inputs), kein doppelter Pfad nötig
-          args: --config .lychee.toml README.md docs/
-          # schlägt den Job hart fehl, wenn Links kaputt sind
-          fail: true
-
       - name: Lint GitHub Actions workflows
         if: runner.os == 'Linux'
         run: |

--- a/.github/workflows/contracts-validate.yml
+++ b/.github/workflows/contracts-validate.yml
@@ -145,6 +145,26 @@ jobs:
       - name: Test producer and consumer evidence guard
         run: uv run pytest -q tests/test_contract_consumers_registry.py
 
+      - name: Test contract source manifest producer
+        run: uv run pytest -q tests/test_contract_source_manifest.py
+
+      - name: Emit and re-verify a contract source manifest from this checkout
+        run: |
+          uv run python scripts/contracts/emit_source_manifest.py \
+            --source "${GITHUB_WORKSPACE}" \
+            --out-dir "${RUNNER_TEMP}/contract-source" \
+            --consumer heim-pc \
+            --source-kind detached_archive \
+            --expected-commit "${GITHUB_SHA}" \
+            --overwrite
+          uv run python scripts/contracts/emit_source_manifest.py \
+            --source "${GITHUB_WORKSPACE}" \
+            --out-dir "${RUNNER_TEMP}/contract-source" \
+            --consumer heim-pc \
+            --source-kind detached_archive \
+            --expected-commit "${GITHUB_SHA}" \
+            --verify
+
       - name: Reject duplicate JSON keys and non-finite numbers
         run: python3 scripts/check-contract-json.py contracts
 

--- a/.github/workflows/contracts-validate.yml
+++ b/.github/workflows/contracts-validate.yml
@@ -16,6 +16,7 @@ concurrency:
       - "scripts/validate-contracts.sh"
       - "scripts/contracts/**"
       - "tests/test_contract_consumers_registry.py"
+      - "tests/test_contract_source_manifest.py"
       - "pyproject.toml"
       - "uv.lock"
       - "contracts/**"
@@ -27,6 +28,7 @@ concurrency:
       - "scripts/validate-contracts.sh"
       - "scripts/contracts/**"
       - "tests/test_contract_consumers_registry.py"
+      - "tests/test_contract_source_manifest.py"
       - "pyproject.toml"
       - "uv.lock"
       - "contracts/**"
@@ -154,6 +156,7 @@ jobs:
             --source "${GITHUB_WORKSPACE}" \
             --out-dir "${RUNNER_TEMP}/contract-source" \
             --consumer heim-pc \
+            --consumer chronik \
             --source-kind detached_archive \
             --expected-commit "${GITHUB_SHA}" \
             --overwrite
@@ -161,6 +164,7 @@ jobs:
             --source "${GITHUB_WORKSPACE}" \
             --out-dir "${RUNNER_TEMP}/contract-source" \
             --consumer heim-pc \
+            --consumer chronik \
             --source-kind detached_archive \
             --expected-commit "${GITHUB_SHA}" \
             --verify

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -23,10 +23,22 @@ Claim status values:
 
 A `verified` claim proves repository coupling at the audited commit. It does not prove live runtime use, runtime health, delivery success, semantic correctness or future compatibility. The current evidence set covers the repositories already declared in `consumers.yaml`; it does not claim complete organization-wide discovery.
 
+## Source resolution for consumers
+
+Consumers must resolve these bytes from exactly one explicit source: a named
+Metarepo Git checkout, or an immutable archive / approved offline cache bound by
+a `contract.source.manifest.schema.json` manifest. A sibling directory or
+environment variable is never source authority.
+
+`scripts/contracts/emit_source_manifest.py` is the reproducible producer of such
+a manifest; `--verify` re-proves an existing cache against the bound source.
+`docs/contracts/contract-source-resolution.md` documents the precedence, the
+typed failure codes and the consumer obligations.
+
 ## Validation
 
 ```bash
 uv run python scripts/contracts/validate_consumers.py
-uv run pytest -q tests/test_contract_consumers_registry.py
+uv run pytest -q tests/test_contract_consumers_registry.py tests/test_contract_source_manifest.py
 scripts/validate-contracts.sh
 ```

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -31,7 +31,10 @@ a `contract.source.manifest.schema.json` manifest. A sibling directory or
 environment variable is never source authority.
 
 `scripts/contracts/emit_source_manifest.py` is the reproducible producer of such
-a manifest; `--verify` re-proves an existing cache against the bound source.
+a manifest. It binds bytes from the selected `HEAD` Git objects—including the
+transitive closure of local relative `$ref` dependencies—so ignored or
+worktree-only files cannot enter the attestation. `--verify` re-proves an
+existing cache against the bound source.
 `docs/contracts/contract-source-resolution.md` documents the precedence, the
 typed failure codes and the consumer obligations.
 

--- a/contracts/contract.source.manifest.schema.json
+++ b/contracts/contract.source.manifest.schema.json
@@ -1,0 +1,58 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.heimgewebe.org/contract.source.manifest.schema.json",
+  "title": "Contract Source Manifest",
+  "description": "Bindet eine nicht-Git-Quelle kanonischer Metarepo-Contractbytes (losgelöstes Archiv oder freigegebener Offline-Cache) an Repositoryidentität, Commit, Inhaltswurzel und SHA-256 je Schema. Das Manifest belegt Herkunft und Unveränderlichkeit der Bytes, nicht semantische Gültigkeit oder Live-Nutzung.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "repository",
+    "commit",
+    "source_kind",
+    "source_root",
+    "schemas"
+  ],
+  "properties": {
+    "schema_version": {
+      "description": "Manifestversion. Nur 1 ist definiert.",
+      "type": "integer",
+      "const": 1
+    },
+    "repository": {
+      "description": "Kanonische GitHub-Identität der Contractquelle.",
+      "type": "string",
+      "const": "heimgewebe/metarepo"
+    },
+    "commit": {
+      "description": "Exakter 40-stelliger Kleinbuchstaben-Hex-Commit, aus dem die gebundenen Bytes stammen.",
+      "type": "string",
+      "pattern": "^[0-9a-f]{40}$"
+    },
+    "source_kind": {
+      "description": "Art der gebundenen Quelle. Ein Git-Checkout wird nie über ein Manifest gebunden, sondern direkt identitätsgeprüft.",
+      "type": "string",
+      "enum": [
+        "detached_archive",
+        "offline_cache"
+      ]
+    },
+    "source_root": {
+      "description": "Normalisierter relativer POSIX-Pfad der Inhaltswurzel unterhalb des Manifestverzeichnisses.",
+      "type": "string",
+      "pattern": "^(?!.*(^|/)\\.\\.?(/|$))[A-Za-z0-9._-]+(/[A-Za-z0-9._-]+)*$"
+    },
+    "schemas": {
+      "description": "Vollständige Bindung jedes Schemas, das ein Konsument aus dieser Quelle verwenden darf: relativer Pfad unterhalb der Inhaltswurzel auf SHA-256 der exakten Bytes.",
+      "type": "object",
+      "minProperties": 1,
+      "propertyNames": {
+        "pattern": "^(?!.*(^|/)\\.\\.?(/|$))[A-Za-z0-9._-]+(/[A-Za-z0-9._-]+)*$"
+      },
+      "additionalProperties": {
+        "type": "string",
+        "pattern": "^[0-9a-f]{64}$"
+      }
+    }
+  }
+}

--- a/docs/contracts/contract-source-resolution.md
+++ b/docs/contracts/contract-source-resolution.md
@@ -1,0 +1,107 @@
+# Auflösung kanonischer Contractquellen
+
+Konsumenten des Heimgewebes validieren gegen die von Metarepo veröffentlichten
+Contractbytes. Dieses Dokument legt fest, **woher** diese Bytes stammen dürfen und
+**wie** die Herkunft belegt wird. Es beschreibt keine semantische Gültigkeit,
+keine Live-Nutzung und keine Merge-Reife.
+
+## Auflösungsreihenfolge
+
+Eine Auflösung ist gültig, wenn genau eine Quelle explizit benannt wurde:
+
+1. **Expliziter Git-Checkout** — der Konsument bekommt den Repositorywurzelpfad
+   als Argument. Die Quelle wird über `remote.origin.url` gegen
+   `heimgewebe/metarepo` geprüft, der 40-stellige `HEAD` wird festgehalten, ein
+   unsauberer Baum schlägt fehl.
+2. **Unveränderliche, manifestgebundene Quelle** — ein losgelöstes Archiv oder ein
+   freigegebener Offline-Cache, gebunden durch ein
+   `contract.source.manifest.schema.json`-Manifest.
+
+Ein danebenliegendes Verzeichnis, eine Umgebungsvariable oder ein bestimmter
+Ausführungswrapper sind **nie** stille Autorität. Fehlt die explizite Angabe,
+schlägt die Validierung fehl; sie fällt nicht auf einen Suchpfad zurück.
+
+Weil sämtliche Eingaben Kommandozeilenargumente sind, überstehen synchrone wie
+dauerhafte Ausführungswege (Shell, CI-Step, Grabowski-Route) die Auflösung
+unverändert: es gibt keine verdeckte Shell-Initialisierung, die erhalten werden
+müsste, und ein weggelassenes Argument wird typisiert abgelehnt statt geraten.
+
+## Manifest erzeugen
+
+`scripts/contracts/emit_source_manifest.py` ist der reproduzierbare Produzent.
+Er liest ausschließlich aus einem explizit benannten, identitätsgeprüften und
+sauberen Metarepo-Checkout:
+
+```bash
+python3 scripts/contracts/emit_source_manifest.py \
+  --source /pfad/zum/metarepo \
+  --out-dir /pfad/zum/archiv \
+  --consumer heim-pc \
+  --source-kind detached_archive \
+  --expected-commit 0123456789abcdef0123456789abcdef01234567
+```
+
+Ergebnis ist `metarepo-contract-source.v1.json` neben einer Inhaltswurzel
+(`content/` per Vorgabe) mit exakt den gebundenen Schemabytes.
+
+- `--consumer NAME` bindet jedes Schema unter `contracts/NAME/`.
+- `--schema PFAD` bindet ein einzelnes Schema zusätzlich.
+- Ohne `--consumer`/`--schema` bricht der Lauf ab; ein Manifest ohne Bindung ist
+  wertlos.
+- Ein unsauberer Quellbaum bricht ab: ein Manifest behauptet unveränderliche
+  Bytes.
+- Das Ausgabeverzeichnis darf nicht innerhalb der Quelle liegen und ein
+  vorhandener, nicht leerer Inhaltsbaum wird nur mit `--overwrite` ersetzt.
+
+Die Ausgabe ist deterministisch: gleiche Quelle und gleiche Auswahl ergeben
+byteidentische Manifeste. Zeitstempel und maschinenlokale Pfade sind nicht Teil
+des Manifests.
+
+## Cache prüfen
+
+`--verify` schreibt nichts, sondern belegt, dass ein vorhandenes Manifest und
+sein Inhaltsbaum weiterhin exakt der gebundenen Quelle entsprechen:
+
+```bash
+python3 scripts/contracts/emit_source_manifest.py \
+  --source /pfad/zum/metarepo \
+  --out-dir /pfad/zum/cache \
+  --consumer heim-pc \
+  --source-kind offline_cache \
+  --verify
+```
+
+Abweichendes Manifest, veränderte, fehlende oder ungebundene Dateien im Cache
+werden mit typisiertem Fehler abgelehnt.
+
+## Typisierte Fehler
+
+Jeder Fehlschlag ist ein stabiler Code auf `stderr`, Exitcode `2`. Ein
+Fehlschlag kann nicht als Erfolg missverstanden werden, weil im Erfolgsfall das
+gerenderte Manifest auf `stdout` erscheint und Exitcode `0` gilt.
+
+| Code | Bedeutung |
+| --- | --- |
+| `SOURCE_MISSING`, `SOURCE_NOT_GIT`, `SOURCE_NOT_REPOSITORY_ROOT` | Die benannte Quelle ist kein auflösbarer Git-Repositorywurzelpfad. |
+| `SOURCE_WRONG_REPOSITORY` | `remote.origin.url` löst nicht auf `heimgewebe/metarepo` auf. |
+| `SOURCE_COMMIT_INVALID`, `SOURCE_COMMIT_MISMATCH`, `EXPECTED_COMMIT_INVALID` | Commitbindung fehlt oder weicht ab. |
+| `SOURCE_DIRTY` | Der Quellbaum trägt verfolgte oder unverfolgte Änderungen. |
+| `SCHEMA_SELECTION`, `CONSUMER_UNKNOWN`, `CONSUMER_EMPTY`, `CONSUMER_INVALID` | Die Auswahl bindet nichts oder benennt keinen vorhandenen Namensraum. |
+| `SCHEMA_PATH_INVALID`, `SCHEMA_PATH_ESCAPE`, `SCHEMA_MISSING`, `SCHEMA_UNREADABLE` | Ein Schemapfad ist nicht normalisiert relativ, verlässt die Quelle oder fehlt. |
+| `OUT_DIR_INSIDE_SOURCE`, `OUT_DIR_MISSING`, `OUT_DIR_INVALID`, `OUT_DIR_UNWRITABLE`, `CONTENT_ROOT_NOT_EMPTY` | Das Ausgabeziel ist unzulässig oder würde bestehenden Inhalt still ersetzen. |
+| `MANIFEST_MISSING`, `MANIFEST_UNREADABLE`, `MANIFEST_DRIFT` | Prüfung gegen ein fehlendes oder abweichendes Manifest. |
+| `CONTENT_MISSING`, `CONTENT_UNREADABLE`, `CONTENT_DRIFT`, `CONTENT_UNBOUND` | Der Cache weicht von den gebundenen Bytes ab. |
+
+## Konsumentenpflichten
+
+Ein Konsument, der eine manifestgebundene Quelle verwendet, muss
+
+- jedes verwendete Schema im Manifest wiederfinden und den SHA-256 vor der
+  Nutzung prüfen,
+- die Inhaltswurzel nicht verlassen,
+- Repositoryidentität und Commit in seinen Validierungsbeleg übernehmen,
+- und bei fehlender, abweichender oder ungebundener Quelle fail-closed abbrechen.
+
+`heim-pc` setzt genau das in `scripts/contract_source.py` um und schreibt einen
+deterministischen Validierungsbeleg mit Quellidentität, Commit, Dirty-State,
+Schemapfaden samt SHA-256, Konsumenten-`HEAD` und Artefakt-Hashes.

--- a/docs/contracts/contract-source-resolution.md
+++ b/docs/contracts/contract-source-resolution.md
@@ -31,7 +31,10 @@ müsste, und ein weggelassenes Argument wird typisiert abgelehnt statt geraten.
 `scripts/contracts/emit_source_manifest.py` ist der reproduzierbare Produzent.
 Er liest ausschließlich aus einem explizit benannten, identitätsgeprüften und
 sauberen Metarepo-Checkout. Auswahl und Bytes kommen aus dem festgehaltenen
-`HEAD`-Tree und seinen Git-Blobs, nicht aus Arbeitsbaumdateien:
+`HEAD`-Tree und seinen Git-Blobs, nicht aus Arbeitsbaumdateien. Für alle
+provenienzrelevanten Git-Leseoperationen sind Replacement-Refs deaktiviert;
+zusätzlich werden das wörtliche Commit-Objekt und sein Root-Tree gegen ihre
+Objekt-IDs geprüft, bevor ein Manifest attestiert wird:
 
 ```bash
 python3 scripts/contracts/emit_source_manifest.py \
@@ -48,12 +51,17 @@ Ergebnis ist `metarepo-contract-source.v1.json` neben einer Inhaltswurzel
 - `--consumer NAME` bindet jedes in `HEAD` getrackte Schema unter
   `contracts/NAME/`.
 - `--schema PFAD` bindet ein einzelnes Schema zusätzlich.
-- Für jede Auswahl wird die transitive Closure lokaler relativer `$ref`s
-  gebunden. Fragment-only-Refs bleiben im selben Blob; normalisierte
-  Cross-Namespace-Refs unter `contracts/` werden verfolgt; Zyklen sind erlaubt.
-  Fehlende, ungültige oder aus `contracts/` escapende lokale Ziele brechen
-  typisiert ab. URIs mit Scheme oder Authority bleiben externe Referenzen und
-  werden niemals über ihren URI-Pfad als lokale Dateien interpretiert.
+- Für jede Auswahl wird die transitive Closure lokaler `$ref`s gebunden. Die
+  Auflösung folgt JSON Schema Draft 2020-12: ein verschachteltes `$id` ändert den
+  aktiven Basis-URI für darunterliegende Referenzen. Alle committed
+  `contracts/**/*.schema.json` werden deterministisch nach physischem Pfad und
+  deklarierten Ressourcen-IDs indexiert, sodass Cross-Namespace- und
+  identifiergebundene lokale Ressourcen vollständig archiviert werden.
+  Fragment-only-Refs bleiben in derselben Ressource; Zyklen sind erlaubt.
+  Fehlende, doppelte, ungültige oder aus `contracts/` escapende lokale Ziele
+  brechen typisiert ab. Nicht lokal gebundene externe URIs bleiben externe
+  Referenzen und werden niemals über ihren URI-Pfad als Checkout-Dateien
+  interpretiert.
 - Ohne `--consumer`/`--schema` bricht der Lauf ab; ein Manifest ohne Bindung ist
   wertlos.
 - Ein unsauberer Quellbaum bricht ab: ein Manifest behauptet unveränderliche
@@ -95,13 +103,13 @@ erscheint und Exitcode `0` gilt.
 | Code | Bedeutung |
 | --- | --- |
 | `SOURCE_MISSING`, `SOURCE_NOT_GIT`, `SOURCE_NOT_REPOSITORY_ROOT` | Die benannte Quelle ist kein auflösbarer Git-Repositorywurzelpfad. |
-| `SOURCE_WRONG_REPOSITORY` | `remote.origin.url` löst nicht auf `heimgewebe/metarepo` auf. |
-| `SOURCE_COMMIT_INVALID`, `SOURCE_COMMIT_MISMATCH`, `EXPECTED_COMMIT_INVALID` | Commitbindung fehlt oder weicht ab. |
+| `SOURCE_WRONG_REPOSITORY` | `remote.origin.url` löst nicht auf `heimgewebe/metarepo` auf oder ist keine parsebare kanonische GitHub-Remote-URL. |
+| `SOURCE_COMMIT_INVALID`, `SOURCE_COMMIT_MISMATCH`, `EXPECTED_COMMIT_INVALID` | Commitbindung fehlt, weicht ab oder das wörtliche Commit-/Root-Tree-Objekt stimmt nicht mit seiner Objekt-ID überein. |
 | `SOURCE_DIRTY` | Der Quellbaum trägt verfolgte oder nicht ignorierte ungetrackte Änderungen. |
 | `SCHEMA_SELECTION`, `CONSUMER_UNKNOWN`, `CONSUMER_EMPTY`, `CONSUMER_INVALID` | Die Auswahl bindet nichts oder benennt keinen vorhandenen Namensraum. |
 | `SOURCE_KIND_INVALID`, `CONTENT_ROOT_INVALID` | Quellenart oder relativer Inhaltswurzelpfad ist unzulässig. |
 | `SCHEMA_PATH_INVALID`, `SCHEMA_PATH_ESCAPE`, `SCHEMA_NOT_TRACKED`, `SCHEMA_NOT_REGULAR`, `SCHEMA_UNREADABLE` | Eine Auswahl ist nicht kanonisch, nicht im gebundenen Commit getrackt, kein regulärer Git-Blob oder nicht lesbar. |
-| `SCHEMA_JSON_INVALID`, `SCHEMA_REF_INVALID`, `SCHEMA_REF_ESCAPE`, `SCHEMA_REF_MISSING` | Eine lokale `$ref`-Closure kann nicht vollständig und sicher aus den gebundenen Git-Blobs gebildet werden. |
+| `SCHEMA_JSON_INVALID`, `SCHEMA_ID_INVALID`, `SCHEMA_ID_DUPLICATE`, `SCHEMA_REF_INVALID`, `SCHEMA_REF_ESCAPE`, `SCHEMA_REF_MISSING` | Eine Schemaressource oder ihre lokale `$ref`-Closure kann nicht vollständig, eindeutig und sicher aus den gebundenen Git-Blobs gebildet werden. |
 | `OUT_DIR_INSIDE_SOURCE`, `OUT_DIR_MISSING`, `OUT_DIR_INVALID`, `OUT_DIR_UNWRITABLE`, `CONTENT_ROOT_NOT_EMPTY` | Das Ausgabeziel ist unzulässig oder würde bestehenden Inhalt still ersetzen. |
 | `CONTENT_ROOT_MISSING`, `CONTENT_ROOT_INVALID_TYPE`, `CONTENT_ROOT_PATH_ESCAPE` | Die Inhaltswurzel fehlt, ist kein Verzeichnis oder traversiert einen Symlink. |
 | `MANIFEST_MISSING`, `MANIFEST_UNREADABLE`, `MANIFEST_INVALID_TYPE`, `MANIFEST_DRIFT` | Prüfung gegen ein fehlendes, nicht reguläres, unlesbares oder abweichendes Manifest. |

--- a/docs/contracts/contract-source-resolution.md
+++ b/docs/contracts/contract-source-resolution.md
@@ -30,7 +30,8 @@ müsste, und ein weggelassenes Argument wird typisiert abgelehnt statt geraten.
 
 `scripts/contracts/emit_source_manifest.py` ist der reproduzierbare Produzent.
 Er liest ausschließlich aus einem explizit benannten, identitätsgeprüften und
-sauberen Metarepo-Checkout:
+sauberen Metarepo-Checkout. Auswahl und Bytes kommen aus dem festgehaltenen
+`HEAD`-Tree und seinen Git-Blobs, nicht aus Arbeitsbaumdateien:
 
 ```bash
 python3 scripts/contracts/emit_source_manifest.py \
@@ -44,12 +45,21 @@ python3 scripts/contracts/emit_source_manifest.py \
 Ergebnis ist `metarepo-contract-source.v1.json` neben einer Inhaltswurzel
 (`content/` per Vorgabe) mit exakt den gebundenen Schemabytes.
 
-- `--consumer NAME` bindet jedes Schema unter `contracts/NAME/`.
+- `--consumer NAME` bindet jedes in `HEAD` getrackte Schema unter
+  `contracts/NAME/`.
 - `--schema PFAD` bindet ein einzelnes Schema zusätzlich.
+- Für jede Auswahl wird die transitive Closure lokaler relativer `$ref`s
+  gebunden. Fragment-only-Refs bleiben im selben Blob; normalisierte
+  Cross-Namespace-Refs unter `contracts/` werden verfolgt; Zyklen sind erlaubt.
+  Fehlende, ungültige oder aus `contracts/` escapende lokale Ziele brechen
+  typisiert ab. URIs mit Scheme oder Authority bleiben externe Referenzen und
+  werden niemals über ihren URI-Pfad als lokale Dateien interpretiert.
 - Ohne `--consumer`/`--schema` bricht der Lauf ab; ein Manifest ohne Bindung ist
   wertlos.
 - Ein unsauberer Quellbaum bricht ab: ein Manifest behauptet unveränderliche
   Bytes.
+- Ignorierte, ausgeschlossene, ungetrackte oder nur im Arbeitsbaum vorhandene
+  Schemas sind keine Bytes des gebundenen Commits und werden niemals attestiert.
 - Das Ausgabeverzeichnis darf nicht innerhalb der Quelle liegen und ein
   vorhandener, nicht leerer Inhaltsbaum wird nur mit `--overwrite` ersetzt.
 
@@ -76,21 +86,26 @@ werden mit typisiertem Fehler abgelehnt.
 
 ## Typisierte Fehler
 
-Jeder Fehlschlag ist ein stabiler Code auf `stderr`, Exitcode `2`. Ein
-Fehlschlag kann nicht als Erfolg missverstanden werden, weil im Erfolgsfall das
-gerenderte Manifest auf `stdout` erscheint und Exitcode `0` gilt.
+Jeder Provenienz-, Auswahl-, Materialisierungs- oder Prüffehler nach erfolgreicher
+CLI-Syntaxprüfung ist ein stabiler Code auf `stderr`, Exitcode `2`. Syntaxfehler
+meldet `argparse` ebenfalls mit Exitcode `2`. Ein Fehlschlag kann nicht als Erfolg
+missverstanden werden, weil im Erfolgsfall das gerenderte Manifest auf `stdout`
+erscheint und Exitcode `0` gilt.
 
 | Code | Bedeutung |
 | --- | --- |
 | `SOURCE_MISSING`, `SOURCE_NOT_GIT`, `SOURCE_NOT_REPOSITORY_ROOT` | Die benannte Quelle ist kein auflösbarer Git-Repositorywurzelpfad. |
 | `SOURCE_WRONG_REPOSITORY` | `remote.origin.url` löst nicht auf `heimgewebe/metarepo` auf. |
 | `SOURCE_COMMIT_INVALID`, `SOURCE_COMMIT_MISMATCH`, `EXPECTED_COMMIT_INVALID` | Commitbindung fehlt oder weicht ab. |
-| `SOURCE_DIRTY` | Der Quellbaum trägt verfolgte oder unverfolgte Änderungen. |
+| `SOURCE_DIRTY` | Der Quellbaum trägt verfolgte oder nicht ignorierte ungetrackte Änderungen. |
 | `SCHEMA_SELECTION`, `CONSUMER_UNKNOWN`, `CONSUMER_EMPTY`, `CONSUMER_INVALID` | Die Auswahl bindet nichts oder benennt keinen vorhandenen Namensraum. |
-| `SCHEMA_PATH_INVALID`, `SCHEMA_PATH_ESCAPE`, `SCHEMA_MISSING`, `SCHEMA_UNREADABLE` | Ein Schemapfad ist nicht normalisiert relativ, verlässt die Quelle oder fehlt. |
+| `SOURCE_KIND_INVALID`, `CONTENT_ROOT_INVALID` | Quellenart oder relativer Inhaltswurzelpfad ist unzulässig. |
+| `SCHEMA_PATH_INVALID`, `SCHEMA_PATH_ESCAPE`, `SCHEMA_NOT_TRACKED`, `SCHEMA_NOT_REGULAR`, `SCHEMA_UNREADABLE` | Eine Auswahl ist nicht kanonisch, nicht im gebundenen Commit getrackt, kein regulärer Git-Blob oder nicht lesbar. |
+| `SCHEMA_JSON_INVALID`, `SCHEMA_REF_INVALID`, `SCHEMA_REF_ESCAPE`, `SCHEMA_REF_MISSING` | Eine lokale `$ref`-Closure kann nicht vollständig und sicher aus den gebundenen Git-Blobs gebildet werden. |
 | `OUT_DIR_INSIDE_SOURCE`, `OUT_DIR_MISSING`, `OUT_DIR_INVALID`, `OUT_DIR_UNWRITABLE`, `CONTENT_ROOT_NOT_EMPTY` | Das Ausgabeziel ist unzulässig oder würde bestehenden Inhalt still ersetzen. |
-| `MANIFEST_MISSING`, `MANIFEST_UNREADABLE`, `MANIFEST_DRIFT` | Prüfung gegen ein fehlendes oder abweichendes Manifest. |
-| `CONTENT_MISSING`, `CONTENT_UNREADABLE`, `CONTENT_DRIFT`, `CONTENT_UNBOUND` | Der Cache weicht von den gebundenen Bytes ab. |
+| `CONTENT_ROOT_MISSING`, `CONTENT_ROOT_INVALID_TYPE`, `CONTENT_ROOT_PATH_ESCAPE` | Die Inhaltswurzel fehlt, ist kein Verzeichnis oder traversiert einen Symlink. |
+| `MANIFEST_MISSING`, `MANIFEST_UNREADABLE`, `MANIFEST_INVALID_TYPE`, `MANIFEST_DRIFT` | Prüfung gegen ein fehlendes, nicht reguläres, unlesbares oder abweichendes Manifest. |
+| `CONTENT_MISSING`, `CONTENT_UNREADABLE`, `CONTENT_INVALID_TYPE`, `CONTENT_DRIFT`, `CONTENT_UNBOUND` | Der Cache fehlt, enthält nicht reguläre Knoten oder weicht von den gebundenen Bytes ab. |
 
 ## Konsumentenpflichten
 

--- a/docs/contracts/contracts-index.md
+++ b/docs/contracts/contracts-index.md
@@ -163,6 +163,10 @@ Sie liegen (sofern nicht anders angegeben) in `contracts/*.schema.json` im **met
   - Aktuelle Implementierung: WGX bleibt während des v2-Cutovers ein revisionsgepinnter Kompatibilitätsrunner; der Contract überträgt WGX keine Fleet-, Task-, Git- oder Host-Autorität.
 - `tooling/toolchain.versions.schema.json`
   - Zweck: Canonical schema für `toolchain.versions.yml`, definiert required keys und Versionsformate.
+- `contract.source.manifest.schema.json`
+  - Zweck: Bindet eine nicht-Git-Quelle kanonischer Contractbytes (losgelöstes Archiv, freigegebener Offline-Cache) an Repositoryidentität, Commit, Inhaltswurzel und SHA-256 je Schema.
+  - Produzent: `scripts/contracts/emit_source_manifest.py`; Auflösungsreihenfolge und Konsumentenpflichten stehen in `docs/contracts/contract-source-resolution.md`.
+  - Belegt Herkunft und Unveränderlichkeit der Bytes, nicht semantische Gültigkeit, Live-Nutzung oder Merge-Reife.
 
 ### 1.7 Heim-PC (State & Config)
 

--- a/scripts/contracts/emit_source_manifest.py
+++ b/scripts/contracts/emit_source_manifest.py
@@ -27,7 +27,7 @@ import stat
 import subprocess
 import sys
 from typing import Any, Iterable, Sequence
-from urllib.parse import urlsplit
+from urllib.parse import urldefrag, urljoin, urlsplit
 
 EXPECTED_REPOSITORY = "heimgewebe/metarepo"
 MANIFEST_NAME = "metarepo-contract-source.v1.json"
@@ -58,12 +58,15 @@ class GitTreeEntry:
 
 
 def _run_git(root: Path, *args: str) -> str:
+    env = os.environ.copy()
+    env["GIT_NO_REPLACE_OBJECTS"] = "1"
     try:
         result = subprocess.run(
             ["git", "-C", str(root), *args],
             check=True,
             text=True,
             capture_output=True,
+            env=env,
         )
     except (OSError, subprocess.CalledProcessError, UnicodeError) as exc:
         stderr = getattr(exc, "stderr", "") or ""
@@ -74,11 +77,14 @@ def _run_git(root: Path, *args: str) -> str:
 def _run_git_bytes(
     root: Path, *args: str, code: str = "SOURCE_NOT_GIT", detail: str = "Git read failed"
 ) -> bytes:
+    env = os.environ.copy()
+    env["GIT_NO_REPLACE_OBJECTS"] = "1"
     try:
         result = subprocess.run(
             ["git", "-C", str(root), *args],
             check=True,
             capture_output=True,
+            env=env,
         )
     except (OSError, subprocess.CalledProcessError) as exc:
         stderr = getattr(exc, "stderr", b"") or b""
@@ -99,7 +105,10 @@ def _repository_identity(origin: str) -> str:
     if "://" in raw:
         from urllib.parse import urlparse
 
-        parsed = urlparse(raw)
+        try:
+            parsed = urlparse(raw)
+        except ValueError:
+            return ""
         if (parsed.hostname or "").lower() != "github.com":
             return ""
         if parsed.scheme.lower() not in {"https", "ssh", "git"}:
@@ -193,6 +202,8 @@ def resolve_source(source_path: str, expected_commit: str | None) -> tuple[Path,
                 "SOURCE_COMMIT_MISMATCH", f"expected {expected}, observed {head}"
             )
 
+    _validate_commit_objects(root, head)
+
     if _run_git(root, "status", "--porcelain=v1", "--untracked-files=all"):
         raise ManifestError(
             "SOURCE_DIRTY",
@@ -201,6 +212,51 @@ def resolve_source(source_path: str, expected_commit: str | None) -> tuple[Path,
         )
 
     return root, head
+
+
+def _git_object_id(kind: str, data: bytes) -> str:
+    header = f"{kind} {len(data)}\0".encode("ascii")
+    return hashlib.sha1(header + data).hexdigest()
+
+
+def _validate_commit_objects(root: Path, commit: str) -> None:
+    """Validate the literal commit and root-tree objects without replacements."""
+
+    commit_data = _run_git_bytes(
+        root,
+        "cat-file",
+        "commit",
+        commit,
+        code="SOURCE_COMMIT_INVALID",
+        detail=f"cannot read commit object {commit}",
+    )
+    if _git_object_id("commit", commit_data) != commit:
+        raise ManifestError(
+            "SOURCE_COMMIT_INVALID", "HEAD does not name the unchanged commit object"
+        )
+    first_line = commit_data.split(b"\n", 1)[0]
+    if not first_line.startswith(b"tree "):
+        raise ManifestError("SOURCE_COMMIT_INVALID", "commit has no root tree")
+    try:
+        tree = first_line.removeprefix(b"tree ").decode("ascii")
+    except UnicodeDecodeError as exc:
+        raise ManifestError(
+            "SOURCE_COMMIT_INVALID", "commit has an invalid root tree"
+        ) from exc
+    if not HEX40.fullmatch(tree):
+        raise ManifestError("SOURCE_COMMIT_INVALID", "commit has an invalid root tree")
+    tree_data = _run_git_bytes(
+        root,
+        "cat-file",
+        "tree",
+        tree,
+        code="SOURCE_COMMIT_INVALID",
+        detail=f"cannot read root tree object {tree}",
+    )
+    if _git_object_id("tree", tree_data) != tree:
+        raise ManifestError(
+            "SOURCE_COMMIT_INVALID", "commit does not bind an unchanged root-tree object"
+        )
 
 
 def _commit_tree(root: Path, commit: str) -> dict[str, GitTreeEntry]:
@@ -353,69 +409,148 @@ def _decode_schema(relative: str, data: bytes) -> Any:
         ) from exc
 
 
-def _schema_references(relative: str, schema: Any) -> Iterable[str]:
+def _physical_schema_uri(relative: str) -> str:
+    return f"https://metarepo.invalid/{relative}"
+
+
+def _resolve_uri(referrer: str, base_uri: str, value: str, keyword: str) -> str:
+    try:
+        parsed = urlsplit(value)
+        resolved = urljoin(base_uri, value)
+        urlsplit(resolved)
+    except ValueError as exc:
+        raise ManifestError(
+            f"SCHEMA_{keyword}_INVALID",
+            f"{referrer} contains an invalid ${keyword.lower()}: {value!r}",
+        ) from exc
+    if not resolved or (not parsed.scheme and value.startswith("//")):
+        raise ManifestError(
+            f"SCHEMA_{keyword}_INVALID",
+            f"{referrer} contains an invalid ${keyword.lower()}: {value!r}",
+        )
+    return resolved
+
+
+def _schema_resources_and_references(
+    relative: str, schema: Any, base_uri: str
+) -> Iterable[tuple[str, str]]:
+    """Yield resource identifiers and references with their active base URI."""
+
     if isinstance(schema, dict):
+        active_base = base_uri
+        if "$id" in schema:
+            identifier = schema["$id"]
+            if not isinstance(identifier, str):
+                raise ManifestError(
+                    "SCHEMA_ID_INVALID", f"{relative} contains a non-string $id"
+                )
+            active_base = _resolve_uri(relative, base_uri, identifier, "ID")
+            document_uri, fragment = urldefrag(active_base)
+            if fragment:
+                raise ManifestError(
+                    "SCHEMA_ID_INVALID", f"{relative} contains a fragment-bearing $id"
+                )
+            yield "identifier", document_uri
         for key in sorted(schema):
             value = schema[key]
             if key == "$ref":
                 if not isinstance(value, str):
                     raise ManifestError(
-                        "SCHEMA_REF_INVALID",
-                        f"{relative} contains a non-string $ref",
+                        "SCHEMA_REF_INVALID", f"{relative} contains a non-string $ref"
                     )
-                yield value
-            yield from _schema_references(relative, value)
+                yield "reference", _resolve_uri(relative, active_base, value, "REF")
+            if key != "$id":
+                yield from _schema_resources_and_references(relative, value, active_base)
     elif isinstance(schema, list):
         for value in schema:
-            yield from _schema_references(relative, value)
+            yield from _schema_resources_and_references(relative, value, base_uri)
 
 
-def _resolve_local_reference(referrer: str, reference: str) -> str | None:
-    """Resolve a repository-local reference, or return None for an external URI."""
+def _schema_identifier_index(
+    root: Path, tree: dict[str, GitTreeEntry]
+) -> tuple[dict[str, str], dict[str, tuple[Any, bytes]]]:
+    """Index every committed schema resource identifier deterministically."""
+
+    identifiers: dict[str, str] = {}
+    schemas: dict[str, tuple[Any, bytes]] = {}
+    for relative in sorted(
+        path
+        for path in tree
+        if path.startswith("contracts/") and path.endswith(".schema.json")
+    ):
+        data = _read_schema_blob(root, tree, relative)
+        schema = _decode_schema(relative, data)
+        schemas[relative] = (schema, data)
+        physical_uri = _physical_schema_uri(relative)
+        previous = identifiers.get(physical_uri)
+        if previous is not None and previous != relative:
+            raise ManifestError(
+                "SCHEMA_ID_DUPLICATE",
+                f"schema resource identifier {physical_uri!r} is bound by both "
+                f"{previous} and {relative}",
+            )
+        identifiers[physical_uri] = relative
+        for kind, identifier in _schema_resources_and_references(
+            relative, schema, physical_uri
+        ):
+            if kind != "identifier":
+                continue
+            previous = identifiers.get(identifier)
+            if previous is not None and previous != relative:
+                raise ManifestError(
+                    "SCHEMA_ID_DUPLICATE",
+                    f"schema resource identifier {identifier!r} is bound by both "
+                    f"{previous} and {relative}",
+                )
+            identifiers[identifier] = relative
+    return identifiers, schemas
+
+
+def _resolve_local_reference(
+    referrer: str, resolved_uri: str, identifiers: dict[str, str]
+) -> str | None:
+    """Bind a resolved URI to a committed local resource, or classify it external."""
 
     try:
-        parsed = urlsplit(reference)
+        document_uri, _fragment = urldefrag(resolved_uri)
+        parsed = urlsplit(document_uri)
     except ValueError as exc:
         raise ManifestError(
-            "SCHEMA_REF_INVALID", f"{referrer} contains an invalid $ref: {reference!r}"
+            "SCHEMA_REF_INVALID", f"{referrer} contains an invalid $ref: {resolved_uri!r}"
         ) from exc
 
-    # A URI with a scheme or authority is external provenance. In particular,
-    # never reinterpret its path component as a path in this checkout.
-    if parsed.scheme or parsed.netloc:
+    indexed = identifiers.get(document_uri)
+    if indexed is not None:
+        return indexed
+
+    if parsed.scheme != "https" or parsed.netloc != "metarepo.invalid":
         return None
     if not parsed.path:
-        # Empty references and fragment-only references stay in the same blob.
         return None
     if parsed.query:
         raise ManifestError(
             "SCHEMA_REF_INVALID",
-            f"{referrer} uses a query in a local $ref: {reference!r}",
+            f"{referrer} uses a query in a local $ref: {resolved_uri!r}",
         )
 
-    path = parsed.path
-    if path.startswith("/"):
-        raise ManifestError(
-            "SCHEMA_REF_ESCAPE",
-            f"{referrer} uses an absolute local $ref path: {reference!r}",
-        )
+    path = parsed.path.removeprefix("/")
     if "\\" in path or "%" in path or "\x00" in path:
         raise ManifestError(
             "SCHEMA_REF_INVALID",
-            f"{referrer} contains a non-canonical local $ref path: {reference!r}",
+            f"{referrer} contains a non-canonical local $ref path: {resolved_uri!r}",
         )
 
-    resolved = posixpath.normpath(posixpath.join(posixpath.dirname(referrer), path))
+    resolved = posixpath.normpath(path)
     if resolved == "contracts" or not resolved.startswith("contracts/"):
         raise ManifestError(
             "SCHEMA_REF_ESCAPE",
-            f"{referrer} has a local $ref outside contracts/: {reference!r}",
+            f"{referrer} has a local $ref outside contracts/: {resolved_uri!r}",
         )
     normalized = _relative_path(resolved, "SCHEMA_REF_INVALID")
     if not normalized.endswith(".schema.json"):
         raise ManifestError(
             "SCHEMA_REF_INVALID",
-            f"{referrer} does not reference a canonical schema path: {reference!r}",
+            f"{referrer} does not reference a canonical schema path: {resolved_uri!r}",
         )
     return normalized
 
@@ -427,6 +562,7 @@ def _schema_closure(
 ) -> dict[str, bytes]:
     """Return deterministic transitive local $ref closure from committed blobs."""
 
+    identifiers, schemas = _schema_identifier_index(root, tree)
     pending = [(relative, "") for relative in schema_paths]
     heapq.heapify(pending)
     payload_bytes: dict[str, bytes] = {}
@@ -434,11 +570,19 @@ def _schema_closure(
         relative, referrer = heapq.heappop(pending)
         if relative in payload_bytes:
             continue
-        data = _read_schema_blob(root, tree, relative, referrer=referrer or None)
+        cached = schemas.get(relative)
+        if cached is None:
+            data = _read_schema_blob(root, tree, relative, referrer=referrer or None)
+            schema = _decode_schema(relative, data)
+        else:
+            schema, data = cached
         payload_bytes[relative] = data
-        schema = _decode_schema(relative, data)
-        for reference in _schema_references(relative, schema):
-            dependency = _resolve_local_reference(relative, reference)
+        for kind, resolved_uri in _schema_resources_and_references(
+            relative, schema, _physical_schema_uri(relative)
+        ):
+            if kind != "reference":
+                continue
+            dependency = _resolve_local_reference(relative, resolved_uri, identifiers)
             if dependency is None or dependency in payload_bytes:
                 continue
             heapq.heappush(pending, (dependency, relative))

--- a/scripts/contracts/emit_source_manifest.py
+++ b/scripts/contracts/emit_source_manifest.py
@@ -14,14 +14,20 @@ contract validity, consumer compatibility or permission to publish.
 from __future__ import annotations
 
 import argparse
+from dataclasses import dataclass
 import hashlib
+import heapq
 import json
+import os
 from pathlib import Path, PurePosixPath
+import posixpath
 import re
 import shutil
+import stat
 import subprocess
 import sys
 from typing import Any, Iterable, Sequence
+from urllib.parse import urlsplit
 
 EXPECTED_REPOSITORY = "heimgewebe/metarepo"
 MANIFEST_NAME = "metarepo-contract-source.v1.json"
@@ -42,6 +48,15 @@ class ManifestError(RuntimeError):
         super().__init__(f"{code}: {detail}")
 
 
+@dataclass(frozen=True)
+class GitTreeEntry:
+    """One path pinned to an immutable object in the selected commit."""
+
+    mode: str
+    kind: str
+    object_id: str
+
+
 def _run_git(root: Path, *args: str) -> str:
     try:
         result = subprocess.run(
@@ -50,10 +65,29 @@ def _run_git(root: Path, *args: str) -> str:
             text=True,
             capture_output=True,
         )
-    except (OSError, subprocess.CalledProcessError) as exc:
+    except (OSError, subprocess.CalledProcessError, UnicodeError) as exc:
         stderr = getattr(exc, "stderr", "") or ""
         raise ManifestError("SOURCE_NOT_GIT", stderr.strip() or str(exc)) from exc
     return result.stdout.strip()
+
+
+def _run_git_bytes(
+    root: Path, *args: str, code: str = "SOURCE_NOT_GIT", detail: str = "Git read failed"
+) -> bytes:
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(root), *args],
+            check=True,
+            capture_output=True,
+        )
+    except (OSError, subprocess.CalledProcessError) as exc:
+        stderr = getattr(exc, "stderr", b"") or b""
+        if isinstance(stderr, bytes):
+            error_detail = stderr.decode("utf-8", errors="replace").strip()
+        else:
+            error_detail = str(stderr).strip()
+        raise ManifestError(code, error_detail or f"{detail}: {exc}") from exc
+    return result.stdout
 
 
 def _repository_identity(origin: str) -> str:
@@ -108,25 +142,6 @@ def _relative_path(value: str, code: str) -> str:
             code, f"must be a normalized relative POSIX path: {value!r}"
         )
     return PurePosixPath(value).as_posix()
-
-
-def _safe_join(root: Path, relative: str) -> Path:
-    try:
-        root_resolved = root.resolve(strict=True)
-        target = (root_resolved / relative).resolve(strict=True)
-    except (FileNotFoundError, OSError) as exc:
-        raise ManifestError("SCHEMA_MISSING", f"schema is unavailable: {relative}") from exc
-    try:
-        target.relative_to(root_resolved)
-    except ValueError as exc:
-        raise ManifestError(
-            "SCHEMA_PATH_ESCAPE", f"schema escapes source root: {relative}"
-        ) from exc
-    if not target.is_file():
-        raise ManifestError(
-            "SCHEMA_MISSING", f"schema is not a regular file: {relative}"
-        )
-    return target
 
 
 def resolve_source(source_path: str, expected_commit: str | None) -> tuple[Path, str]:
@@ -188,10 +203,42 @@ def resolve_source(source_path: str, expected_commit: str | None) -> tuple[Path,
     return root, head
 
 
+def _commit_tree(root: Path, commit: str) -> dict[str, GitTreeEntry]:
+    """Read the contracts tree from one commit, never from the working tree."""
+
+    raw_tree = _run_git_bytes(
+        root,
+        "ls-tree",
+        "-r",
+        "-z",
+        "--full-tree",
+        commit,
+        "--",
+        "contracts",
+        code="SOURCE_COMMIT_INVALID",
+        detail=f"cannot inspect contract tree at {commit}",
+    )
+    entries: dict[str, GitTreeEntry] = {}
+    for raw_entry in raw_tree.split(b"\0"):
+        if not raw_entry:
+            continue
+        try:
+            raw_metadata, raw_path = raw_entry.split(b"\t", 1)
+            mode, kind, object_id = raw_metadata.decode("ascii").split(" ")
+            relative = raw_path.decode("utf-8")
+        except (UnicodeDecodeError, ValueError) as exc:
+            raise ManifestError(
+                "SCHEMA_PATH_INVALID",
+                "the committed contracts tree contains an unrepresentable path",
+            ) from exc
+        entries[relative] = GitTreeEntry(mode, kind, object_id)
+    return entries
+
+
 def select_schemas(
-    root: Path, consumers: Sequence[str], schemas: Sequence[str]
+    tree: dict[str, GitTreeEntry], consumers: Sequence[str], schemas: Sequence[str]
 ) -> list[str]:
-    """Expand consumer namespaces and explicit paths into one sorted schema set."""
+    """Expand selections against paths tracked by the bound commit."""
 
     selected: set[str] = set()
 
@@ -201,17 +248,18 @@ def select_schemas(
             raise ManifestError(
                 "CONSUMER_INVALID", f"consumer must be a single path segment: {consumer!r}"
             )
-        namespace = root / "contracts" / name
-        if not namespace.is_dir():
+        namespace = f"contracts/{name}/"
+        namespace_paths = sorted(path for path in tree if path.startswith(namespace))
+        if not namespace_paths:
             raise ManifestError(
                 "CONSUMER_UNKNOWN",
                 f"no canonical contract namespace contracts/{name} in the bound source",
             )
-        found = sorted(
-            path.relative_to(root).as_posix()
-            for path in namespace.rglob("*.schema.json")
-            if path.is_file()
-        )
+        found = [
+            _relative_path(path, "SCHEMA_PATH_INVALID")
+            for path in namespace_paths
+            if path.endswith(".schema.json")
+        ]
         if not found:
             raise ManifestError(
                 "CONSUMER_EMPTY",
@@ -220,7 +268,18 @@ def select_schemas(
         selected.update(found)
 
     for schema in schemas:
-        selected.add(_relative_path(schema, "SCHEMA_PATH_INVALID"))
+        relative = _relative_path(schema, "SCHEMA_PATH_INVALID")
+        if not relative.endswith(".schema.json"):
+            raise ManifestError(
+                "SCHEMA_PATH_INVALID",
+                f"explicit selection is not a canonical schema path: {relative}",
+            )
+        if relative not in tree:
+            raise ManifestError(
+                "SCHEMA_NOT_TRACKED",
+                f"schema is not tracked by the bound commit: {relative}",
+            )
+        selected.add(relative)
 
     if not selected:
         raise ManifestError(
@@ -230,8 +289,165 @@ def select_schemas(
     return sorted(selected)
 
 
+def _read_schema_blob(
+    root: Path,
+    tree: dict[str, GitTreeEntry],
+    relative: str,
+    *,
+    referrer: str | None = None,
+) -> bytes:
+    entry = tree.get(relative)
+    if entry is None:
+        if referrer is not None:
+            raise ManifestError(
+                "SCHEMA_REF_MISSING",
+                f"{referrer} references a schema not tracked by the bound commit: {relative}",
+            )
+        raise ManifestError(
+            "SCHEMA_NOT_TRACKED",
+            f"schema is not tracked by the bound commit: {relative}",
+        )
+    if entry.kind != "blob" or entry.mode not in {"100644", "100755"}:
+        if entry.mode == "120000":
+            raise ManifestError(
+                "SCHEMA_PATH_ESCAPE",
+                f"schema is a Git symlink rather than commit-bound schema bytes: {relative}",
+            )
+        raise ManifestError(
+            "SCHEMA_NOT_REGULAR",
+            f"schema is not a regular Git blob in the bound commit: {relative}",
+        )
+    return _run_git_bytes(
+        root,
+        "cat-file",
+        "blob",
+        entry.object_id,
+        code="SCHEMA_UNREADABLE",
+        detail=f"cannot read committed schema blob {relative}",
+    )
+
+
+def _decode_schema(relative: str, data: bytes) -> Any:
+    def reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+        result: dict[str, Any] = {}
+        for key, value in pairs:
+            if key in result:
+                raise ValueError(f"duplicate object key {key!r}")
+            result[key] = value
+        return result
+
+    def reject_constant(value: str) -> None:
+        raise ValueError(f"non-finite JSON number {value}")
+
+    try:
+        text = data.decode("utf-8")
+        return json.loads(
+            text,
+            object_pairs_hook=reject_duplicate_keys,
+            parse_constant=reject_constant,
+        )
+    except (UnicodeDecodeError, json.JSONDecodeError, ValueError) as exc:
+        raise ManifestError(
+            "SCHEMA_JSON_INVALID",
+            f"cannot inspect local references in {relative}: {exc}",
+        ) from exc
+
+
+def _schema_references(relative: str, schema: Any) -> Iterable[str]:
+    if isinstance(schema, dict):
+        for key in sorted(schema):
+            value = schema[key]
+            if key == "$ref":
+                if not isinstance(value, str):
+                    raise ManifestError(
+                        "SCHEMA_REF_INVALID",
+                        f"{relative} contains a non-string $ref",
+                    )
+                yield value
+            yield from _schema_references(relative, value)
+    elif isinstance(schema, list):
+        for value in schema:
+            yield from _schema_references(relative, value)
+
+
+def _resolve_local_reference(referrer: str, reference: str) -> str | None:
+    """Resolve a repository-local reference, or return None for an external URI."""
+
+    try:
+        parsed = urlsplit(reference)
+    except ValueError as exc:
+        raise ManifestError(
+            "SCHEMA_REF_INVALID", f"{referrer} contains an invalid $ref: {reference!r}"
+        ) from exc
+
+    # A URI with a scheme or authority is external provenance. In particular,
+    # never reinterpret its path component as a path in this checkout.
+    if parsed.scheme or parsed.netloc:
+        return None
+    if not parsed.path:
+        # Empty references and fragment-only references stay in the same blob.
+        return None
+    if parsed.query:
+        raise ManifestError(
+            "SCHEMA_REF_INVALID",
+            f"{referrer} uses a query in a local $ref: {reference!r}",
+        )
+
+    path = parsed.path
+    if path.startswith("/"):
+        raise ManifestError(
+            "SCHEMA_REF_ESCAPE",
+            f"{referrer} uses an absolute local $ref path: {reference!r}",
+        )
+    if "\\" in path or "%" in path or "\x00" in path:
+        raise ManifestError(
+            "SCHEMA_REF_INVALID",
+            f"{referrer} contains a non-canonical local $ref path: {reference!r}",
+        )
+
+    resolved = posixpath.normpath(posixpath.join(posixpath.dirname(referrer), path))
+    if resolved == "contracts" or not resolved.startswith("contracts/"):
+        raise ManifestError(
+            "SCHEMA_REF_ESCAPE",
+            f"{referrer} has a local $ref outside contracts/: {reference!r}",
+        )
+    normalized = _relative_path(resolved, "SCHEMA_REF_INVALID")
+    if not normalized.endswith(".schema.json"):
+        raise ManifestError(
+            "SCHEMA_REF_INVALID",
+            f"{referrer} does not reference a canonical schema path: {reference!r}",
+        )
+    return normalized
+
+
+def _schema_closure(
+    root: Path,
+    tree: dict[str, GitTreeEntry],
+    schema_paths: Iterable[str],
+) -> dict[str, bytes]:
+    """Return deterministic transitive local $ref closure from committed blobs."""
+
+    pending = [(relative, "") for relative in schema_paths]
+    heapq.heapify(pending)
+    payload_bytes: dict[str, bytes] = {}
+    while pending:
+        relative, referrer = heapq.heappop(pending)
+        if relative in payload_bytes:
+            continue
+        data = _read_schema_blob(root, tree, relative, referrer=referrer or None)
+        payload_bytes[relative] = data
+        schema = _decode_schema(relative, data)
+        for reference in _schema_references(relative, schema):
+            dependency = _resolve_local_reference(relative, reference)
+            if dependency is None or dependency in payload_bytes:
+                continue
+            heapq.heappush(pending, (dependency, relative))
+    return dict(sorted(payload_bytes.items()))
+
+
 def build_manifest(
     root: Path,
+    tree: dict[str, GitTreeEntry],
     commit: str,
     source_kind: str,
     content_root: str,
@@ -245,15 +461,14 @@ def build_manifest(
             f"source_kind must be one of {', '.join(SOURCE_KINDS)}",
         )
     content = _relative_path(content_root, "CONTENT_ROOT_INVALID")
-
-    payload_bytes: dict[str, bytes] = {}
-    digests: dict[str, str] = {}
-    for relative in schema_paths:
-        data = _read_bytes(
-            _safe_join(root, relative), "SCHEMA_UNREADABLE", f"cannot read {relative}"
+    if PurePosixPath(content).parts[0] == MANIFEST_NAME:
+        raise ManifestError(
+            "CONTENT_ROOT_INVALID",
+            "content root must not collide with the manifest path",
         )
-        payload_bytes[relative] = data
-        digests[relative] = _sha256(data)
+
+    payload_bytes = _schema_closure(root, tree, schema_paths)
+    digests = {relative: _sha256(data) for relative, data in payload_bytes.items()}
 
     manifest = {
         "schema_version": 1,
@@ -280,6 +495,8 @@ def _resolve_out_dir(out_dir: str, source_root: Path, create: bool) -> Path:
     if create:
         try:
             path.mkdir(parents=True, exist_ok=True)
+        except FileExistsError as exc:
+            raise ManifestError("OUT_DIR_INVALID", f"not a directory: {out_dir}") from exc
         except OSError as exc:
             raise ManifestError("OUT_DIR_UNWRITABLE", f"{out_dir}: {exc}") from exc
     try:
@@ -296,11 +513,73 @@ def _resolve_out_dir(out_dir: str, source_root: Path, create: bool) -> Path:
     return resolved
 
 
+def _resolve_content_dir(
+    out_dir: Path, content_root: str, *, error_code: str
+) -> Path:
+    """Resolve a lexical content root without following existing symlinks."""
+
+    current = out_dir
+    parts = PurePosixPath(content_root).parts
+    for index, part in enumerate(parts):
+        current /= part
+        try:
+            metadata = current.lstat()
+        except FileNotFoundError:
+            continue
+        except OSError as exc:
+            raise ManifestError(error_code, f"cannot inspect {current}: {exc}") from exc
+        if stat.S_ISLNK(metadata.st_mode):
+            raise ManifestError(
+                "CONTENT_ROOT_PATH_ESCAPE",
+                f"content root traverses a symlink: {current}",
+            )
+        if index < len(parts) - 1 and not stat.S_ISDIR(metadata.st_mode):
+            raise ManifestError(
+                "CONTENT_ROOT_INVALID_TYPE",
+                f"content root parent is not a directory: {current}",
+            )
+    return current
+
+
+def _manifest_target_for_write(out_dir: Path) -> Path:
+    manifest_path = out_dir / MANIFEST_NAME
+    try:
+        metadata = manifest_path.lstat()
+    except FileNotFoundError:
+        return manifest_path
+    except OSError as exc:
+        raise ManifestError(
+            "OUT_DIR_UNWRITABLE", f"cannot inspect {manifest_path}: {exc}"
+        ) from exc
+    if stat.S_ISLNK(metadata.st_mode) or not stat.S_ISREG(metadata.st_mode):
+        raise ManifestError(
+            "MANIFEST_INVALID_TYPE",
+            f"manifest target is not a regular non-symlink file: {manifest_path}",
+        )
+    return manifest_path
+
+
 def _materialize(
     content_dir: Path, payload_bytes: dict[str, bytes], overwrite: bool
 ) -> None:
-    if content_dir.exists():
-        if any(content_dir.iterdir()) and not overwrite:
+    try:
+        metadata = content_dir.lstat()
+    except FileNotFoundError:
+        metadata = None
+    except OSError as exc:
+        raise ManifestError("OUT_DIR_UNWRITABLE", f"{content_dir}: {exc}") from exc
+
+    if metadata is not None:
+        if stat.S_ISLNK(metadata.st_mode) or not stat.S_ISDIR(metadata.st_mode):
+            raise ManifestError(
+                "CONTENT_ROOT_INVALID_TYPE",
+                f"content root is not a regular directory: {content_dir}",
+            )
+        try:
+            has_content = next(content_dir.iterdir(), None) is not None
+        except OSError as exc:
+            raise ManifestError("OUT_DIR_UNWRITABLE", f"{content_dir}: {exc}") from exc
+        if has_content and not overwrite:
             raise ManifestError(
                 "CONTENT_ROOT_NOT_EMPTY",
                 f"{content_dir} already has content; pass --overwrite to replace it",
@@ -318,17 +597,105 @@ def _materialize(
             raise ManifestError("OUT_DIR_UNWRITABLE", f"{target}: {exc}") from exc
 
 
+def _regular_manifest_for_verify(out_dir: Path) -> Path:
+    manifest_path = out_dir / MANIFEST_NAME
+    try:
+        metadata = manifest_path.lstat()
+    except FileNotFoundError as exc:
+        raise ManifestError(
+            "MANIFEST_MISSING", f"no manifest to verify at {manifest_path}"
+        ) from exc
+    except OSError as exc:
+        raise ManifestError(
+            "MANIFEST_UNREADABLE", f"cannot inspect {manifest_path}: {exc}"
+        ) from exc
+    if stat.S_ISLNK(metadata.st_mode) or not stat.S_ISREG(metadata.st_mode):
+        raise ManifestError(
+            "MANIFEST_INVALID_TYPE",
+            f"manifest is not a regular non-symlink file: {manifest_path}",
+        )
+    return manifest_path
+
+
+def _regular_cached_schema(content_dir: Path, relative: str) -> Path:
+    current = content_dir
+    parts = PurePosixPath(relative).parts
+    for index, part in enumerate(parts):
+        current /= part
+        try:
+            metadata = current.lstat()
+        except FileNotFoundError as exc:
+            raise ManifestError(
+                "CONTENT_MISSING", f"bound schema is absent from the cache: {relative}"
+            ) from exc
+        except OSError as exc:
+            raise ManifestError(
+                "CONTENT_UNREADABLE", f"cannot inspect {relative}: {exc}"
+            ) from exc
+        is_final = index == len(parts) - 1
+        if stat.S_ISLNK(metadata.st_mode):
+            raise ManifestError(
+                "CONTENT_INVALID_TYPE",
+                f"bound schema path traverses a symlink: {relative}",
+            )
+        if is_final:
+            if not stat.S_ISREG(metadata.st_mode):
+                raise ManifestError(
+                    "CONTENT_INVALID_TYPE",
+                    f"bound schema is not a regular file: {relative}",
+                )
+        elif not stat.S_ISDIR(metadata.st_mode):
+            raise ManifestError(
+                "CONTENT_INVALID_TYPE",
+                f"bound schema parent is not a directory: {relative}",
+            )
+    return current
+
+
+def _present_cache_files(content_dir: Path) -> set[str]:
+    present: set[str] = set()
+    pending = [content_dir]
+    while pending:
+        directory = pending.pop()
+        try:
+            with os.scandir(directory) as iterator:
+                entries = sorted(iterator, key=lambda entry: entry.name)
+        except OSError as exc:
+            raise ManifestError(
+                "CONTENT_UNREADABLE", f"cannot enumerate {directory}: {exc}"
+            ) from exc
+        for entry in entries:
+            path = Path(entry.path)
+            relative = path.relative_to(content_dir).as_posix()
+            try:
+                if entry.is_symlink():
+                    raise ManifestError(
+                        "CONTENT_INVALID_TYPE",
+                        f"cache contains a symlink: {relative}",
+                    )
+                if entry.is_dir(follow_symlinks=False):
+                    pending.append(path)
+                elif entry.is_file(follow_symlinks=False):
+                    present.add(relative)
+                else:
+                    raise ManifestError(
+                        "CONTENT_INVALID_TYPE",
+                        f"cache contains a non-regular node: {relative}",
+                    )
+            except OSError as exc:
+                raise ManifestError(
+                    "CONTENT_UNREADABLE", f"cannot inspect {relative}: {exc}"
+                ) from exc
+    return present
+
+
 def _verify(
     out_dir: Path,
     content_root: str,
     manifest_bytes: bytes,
     payload_bytes: dict[str, bytes],
 ) -> None:
-    manifest_path = out_dir / MANIFEST_NAME
-    if not manifest_path.is_file():
-        raise ManifestError(
-            "MANIFEST_MISSING", f"no manifest to verify at {manifest_path}"
-        )
+    manifest_path = _regular_manifest_for_verify(out_dir)
     observed_manifest = _read_bytes(
         manifest_path, "MANIFEST_UNREADABLE", f"cannot read {manifest_path}"
     )
@@ -338,28 +705,33 @@ def _verify(
             "the stored manifest differs from the manifest the bound source produces",
         )
 
-    content_dir = out_dir / content_root
-    if not content_dir.is_dir():
+    content_dir = _resolve_content_dir(
+        out_dir, content_root, error_code="CONTENT_UNREADABLE"
+    )
+    try:
+        content_metadata = content_dir.lstat()
+    except FileNotFoundError as exc:
         raise ManifestError(
             "CONTENT_ROOT_MISSING", f"content root is unavailable: {content_dir}"
+        ) from exc
+    except OSError as exc:
+        raise ManifestError(
+            "CONTENT_UNREADABLE", f"cannot inspect content root {content_dir}: {exc}"
+        ) from exc
+    if not stat.S_ISDIR(content_metadata.st_mode):
+        raise ManifestError(
+            "CONTENT_ROOT_INVALID_TYPE",
+            f"content root is not a regular directory: {content_dir}",
         )
     for relative, data in sorted(payload_bytes.items()):
-        target = content_dir / relative
-        if not target.is_file():
-            raise ManifestError(
-                "CONTENT_MISSING", f"bound schema is absent from the cache: {relative}"
-            )
+        target = _regular_cached_schema(content_dir, relative)
         observed = _read_bytes(target, "CONTENT_UNREADABLE", f"cannot read {relative}")
         if observed != data:
             raise ManifestError(
                 "CONTENT_DRIFT", f"cached schema bytes differ from the bound source: {relative}"
             )
     bound = set(payload_bytes)
-    present = {
-        path.relative_to(content_dir).as_posix()
-        for path in content_dir.rglob("*")
-        if path.is_file()
-    }
+    present = _present_cache_files(content_dir)
     unbound = sorted(present - bound)
     if unbound:
         raise ManifestError(
@@ -396,9 +768,11 @@ def _parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--source-kind",
-        choices=SOURCE_KINDS,
         default="detached_archive",
-        help="How the emitted source is consumed. Default: detached_archive.",
+        help=(
+            "How the emitted source is consumed "
+            f"({', '.join(SOURCE_KINDS)}). Default: detached_archive."
+        ),
     )
     parser.add_argument(
         "--content-root",
@@ -426,9 +800,10 @@ def run(argv: Sequence[str] | None = None) -> int:
     args = _parser().parse_args(argv)
 
     root, commit = resolve_source(args.source, args.expected_commit)
-    schema_paths = select_schemas(root, args.consumer, args.schema)
+    tree = _commit_tree(root, commit)
+    schema_paths = select_schemas(tree, args.consumer, args.schema)
     manifest, payload_bytes = build_manifest(
-        root, commit, args.source_kind, args.content_root, schema_paths
+        root, tree, commit, args.source_kind, args.content_root, schema_paths
     )
     manifest_bytes = render_manifest(manifest)
     out_dir = _resolve_out_dir(args.out_dir, root, create=not args.verify)
@@ -436,8 +811,11 @@ def run(argv: Sequence[str] | None = None) -> int:
     if args.verify:
         _verify(out_dir, manifest["source_root"], manifest_bytes, payload_bytes)
     else:
-        _materialize(out_dir / manifest["source_root"], payload_bytes, args.overwrite)
-        manifest_path = out_dir / MANIFEST_NAME
+        content_dir = _resolve_content_dir(
+            out_dir, manifest["source_root"], error_code="OUT_DIR_UNWRITABLE"
+        )
+        manifest_path = _manifest_target_for_write(out_dir)
+        _materialize(content_dir, payload_bytes, args.overwrite)
         try:
             manifest_path.write_bytes(manifest_bytes)
         except OSError as exc:

--- a/scripts/contracts/emit_source_manifest.py
+++ b/scripts/contracts/emit_source_manifest.py
@@ -1,0 +1,459 @@
+#!/usr/bin/env python3
+"""Emit an identity-bound contract source manifest for non-Git consumers.
+
+Consumers resolve canonical Metarepo contracts either from an explicit Git
+checkout or from a manifest that binds a detached archive / approved offline
+cache to repository identity, commit and per-schema SHA-256. This producer is
+the reproducible way to create that manifest: everything is taken from explicit
+arguments and from an identity-verified, clean Metarepo checkout. No ambient
+sibling directory, environment variable or shell initialisation is consulted.
+
+The manifest establishes provenance of bytes. It does not establish semantic
+contract validity, consumer compatibility or permission to publish.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path, PurePosixPath
+import re
+import shutil
+import subprocess
+import sys
+from typing import Any, Iterable, Sequence
+
+EXPECTED_REPOSITORY = "heimgewebe/metarepo"
+MANIFEST_NAME = "metarepo-contract-source.v1.json"
+MANIFEST_SCHEMA_PATH = "contracts/contract.source.manifest.schema.json"
+SOURCE_KINDS = ("detached_archive", "offline_cache")
+DEFAULT_CONTENT_ROOT = "content"
+
+HEX40 = re.compile(r"^[0-9a-f]{40}$")
+RELATIVE_POSIX = re.compile(r"^(?!.*(^|/)\.\.?(/|$))[A-Za-z0-9._-]+(/[A-Za-z0-9._-]+)*$")
+
+
+class ManifestError(RuntimeError):
+    """Stable, typed contract source manifest failure."""
+
+    def __init__(self, code: str, detail: str) -> None:
+        self.code = code
+        self.detail = detail
+        super().__init__(f"{code}: {detail}")
+
+
+def _run_git(root: Path, *args: str) -> str:
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(root), *args],
+            check=True,
+            text=True,
+            capture_output=True,
+        )
+    except (OSError, subprocess.CalledProcessError) as exc:
+        stderr = getattr(exc, "stderr", "") or ""
+        raise ManifestError("SOURCE_NOT_GIT", stderr.strip() or str(exc)) from exc
+    return result.stdout.strip()
+
+
+def _repository_identity(origin: str) -> str:
+    """Return owner/repo only for an explicit github.com Git remote URL."""
+
+    raw = origin.strip()
+    if not raw:
+        return ""
+    if "://" in raw:
+        from urllib.parse import urlparse
+
+        parsed = urlparse(raw)
+        if (parsed.hostname or "").lower() != "github.com":
+            return ""
+        if parsed.scheme.lower() not in {"https", "ssh", "git"}:
+            return ""
+        if parsed.query or parsed.fragment:
+            return ""
+        path = parsed.path
+    elif ":" in raw:
+        authority, candidate = raw.split(":", 1)
+        if authority.rsplit("@", 1)[-1].lower() != "github.com":
+            return ""
+        path = candidate
+    else:
+        # A bare owner/repo string is never proof of a checkout's remote identity.
+        return ""
+
+    normalized = path.strip("/")
+    if normalized.lower().endswith(".git"):
+        normalized = normalized[:-4]
+    parts = normalized.split("/")
+    if len(parts) != 2 or not all(parts):
+        return ""
+    return normalized.lower()
+
+
+def _sha256(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _read_bytes(path: Path, code: str, detail: str) -> bytes:
+    try:
+        return path.read_bytes()
+    except OSError as exc:
+        raise ManifestError(code, f"{detail}: {exc}") from exc
+
+
+def _relative_path(value: str, code: str) -> str:
+    if not RELATIVE_POSIX.fullmatch(value):
+        raise ManifestError(
+            code, f"must be a normalized relative POSIX path: {value!r}"
+        )
+    return PurePosixPath(value).as_posix()
+
+
+def _safe_join(root: Path, relative: str) -> Path:
+    try:
+        root_resolved = root.resolve(strict=True)
+        target = (root_resolved / relative).resolve(strict=True)
+    except (FileNotFoundError, OSError) as exc:
+        raise ManifestError("SCHEMA_MISSING", f"schema is unavailable: {relative}") from exc
+    try:
+        target.relative_to(root_resolved)
+    except ValueError as exc:
+        raise ManifestError(
+            "SCHEMA_PATH_ESCAPE", f"schema escapes source root: {relative}"
+        ) from exc
+    if not target.is_file():
+        raise ManifestError(
+            "SCHEMA_MISSING", f"schema is not a regular file: {relative}"
+        )
+    return target
+
+
+def resolve_source(source_path: str, expected_commit: str | None) -> tuple[Path, str]:
+    """Resolve one explicit, clean, identity-bound Metarepo checkout."""
+
+    try:
+        root = Path(source_path).expanduser().resolve(strict=True)
+    except (FileNotFoundError, OSError) as exc:
+        raise ManifestError(
+            "SOURCE_MISSING", f"explicit Metarepo source is unavailable: {source_path}"
+        ) from exc
+    if not root.is_dir():
+        raise ManifestError("SOURCE_NOT_GIT", f"not a directory: {root}")
+
+    try:
+        top = Path(_run_git(root, "rev-parse", "--show-toplevel")).resolve(strict=True)
+    except (FileNotFoundError, OSError) as exc:
+        raise ManifestError(
+            "SOURCE_NOT_GIT", f"cannot resolve Git repository root: {root}"
+        ) from exc
+    if top != root:
+        raise ManifestError(
+            "SOURCE_NOT_REPOSITORY_ROOT",
+            f"explicit source must be the Git repository root: {root}",
+        )
+
+    origin = _run_git(root, "config", "--get", "remote.origin.url")
+    if _repository_identity(origin) != EXPECTED_REPOSITORY:
+        raise ManifestError(
+            "SOURCE_WRONG_REPOSITORY",
+            f"expected GitHub repository {EXPECTED_REPOSITORY}; "
+            "the explicit origin did not resolve to that canonical identity",
+        )
+
+    head = _run_git(root, "rev-parse", "HEAD").lower()
+    if not HEX40.fullmatch(head):
+        raise ManifestError(
+            "SOURCE_COMMIT_INVALID", "HEAD is not a full 40-hex lowercase commit"
+        )
+    if expected_commit is not None:
+        expected = expected_commit.strip().lower()
+        if not HEX40.fullmatch(expected):
+            raise ManifestError(
+                "EXPECTED_COMMIT_INVALID",
+                "expected commit must be exactly 40 lowercase hex characters",
+            )
+        if head != expected:
+            raise ManifestError(
+                "SOURCE_COMMIT_MISMATCH", f"expected {expected}, observed {head}"
+            )
+
+    if _run_git(root, "status", "--porcelain=v1", "--untracked-files=all"):
+        raise ManifestError(
+            "SOURCE_DIRTY",
+            "a manifest binds immutable bytes; the Metarepo source must be clean. "
+            "Commit or stash local changes, or use the Git-checkout resolver path instead.",
+        )
+
+    return root, head
+
+
+def select_schemas(
+    root: Path, consumers: Sequence[str], schemas: Sequence[str]
+) -> list[str]:
+    """Expand consumer namespaces and explicit paths into one sorted schema set."""
+
+    selected: set[str] = set()
+
+    for consumer in consumers:
+        name = _relative_path(consumer, "CONSUMER_INVALID")
+        if "/" in name:
+            raise ManifestError(
+                "CONSUMER_INVALID", f"consumer must be a single path segment: {consumer!r}"
+            )
+        namespace = root / "contracts" / name
+        if not namespace.is_dir():
+            raise ManifestError(
+                "CONSUMER_UNKNOWN",
+                f"no canonical contract namespace contracts/{name} in the bound source",
+            )
+        found = sorted(
+            path.relative_to(root).as_posix()
+            for path in namespace.rglob("*.schema.json")
+            if path.is_file()
+        )
+        if not found:
+            raise ManifestError(
+                "CONSUMER_EMPTY",
+                f"contracts/{name} binds no schema files in the bound source",
+            )
+        selected.update(found)
+
+    for schema in schemas:
+        selected.add(_relative_path(schema, "SCHEMA_PATH_INVALID"))
+
+    if not selected:
+        raise ManifestError(
+            "SCHEMA_SELECTION",
+            "at least one --consumer or --schema is required; an empty manifest binds nothing",
+        )
+    return sorted(selected)
+
+
+def build_manifest(
+    root: Path,
+    commit: str,
+    source_kind: str,
+    content_root: str,
+    schema_paths: Iterable[str],
+) -> tuple[dict[str, Any], dict[str, bytes]]:
+    """Return the manifest payload plus the exact bytes it binds."""
+
+    if source_kind not in SOURCE_KINDS:
+        raise ManifestError(
+            "SOURCE_KIND_INVALID",
+            f"source_kind must be one of {', '.join(SOURCE_KINDS)}",
+        )
+    content = _relative_path(content_root, "CONTENT_ROOT_INVALID")
+
+    payload_bytes: dict[str, bytes] = {}
+    digests: dict[str, str] = {}
+    for relative in schema_paths:
+        data = _read_bytes(
+            _safe_join(root, relative), "SCHEMA_UNREADABLE", f"cannot read {relative}"
+        )
+        payload_bytes[relative] = data
+        digests[relative] = _sha256(data)
+
+    manifest = {
+        "schema_version": 1,
+        "repository": EXPECTED_REPOSITORY,
+        "commit": commit,
+        "source_kind": source_kind,
+        "source_root": content,
+        "schemas": dict(sorted(digests.items())),
+    }
+    return manifest, payload_bytes
+
+
+def render_manifest(manifest: dict[str, Any]) -> bytes:
+    """Render one canonical byte representation for identical inputs."""
+
+    return (
+        json.dumps(manifest, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+        + "\n"
+    ).encode("utf-8")
+
+
+def _resolve_out_dir(out_dir: str, source_root: Path, create: bool) -> Path:
+    path = Path(out_dir).expanduser()
+    if create:
+        try:
+            path.mkdir(parents=True, exist_ok=True)
+        except OSError as exc:
+            raise ManifestError("OUT_DIR_UNWRITABLE", f"{out_dir}: {exc}") from exc
+    try:
+        resolved = path.resolve(strict=True)
+    except (FileNotFoundError, OSError) as exc:
+        raise ManifestError("OUT_DIR_MISSING", f"output directory is unavailable: {out_dir}") from exc
+    if not resolved.is_dir():
+        raise ManifestError("OUT_DIR_INVALID", f"not a directory: {resolved}")
+    if resolved == source_root or source_root in resolved.parents:
+        raise ManifestError(
+            "OUT_DIR_INSIDE_SOURCE",
+            "the output directory must not live inside the bound Metarepo source",
+        )
+    return resolved
+
+
+def _materialize(
+    content_dir: Path, payload_bytes: dict[str, bytes], overwrite: bool
+) -> None:
+    if content_dir.exists():
+        if any(content_dir.iterdir()) and not overwrite:
+            raise ManifestError(
+                "CONTENT_ROOT_NOT_EMPTY",
+                f"{content_dir} already has content; pass --overwrite to replace it",
+            )
+        try:
+            shutil.rmtree(content_dir)
+        except OSError as exc:
+            raise ManifestError("OUT_DIR_UNWRITABLE", f"{content_dir}: {exc}") from exc
+    for relative, data in sorted(payload_bytes.items()):
+        target = content_dir / relative
+        try:
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_bytes(data)
+        except OSError as exc:
+            raise ManifestError("OUT_DIR_UNWRITABLE", f"{target}: {exc}") from exc
+
+
+def _verify(
+    out_dir: Path,
+    content_root: str,
+    manifest_bytes: bytes,
+    payload_bytes: dict[str, bytes],
+) -> None:
+    manifest_path = out_dir / MANIFEST_NAME
+    if not manifest_path.is_file():
+        raise ManifestError(
+            "MANIFEST_MISSING", f"no manifest to verify at {manifest_path}"
+        )
+    observed_manifest = _read_bytes(
+        manifest_path, "MANIFEST_UNREADABLE", f"cannot read {manifest_path}"
+    )
+    if observed_manifest != manifest_bytes:
+        raise ManifestError(
+            "MANIFEST_DRIFT",
+            "the stored manifest differs from the manifest the bound source produces",
+        )
+
+    content_dir = out_dir / content_root
+    if not content_dir.is_dir():
+        raise ManifestError(
+            "CONTENT_ROOT_MISSING", f"content root is unavailable: {content_dir}"
+        )
+    for relative, data in sorted(payload_bytes.items()):
+        target = content_dir / relative
+        if not target.is_file():
+            raise ManifestError(
+                "CONTENT_MISSING", f"bound schema is absent from the cache: {relative}"
+            )
+        observed = _read_bytes(target, "CONTENT_UNREADABLE", f"cannot read {relative}")
+        if observed != data:
+            raise ManifestError(
+                "CONTENT_DRIFT", f"cached schema bytes differ from the bound source: {relative}"
+            )
+    bound = set(payload_bytes)
+    present = {
+        path.relative_to(content_dir).as_posix()
+        for path in content_dir.rglob("*")
+        if path.is_file()
+    }
+    unbound = sorted(present - bound)
+    if unbound:
+        raise ManifestError(
+            "CONTENT_UNBOUND",
+            f"the cache carries files the manifest does not bind: {', '.join(unbound)}",
+        )
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--source",
+        required=True,
+        help="Path to the explicit heimgewebe/metarepo Git repository root.",
+    )
+    parser.add_argument(
+        "--out-dir",
+        required=True,
+        help="Directory that receives the manifest and its content root.",
+    )
+    parser.add_argument(
+        "--consumer",
+        action="append",
+        default=[],
+        metavar="NAME",
+        help="Bind every schema under contracts/NAME/ (repeatable).",
+    )
+    parser.add_argument(
+        "--schema",
+        action="append",
+        default=[],
+        metavar="PATH",
+        help="Bind one additional schema by its path relative to the source root (repeatable).",
+    )
+    parser.add_argument(
+        "--source-kind",
+        choices=SOURCE_KINDS,
+        default="detached_archive",
+        help="How the emitted source is consumed. Default: detached_archive.",
+    )
+    parser.add_argument(
+        "--content-root",
+        default=DEFAULT_CONTENT_ROOT,
+        help=f"Relative content root below --out-dir. Default: {DEFAULT_CONTENT_ROOT}.",
+    )
+    parser.add_argument(
+        "--expected-commit",
+        help="Require the bound source to be at this exact 40-hex commit.",
+    )
+    parser.add_argument(
+        "--overwrite",
+        action="store_true",
+        help="Replace an existing non-empty content root instead of failing closed.",
+    )
+    parser.add_argument(
+        "--verify",
+        action="store_true",
+        help="Do not write; assert that an existing manifest and cache still match the bound source.",
+    )
+    return parser
+
+
+def run(argv: Sequence[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+
+    root, commit = resolve_source(args.source, args.expected_commit)
+    schema_paths = select_schemas(root, args.consumer, args.schema)
+    manifest, payload_bytes = build_manifest(
+        root, commit, args.source_kind, args.content_root, schema_paths
+    )
+    manifest_bytes = render_manifest(manifest)
+    out_dir = _resolve_out_dir(args.out_dir, root, create=not args.verify)
+
+    if args.verify:
+        _verify(out_dir, manifest["source_root"], manifest_bytes, payload_bytes)
+    else:
+        _materialize(out_dir / manifest["source_root"], payload_bytes, args.overwrite)
+        manifest_path = out_dir / MANIFEST_NAME
+        try:
+            manifest_path.write_bytes(manifest_bytes)
+        except OSError as exc:
+            raise ManifestError("OUT_DIR_UNWRITABLE", f"{manifest_path}: {exc}") from exc
+
+    sys.stdout.write(manifest_bytes.decode("utf-8"))
+    return 0
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    try:
+        return run(argv)
+    except ManifestError as exc:
+        print(str(exc), file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_contract_source_manifest.py
+++ b/tests/test_contract_source_manifest.py
@@ -1,0 +1,406 @@
+"""Guard the identity-bound contract source manifest producer."""
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+import subprocess
+import sys
+
+import pytest
+from jsonschema import Draft202012Validator
+
+ROOT = Path(__file__).resolve().parents[1]
+PRODUCER_DIR = ROOT / "scripts" / "contracts"
+if str(PRODUCER_DIR) not in sys.path:
+    sys.path.insert(0, str(PRODUCER_DIR))
+
+from emit_source_manifest import (  # noqa: E402
+    MANIFEST_NAME,
+    MANIFEST_SCHEMA_PATH,
+    ManifestError,
+    main,
+    run,
+)
+
+ZONES_SCHEMA = "contracts/heim-pc/config/zones.schema.json"
+DRIFT_SCHEMA = "contracts/heim-pc/state/heim-pc.state.drift.schema.json"
+
+
+def _git(repo: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", "-C", str(repo), *args], check=True, text=True, capture_output=True
+    )
+    return result.stdout.strip()
+
+
+def _source_repo(tmp_path: Path, origin: str = "https://github.com/heimgewebe/metarepo.git") -> Path:
+    """Create a minimal stand-in for a canonical Metarepo checkout."""
+
+    repo = tmp_path / "metarepo"
+    repo.mkdir()
+    _git(repo, "init", "--initial-branch=main")
+    _git(repo, "config", "user.email", "test@example.invalid")
+    _git(repo, "config", "user.name", "Contract Test")
+    _git(repo, "remote", "add", "origin", origin)
+
+    for relative in (ZONES_SCHEMA, DRIFT_SCHEMA, MANIFEST_SCHEMA_PATH):
+        target = repo / relative
+        target.parent.mkdir(parents=True, exist_ok=True)
+        if relative == MANIFEST_SCHEMA_PATH:
+            target.write_bytes((ROOT / MANIFEST_SCHEMA_PATH).read_bytes())
+        else:
+            target.write_text(
+                json.dumps({"title": relative, "type": "object"}, indent=2) + "\n",
+                encoding="utf-8",
+            )
+    # A non-schema file must never be bound by a consumer namespace expansion.
+    (repo / "contracts/heim-pc/README.md").write_text("consumer notes\n", encoding="utf-8")
+
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-m", "seed canonical contracts")
+    return repo
+
+
+def _emit(repo: Path, out_dir: Path, *extra: str) -> dict:
+    payload = run(
+        [
+            "--source",
+            str(repo),
+            "--out-dir",
+            str(out_dir),
+            "--consumer",
+            "heim-pc",
+            *extra,
+        ]
+    )
+    assert payload == 0
+    return json.loads((out_dir / MANIFEST_NAME).read_text(encoding="utf-8"))
+
+
+def test_manifest_binds_repository_commit_and_every_schema_hash(tmp_path, capsys):
+    repo = _source_repo(tmp_path)
+    out_dir = tmp_path / "archive"
+
+    manifest = _emit(repo, out_dir)
+
+    assert manifest["schema_version"] == 1
+    assert manifest["repository"] == "heimgewebe/metarepo"
+    assert manifest["commit"] == _git(repo, "rev-parse", "HEAD").lower()
+    assert manifest["source_kind"] == "detached_archive"
+    assert manifest["source_root"] == "content"
+    # A consumer namespace binds its schemas and nothing else.
+    assert set(manifest["schemas"]) == {ZONES_SCHEMA, DRIFT_SCHEMA}
+    assert not (out_dir / "content/contracts/heim-pc/README.md").exists()
+
+    for relative, digest in manifest["schemas"].items():
+        source_bytes = (repo / relative).read_bytes()
+        cached_bytes = (out_dir / "content" / relative).read_bytes()
+        assert cached_bytes == source_bytes
+        assert digest == hashlib.sha256(source_bytes).hexdigest()
+
+    # The manifest is emitted on stdout as well, byte-identical to the file.
+    assert capsys.readouterr().out == (out_dir / MANIFEST_NAME).read_text(encoding="utf-8")
+
+
+def test_emitted_manifest_satisfies_the_published_contract(tmp_path):
+    repo = _source_repo(tmp_path)
+    manifest = _emit(repo, tmp_path / "archive")
+
+    schema = json.loads((ROOT / MANIFEST_SCHEMA_PATH).read_text(encoding="utf-8"))
+    Draft202012Validator.check_schema(schema)
+    Draft202012Validator(schema).validate(manifest)
+
+
+def test_offline_cache_round_trip_is_deterministic_and_verifiable(tmp_path):
+    repo = _source_repo(tmp_path)
+    out_dir = tmp_path / "cache"
+
+    _emit(repo, out_dir, "--source-kind", "offline_cache")
+    first = (out_dir / MANIFEST_NAME).read_bytes()
+    _emit(repo, out_dir, "--source-kind", "offline_cache", "--overwrite")
+    assert (out_dir / MANIFEST_NAME).read_bytes() == first
+
+    assert (
+        run(
+            [
+                "--source",
+                str(repo),
+                "--out-dir",
+                str(out_dir),
+                "--consumer",
+                "heim-pc",
+                "--source-kind",
+                "offline_cache",
+                "--verify",
+            ]
+        )
+        == 0
+    )
+
+
+@pytest.mark.parametrize(
+    ("mutate", "code"),
+    [
+        (
+            lambda out_dir: (out_dir / "content" / ZONES_SCHEMA).write_text(
+                "{}\n", encoding="utf-8"
+            ),
+            "CONTENT_DRIFT",
+        ),
+        (
+            lambda out_dir: (out_dir / "content" / ZONES_SCHEMA).unlink(),
+            "CONTENT_MISSING",
+        ),
+        (
+            lambda out_dir: (out_dir / "content/contracts/heim-pc/extra.json").write_text(
+                "{}\n", encoding="utf-8"
+            ),
+            "CONTENT_UNBOUND",
+        ),
+        (
+            lambda out_dir: (out_dir / MANIFEST_NAME).write_text("{}\n", encoding="utf-8"),
+            "MANIFEST_DRIFT",
+        ),
+        (
+            lambda out_dir: (out_dir / MANIFEST_NAME).unlink(),
+            "MANIFEST_MISSING",
+        ),
+    ],
+)
+def test_verify_rejects_every_cache_divergence(tmp_path, mutate, code):
+    repo = _source_repo(tmp_path)
+    out_dir = tmp_path / "cache"
+    _emit(repo, out_dir, "--source-kind", "offline_cache")
+
+    mutate(out_dir)
+
+    with pytest.raises(ManifestError) as excinfo:
+        run(
+            [
+                "--source",
+                str(repo),
+                "--out-dir",
+                str(out_dir),
+                "--consumer",
+                "heim-pc",
+                "--source-kind",
+                "offline_cache",
+                "--verify",
+            ]
+        )
+    assert excinfo.value.code == code
+
+
+def test_dirty_source_cannot_be_bound_as_immutable(tmp_path):
+    repo = _source_repo(tmp_path)
+    (repo / ZONES_SCHEMA).write_text("{}\n", encoding="utf-8")
+
+    with pytest.raises(ManifestError) as excinfo:
+        run(["--source", str(repo), "--out-dir", str(tmp_path / "out"), "--consumer", "heim-pc"])
+    assert excinfo.value.code == "SOURCE_DIRTY"
+    assert not (tmp_path / "out").exists()
+
+
+def test_untracked_file_also_makes_the_source_dirty(tmp_path):
+    repo = _source_repo(tmp_path)
+    (repo / "contracts/heim-pc/scratch.schema.json").write_text("{}\n", encoding="utf-8")
+
+    with pytest.raises(ManifestError) as excinfo:
+        run(["--source", str(repo), "--out-dir", str(tmp_path / "out"), "--consumer", "heim-pc"])
+    assert excinfo.value.code == "SOURCE_DIRTY"
+
+
+@pytest.mark.parametrize(
+    "origin",
+    [
+        "https://github.com/heimgewebe/heim-pc.git",
+        "https://gitlab.com/heimgewebe/metarepo.git",
+        "heimgewebe/metarepo",
+        "",
+    ],
+)
+def test_only_a_canonical_github_origin_is_accepted(tmp_path, origin):
+    repo = _source_repo(tmp_path, origin="https://github.com/heimgewebe/metarepo.git")
+    if origin:
+        _git(repo, "remote", "set-url", "origin", origin)
+    else:
+        _git(repo, "remote", "remove", "origin")
+
+    with pytest.raises(ManifestError) as excinfo:
+        run(["--source", str(repo), "--out-dir", str(tmp_path / "out"), "--consumer", "heim-pc"])
+    assert excinfo.value.code in {"SOURCE_WRONG_REPOSITORY", "SOURCE_NOT_GIT"}
+
+
+def test_expected_commit_mismatch_fails_closed(tmp_path):
+    repo = _source_repo(tmp_path)
+
+    with pytest.raises(ManifestError) as excinfo:
+        run(
+            [
+                "--source",
+                str(repo),
+                "--out-dir",
+                str(tmp_path / "out"),
+                "--consumer",
+                "heim-pc",
+                "--expected-commit",
+                "0" * 40,
+            ]
+        )
+    assert excinfo.value.code == "SOURCE_COMMIT_MISMATCH"
+
+    with pytest.raises(ManifestError) as excinfo:
+        run(
+            [
+                "--source",
+                str(repo),
+                "--out-dir",
+                str(tmp_path / "out"),
+                "--consumer",
+                "heim-pc",
+                "--expected-commit",
+                "not-a-commit",
+            ]
+        )
+    assert excinfo.value.code == "EXPECTED_COMMIT_INVALID"
+
+
+def test_a_manifest_must_bind_something_explicitly(tmp_path):
+    repo = _source_repo(tmp_path)
+
+    with pytest.raises(ManifestError) as excinfo:
+        run(["--source", str(repo), "--out-dir", str(tmp_path / "out")])
+    assert excinfo.value.code == "SCHEMA_SELECTION"
+
+    with pytest.raises(ManifestError) as excinfo:
+        run(
+            [
+                "--source",
+                str(repo),
+                "--out-dir",
+                str(tmp_path / "out"),
+                "--consumer",
+                "weltgewebe",
+            ]
+        )
+    assert excinfo.value.code == "CONSUMER_UNKNOWN"
+
+
+@pytest.mark.parametrize(
+    ("schema", "code"),
+    [
+        ("/etc/passwd", "SCHEMA_PATH_INVALID"),
+        ("contracts/../../secret.json", "SCHEMA_PATH_INVALID"),
+        ("contracts\\heim-pc\\zones.json", "SCHEMA_PATH_INVALID"),
+        ("contracts/heim-pc/absent.schema.json", "SCHEMA_MISSING"),
+        ("contracts/heim-pc", "SCHEMA_MISSING"),
+    ],
+)
+def test_explicit_schema_paths_stay_inside_the_bound_source(tmp_path, schema, code):
+    repo = _source_repo(tmp_path)
+
+    with pytest.raises(ManifestError) as excinfo:
+        run(
+            [
+                "--source",
+                str(repo),
+                "--out-dir",
+                str(tmp_path / "out"),
+                "--schema",
+                schema,
+            ]
+        )
+    assert excinfo.value.code == code
+
+
+def test_symlinked_schema_escaping_the_source_is_rejected(tmp_path):
+    outside = tmp_path / "outside.schema.json"
+    outside.write_text("{}\n", encoding="utf-8")
+    repo = _source_repo(tmp_path)
+    link = repo / "contracts/heim-pc/linked.schema.json"
+    link.symlink_to(outside)
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-m", "add escaping link")
+
+    with pytest.raises(ManifestError) as excinfo:
+        run(
+            [
+                "--source",
+                str(repo),
+                "--out-dir",
+                str(tmp_path / "out"),
+                "--schema",
+                "contracts/heim-pc/linked.schema.json",
+            ]
+        )
+    assert excinfo.value.code == "SCHEMA_PATH_ESCAPE"
+
+
+def test_output_must_not_dirty_the_bound_source(tmp_path):
+    repo = _source_repo(tmp_path)
+
+    with pytest.raises(ManifestError) as excinfo:
+        run(
+            [
+                "--source",
+                str(repo),
+                "--out-dir",
+                str(repo / "build" / "archive"),
+                "--consumer",
+                "heim-pc",
+            ]
+        )
+    assert excinfo.value.code == "OUT_DIR_INSIDE_SOURCE"
+
+
+def test_existing_cache_content_is_never_silently_replaced(tmp_path):
+    repo = _source_repo(tmp_path)
+    out_dir = tmp_path / "cache"
+    _emit(repo, out_dir)
+
+    with pytest.raises(ManifestError) as excinfo:
+        run(
+            [
+                "--source",
+                str(repo),
+                "--out-dir",
+                str(out_dir),
+                "--consumer",
+                "heim-pc",
+            ]
+        )
+    assert excinfo.value.code == "CONTENT_ROOT_NOT_EMPTY"
+
+
+def test_ci_style_sibling_layout_is_authoritative_only_when_named(tmp_path, monkeypatch):
+    """A CI checkout next to the consumer is a path, never ambient authority."""
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    repo = _source_repo(workspace)
+    (workspace / "metarepo").rename(workspace / "_metarepo")
+    sibling = workspace / "_metarepo"
+    consumer = workspace / "heim-pc"
+    consumer.mkdir()
+    monkeypatch.chdir(consumer)
+    monkeypatch.setenv("METAREPO_ROOT", str(sibling))
+
+    with pytest.raises(SystemExit):
+        run(["--out-dir", str(tmp_path / "out"), "--consumer", "heim-pc"])
+
+    manifest = _emit(sibling, tmp_path / "out")
+    assert manifest["commit"] == _git(sibling, "rev-parse", "HEAD").lower()
+    assert repo.name == "metarepo"
+
+
+def test_cli_entry_point_reports_typed_failures_without_traceback(tmp_path, capsys):
+    repo = _source_repo(tmp_path)
+    (repo / ZONES_SCHEMA).write_text("{}\n", encoding="utf-8")
+
+    exit_code = main(
+        ["--source", str(repo), "--out-dir", str(tmp_path / "out"), "--consumer", "heim-pc"]
+    )
+
+    assert exit_code == 2
+    assert capsys.readouterr().err.startswith("SOURCE_DIRTY: ")

--- a/tests/test_contract_source_manifest.py
+++ b/tests/test_contract_source_manifest.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import hashlib
 import json
 from pathlib import Path
+import shutil
 import subprocess
 import sys
 
@@ -25,6 +26,8 @@ from emit_source_manifest import (  # noqa: E402
 
 ZONES_SCHEMA = "contracts/heim-pc/config/zones.schema.json"
 DRIFT_SCHEMA = "contracts/heim-pc/state/heim-pc.state.drift.schema.json"
+CHRONIK_SCHEMA = "contracts/chronik/event.batch.v1.schema.json"
+BASE_EVENT_SCHEMA = "contracts/events/base.event.schema.json"
 
 
 def _git(repo: Path, *args: str) -> str:
@@ -32,6 +35,19 @@ def _git(repo: Path, *args: str) -> str:
         ["git", "-C", str(repo), *args], check=True, text=True, capture_output=True
     )
     return result.stdout.strip()
+
+
+def _git_bytes(repo: Path, *args: str) -> bytes:
+    result = subprocess.run(
+        ["git", "-C", str(repo), *args], check=True, capture_output=True
+    )
+    return result.stdout
+
+
+def _write_schema(repo: Path, relative: str, payload: object) -> None:
+    target = repo / relative
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
 
 
 def _source_repo(tmp_path: Path, origin: str = "https://github.com/heimgewebe/metarepo.git") -> Path:
@@ -139,6 +155,149 @@ def test_offline_cache_round_trip_is_deterministic_and_verifiable(tmp_path):
     )
 
 
+def test_chronik_consumer_binds_transitive_cross_namespace_reference(tmp_path):
+    repo = _source_repo(tmp_path)
+    _write_schema(repo, BASE_EVENT_SCHEMA, {"title": "base event", "type": "object"})
+    _write_schema(
+        repo,
+        CHRONIK_SCHEMA,
+        {
+            "title": "event batch",
+            "type": "array",
+            "items": {"$ref": "../events/base.event.schema.json"},
+        },
+    )
+    _git(repo, "add", "contracts")
+    _git(repo, "commit", "-m", "add chronik schema dependency")
+    out_dir = tmp_path / "chronik-archive"
+
+    assert (
+        run(
+            [
+                "--source",
+                str(repo),
+                "--out-dir",
+                str(out_dir),
+                "--consumer",
+                "chronik",
+            ]
+        )
+        == 0
+    )
+
+    manifest = json.loads((out_dir / MANIFEST_NAME).read_text(encoding="utf-8"))
+    assert set(manifest["schemas"]) == {CHRONIK_SCHEMA, BASE_EVENT_SCHEMA}
+    for relative in manifest["schemas"]:
+        committed = _git_bytes(repo, "show", f"HEAD:{relative}")
+        assert (out_dir / "content" / relative).read_bytes() == committed
+        assert manifest["schemas"][relative] == hashlib.sha256(committed).hexdigest()
+
+
+def test_local_ref_closure_handles_fragments_normalization_external_uris_and_cycles(
+    tmp_path,
+):
+    repo = _source_repo(tmp_path)
+    first = "contracts/cycle/a.schema.json"
+    second = "contracts/events/cycle-b.schema.json"
+    _write_schema(
+        repo,
+        first,
+        {
+            "$defs": {
+                "local": {"type": "string"},
+                "self": {"$ref": "#/$defs/local"},
+            },
+            "allOf": [
+                {"$ref": "../events/./cycle-b.schema.json#/$defs/value"},
+                {
+                    "$ref": "https://example.invalid/contracts/not-local.schema.json"
+                },
+            ],
+        },
+    )
+    _write_schema(
+        repo,
+        second,
+        {
+            "$defs": {"value": {"type": "integer"}},
+            "allOf": [{"$ref": "../cycle/a.schema.json"}],
+        },
+    )
+    _git(repo, "add", "contracts")
+    _git(repo, "commit", "-m", "add cyclic schema references")
+    out_dir = tmp_path / "cycle-archive"
+
+    assert (
+        run(
+            [
+                "--source",
+                str(repo),
+                "--out-dir",
+                str(out_dir),
+                "--consumer",
+                "cycle",
+            ]
+        )
+        == 0
+    )
+
+    manifest = json.loads((out_dir / MANIFEST_NAME).read_text(encoding="utf-8"))
+    assert set(manifest["schemas"]) == {first, second}
+
+
+@pytest.mark.parametrize(
+    ("reference", "code"),
+    [
+        ("../../outside.schema.json", "SCHEMA_REF_ESCAPE"),
+        ("../events/missing.schema.json", "SCHEMA_REF_MISSING"),
+        ("../events/%2e%2e/secret.schema.json", "SCHEMA_REF_INVALID"),
+        ("../events/base.event.schema.json?revision=worktree", "SCHEMA_REF_INVALID"),
+    ],
+)
+def test_invalid_missing_or_escaping_local_refs_fail_closed(tmp_path, reference, code):
+    repo = _source_repo(tmp_path)
+    _write_schema(
+        repo,
+        "contracts/broken/root.schema.json",
+        {"$ref": reference},
+    )
+    _git(repo, "add", "contracts")
+    _git(repo, "commit", "-m", "add invalid schema reference")
+
+    with pytest.raises(ManifestError) as excinfo:
+        run(
+            [
+                "--source",
+                str(repo),
+                "--out-dir",
+                str(tmp_path / "out"),
+                "--consumer",
+                "broken",
+            ]
+        )
+    assert excinfo.value.code == code
+
+
+def test_non_string_ref_fails_closed(tmp_path):
+    repo = _source_repo(tmp_path)
+    _write_schema(repo, "contracts/broken/root.schema.json", {"$ref": 42})
+    _git(repo, "add", "contracts")
+    _git(repo, "commit", "-m", "add malformed schema reference")
+
+    with pytest.raises(ManifestError) as excinfo:
+        run(
+            [
+                "--source",
+                str(repo),
+                "--out-dir",
+                str(tmp_path / "out"),
+                "--consumer",
+                "broken",
+            ]
+        )
+    assert excinfo.value.code == "SCHEMA_REF_INVALID"
+
+
 @pytest.mark.parametrize(
     ("mutate", "code"),
     [
@@ -211,6 +370,56 @@ def test_untracked_file_also_makes_the_source_dirty(tmp_path):
     assert excinfo.value.code == "SOURCE_DIRTY"
 
 
+@pytest.mark.parametrize("ignore_source", ["gitignore", "info-exclude"])
+def test_ignored_schemas_are_never_selected_or_read_from_the_worktree(
+    tmp_path, ignore_source
+):
+    repo = _source_repo(tmp_path)
+    ignored = "contracts/heim-pc/ignored.schema.json"
+    if ignore_source == "gitignore":
+        (repo / ".gitignore").write_text(f"/{ignored}\n", encoding="utf-8")
+        _git(repo, "add", ".gitignore")
+        _git(repo, "commit", "-m", "ignore generated schemas")
+    else:
+        (repo / ".git/info").mkdir(exist_ok=True)
+        (repo / ".git/info/exclude").write_text(f"/{ignored}\n", encoding="utf-8")
+    _write_schema(repo, ignored, {"title": "must not be attested"})
+
+    assert _git(repo, "status", "--porcelain=v1", "--untracked-files=all") == ""
+    assert ignored in _git(repo, "status", "--short", "--ignored")
+
+    manifest = _emit(repo, tmp_path / "consumer-archive")
+    assert ignored not in manifest["schemas"]
+    assert not (tmp_path / "consumer-archive/content" / ignored).exists()
+
+    with pytest.raises(ManifestError) as excinfo:
+        run(
+            [
+                "--source",
+                str(repo),
+                "--out-dir",
+                str(tmp_path / "explicit-archive"),
+                "--schema",
+                ignored,
+            ]
+        )
+    assert excinfo.value.code == "SCHEMA_NOT_TRACKED"
+
+
+def test_payload_bytes_come_from_head_even_when_git_hides_worktree_drift(tmp_path):
+    repo = _source_repo(tmp_path)
+    committed = _git_bytes(repo, "show", f"HEAD:{ZONES_SCHEMA}")
+    _git(repo, "update-index", "--assume-unchanged", ZONES_SCHEMA)
+    (repo / ZONES_SCHEMA).write_text('{"title":"worktree only"}\n', encoding="utf-8")
+    assert _git(repo, "status", "--porcelain=v1", "--untracked-files=all") == ""
+
+    out_dir = tmp_path / "archive"
+    manifest = _emit(repo, out_dir)
+
+    assert (out_dir / "content" / ZONES_SCHEMA).read_bytes() == committed
+    assert manifest["schemas"][ZONES_SCHEMA] == hashlib.sha256(committed).hexdigest()
+
+
 @pytest.mark.parametrize(
     "origin",
     [
@@ -266,6 +475,46 @@ def test_expected_commit_mismatch_fails_closed(tmp_path):
     assert excinfo.value.code == "EXPECTED_COMMIT_INVALID"
 
 
+def test_invalid_source_kind_has_a_typed_cli_failure(tmp_path, capsys):
+    repo = _source_repo(tmp_path)
+
+    exit_code = main(
+        [
+            "--source",
+            str(repo),
+            "--out-dir",
+            str(tmp_path / "out"),
+            "--consumer",
+            "heim-pc",
+            "--source-kind",
+            "mutable_worktree",
+        ]
+    )
+
+    assert exit_code == 2
+    assert capsys.readouterr().err.startswith("SOURCE_KIND_INVALID: ")
+
+
+def test_content_root_cannot_collide_with_manifest_path(tmp_path):
+    repo = _source_repo(tmp_path)
+
+    with pytest.raises(ManifestError) as excinfo:
+        run(
+            [
+                "--source",
+                str(repo),
+                "--out-dir",
+                str(tmp_path / "out"),
+                "--consumer",
+                "heim-pc",
+                "--content-root",
+                f"{MANIFEST_NAME}/content",
+            ]
+        )
+    assert excinfo.value.code == "CONTENT_ROOT_INVALID"
+    assert not (tmp_path / "out").exists()
+
+
 def test_a_manifest_must_bind_something_explicitly(tmp_path):
     repo = _source_repo(tmp_path)
 
@@ -293,8 +542,9 @@ def test_a_manifest_must_bind_something_explicitly(tmp_path):
         ("/etc/passwd", "SCHEMA_PATH_INVALID"),
         ("contracts/../../secret.json", "SCHEMA_PATH_INVALID"),
         ("contracts\\heim-pc\\zones.json", "SCHEMA_PATH_INVALID"),
-        ("contracts/heim-pc/absent.schema.json", "SCHEMA_MISSING"),
-        ("contracts/heim-pc", "SCHEMA_MISSING"),
+        ("contracts/heim-pc/README.md", "SCHEMA_PATH_INVALID"),
+        ("contracts/heim-pc/absent.schema.json", "SCHEMA_NOT_TRACKED"),
+        ("contracts/heim-pc", "SCHEMA_PATH_INVALID"),
     ],
 )
 def test_explicit_schema_paths_stay_inside_the_bound_source(tmp_path, schema, code):
@@ -312,6 +562,26 @@ def test_explicit_schema_paths_stay_inside_the_bound_source(tmp_path, schema, co
             ]
         )
     assert excinfo.value.code == code
+
+
+def test_consumer_selection_rejects_non_canonical_tracked_schema_path(tmp_path):
+    repo = _source_repo(tmp_path)
+    _write_schema(repo, "contracts/odd/not canonical.schema.json", {"type": "object"})
+    _git(repo, "add", "contracts")
+    _git(repo, "commit", "-m", "add non-canonical schema path")
+
+    with pytest.raises(ManifestError) as excinfo:
+        run(
+            [
+                "--source",
+                str(repo),
+                "--out-dir",
+                str(tmp_path / "out"),
+                "--consumer",
+                "odd",
+            ]
+        )
+    assert excinfo.value.code == "SCHEMA_PATH_INVALID"
 
 
 def test_symlinked_schema_escaping_the_source_is_rejected(tmp_path):
@@ -371,6 +641,81 @@ def test_existing_cache_content_is_never_silently_replaced(tmp_path):
             ]
         )
     assert excinfo.value.code == "CONTENT_ROOT_NOT_EMPTY"
+
+
+@pytest.mark.parametrize("overwrite", [False, True])
+def test_materialize_rejects_non_directory_content_root_without_traceback(
+    tmp_path, capsys, overwrite
+):
+    repo = _source_repo(tmp_path)
+    out_dir = tmp_path / "cache"
+    out_dir.mkdir()
+    (out_dir / "content").write_text("not a directory\n", encoding="utf-8")
+    argv = [
+        "--source",
+        str(repo),
+        "--out-dir",
+        str(out_dir),
+        "--consumer",
+        "heim-pc",
+    ]
+    if overwrite:
+        argv.append("--overwrite")
+
+    assert main(argv) == 2
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err.startswith("CONTENT_ROOT_INVALID_TYPE: ")
+    assert "Traceback" not in captured.err
+
+
+def _replace_content_root_with_file(out_dir: Path) -> None:
+    shutil.rmtree(out_dir / "content")
+    (out_dir / "content").write_text("not a directory\n", encoding="utf-8")
+
+
+def _replace_manifest_with_directory(out_dir: Path) -> None:
+    (out_dir / MANIFEST_NAME).unlink()
+    (out_dir / MANIFEST_NAME).mkdir()
+
+
+def _replace_bound_schema_with_symlink(out_dir: Path) -> None:
+    target = out_dir / "content" / ZONES_SCHEMA
+    target.unlink()
+    outside = out_dir / "outside.schema.json"
+    outside.write_text("{}\n", encoding="utf-8")
+    target.symlink_to(outside)
+
+
+@pytest.mark.parametrize(
+    ("mutate", "code"),
+    [
+        (_replace_content_root_with_file, "CONTENT_ROOT_INVALID_TYPE"),
+        (_replace_manifest_with_directory, "MANIFEST_INVALID_TYPE"),
+        (_replace_bound_schema_with_symlink, "CONTENT_INVALID_TYPE"),
+    ],
+)
+def test_verify_rejects_non_regular_cache_nodes(tmp_path, mutate, code):
+    repo = _source_repo(tmp_path)
+    out_dir = tmp_path / "cache"
+    _emit(repo, out_dir, "--source-kind", "offline_cache")
+    mutate(out_dir)
+
+    with pytest.raises(ManifestError) as excinfo:
+        run(
+            [
+                "--source",
+                str(repo),
+                "--out-dir",
+                str(out_dir),
+                "--consumer",
+                "heim-pc",
+                "--source-kind",
+                "offline_cache",
+                "--verify",
+            ]
+        )
+    assert excinfo.value.code == code
 
 
 def test_ci_style_sibling_layout_is_authoritative_only_when_named(tmp_path, monkeypatch):

--- a/tests/test_contract_source_manifest_review_regressions.py
+++ b/tests/test_contract_source_manifest_review_regressions.py
@@ -1,0 +1,166 @@
+"""Regression guards for PR #710 source-manifest review findings."""
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+import subprocess
+import sys
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+PRODUCER_DIR = ROOT / "scripts" / "contracts"
+if str(PRODUCER_DIR) not in sys.path:
+    sys.path.insert(0, str(PRODUCER_DIR))
+
+from emit_source_manifest import MANIFEST_NAME, main, run  # noqa: E402
+
+ZONES_SCHEMA = "contracts/heim-pc/config/zones.schema.json"
+
+
+def _git(repo: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+    return result.stdout.strip()
+
+
+def _git_bytes(repo: Path, *args: str) -> bytes:
+    result = subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=True,
+        capture_output=True,
+    )
+    return result.stdout
+
+
+def _write_schema(repo: Path, relative: str, payload: object) -> None:
+    target = repo / relative
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def _source_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "metarepo"
+    repo.mkdir()
+    _git(repo, "init", "--initial-branch=main")
+    _git(repo, "config", "user.email", "test@example.invalid")
+    _git(repo, "config", "user.name", "Contract Review Test")
+    _git(repo, "remote", "add", "origin", "https://github.com/heimgewebe/metarepo.git")
+    _write_schema(repo, ZONES_SCHEMA, {"title": "zones", "type": "object"})
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-m", "seed contracts")
+    return repo
+
+
+def _emit(repo: Path, out_dir: Path, *extra: str) -> dict:
+    assert (
+        run(
+            [
+                "--source",
+                str(repo),
+                "--out-dir",
+                str(out_dir),
+                "--consumer",
+                "heim-pc",
+                *extra,
+            ]
+        )
+        == 0
+    )
+    return json.loads((out_dir / MANIFEST_NAME).read_text(encoding="utf-8"))
+
+
+def test_nested_id_base_resolves_through_committed_resource_identifier(tmp_path: Path) -> None:
+    repo = _source_repo(tmp_path)
+    root = "contracts/scoped/root.schema.json"
+    target = "contracts/resources/actual-target.schema.json"
+    resource_base = "https://schemas.example.invalid/scoped/"
+    _write_schema(
+        repo,
+        root,
+        {
+            "$id": "https://schemas.example.invalid/root.schema.json",
+            "$defs": {
+                "scope": {
+                    "$id": resource_base,
+                    "$ref": "target.schema.json#/$defs/value",
+                }
+            },
+        },
+    )
+    _write_schema(
+        repo,
+        target,
+        {
+            "$id": f"{resource_base}target.schema.json",
+            "$defs": {"value": {"type": "string"}},
+        },
+    )
+    _git(repo, "add", "contracts")
+    _git(repo, "commit", "-m", "add nested identifier scope")
+
+    out_dir = tmp_path / "scoped-archive"
+    assert (
+        run(
+            [
+                "--source",
+                str(repo),
+                "--out-dir",
+                str(out_dir),
+                "--consumer",
+                "scoped",
+            ]
+        )
+        == 0
+    )
+
+    manifest = json.loads((out_dir / MANIFEST_NAME).read_text(encoding="utf-8"))
+    assert set(manifest["schemas"]) == {root, target}
+
+
+def test_replacement_refs_cannot_change_bound_commit_objects(tmp_path: Path) -> None:
+    repo = _source_repo(tmp_path)
+    original = _git(repo, "rev-parse", "HEAD")
+    committed = _git_bytes(repo, "show", f"{original}:{ZONES_SCHEMA}")
+    (repo / ZONES_SCHEMA).write_text(
+        '{"title":"replacement bytes"}\n', encoding="utf-8"
+    )
+    _git(repo, "add", ZONES_SCHEMA)
+    _git(repo, "commit", "-m", "create replacement commit")
+    replacement = _git(repo, "rev-parse", "HEAD")
+    _git(repo, "reset", "--hard", original)
+    _git(repo, "replace", original, replacement)
+
+    out_dir = tmp_path / "replacement-archive"
+    manifest = _emit(repo, out_dir)
+
+    assert manifest["commit"] == original
+    assert (out_dir / "content" / ZONES_SCHEMA).read_bytes() == committed
+    assert manifest["schemas"][ZONES_SCHEMA] == hashlib.sha256(committed).hexdigest()
+
+
+def test_malformed_origin_url_is_a_typed_cli_failure(tmp_path: Path, capsys) -> None:
+    repo = _source_repo(tmp_path)
+    _git(repo, "remote", "set-url", "origin", "https://[invalid")
+
+    exit_code = main(
+        [
+            "--source",
+            str(repo),
+            "--out-dir",
+            str(tmp_path / "out"),
+            "--consumer",
+            "heim-pc",
+        ]
+    )
+
+    assert exit_code == 2
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err.startswith("SOURCE_WRONG_REPOSITORY: ")
+    assert "Traceback" not in captured.err

--- a/tests/test_contract_source_manifest_review_regressions.py
+++ b/tests/test_contract_source_manifest_review_regressions.py
@@ -134,7 +134,8 @@ def test_replacement_refs_cannot_change_bound_commit_objects(tmp_path: Path) -> 
     _git(repo, "commit", "-m", "create replacement commit")
     replacement = _git(repo, "rev-parse", "HEAD")
     _git(repo, "reset", "--hard", original)
-    _git(repo, "replace", original, replacement)
+    _git(repo, "update-ref", f"refs/replace/{original}", replacement)
+    assert _git(repo, "replace", "-l") == original
 
     out_dir = tmp_path / "replacement-archive"
     manifest = _emit(repo, out_dir)


### PR DESCRIPTION
## Warum

`heim-pc` löst kanonische Contracts fail-closed aus genau einer explizit benannten Quelle auf: entweder einem identitätsgeprüften Metarepo-Git-Checkout oder einem Manifest, das ein losgelöstes Archiv bzw. einen freigegebenen Offline-Cache an Repositoryidentität, Commit und SHA-256 je Schema bindet.

Für den zweiten Weg gab es bisher keinen reproduzierbaren Produzenten. Diese PR macht Herkunft, exakte Commit-Bytes und lokale Schema-Abhängigkeiten vollständig und reproduzierbar belegbar.

## Was diese PR ändert

- veröffentlicht `contracts/contract.source.manifest.schema.json` als Contract;
- erzeugt Manifest und Cache deterministisch über `scripts/contracts/emit_source_manifest.py`;
- liest Auswahl und Bytes ausschließlich aus dem gebundenen Git-Commit, nicht aus dem Arbeitsbaum;
- deaktiviert Git-Replacement-Refs für provenance-relevante Leseoperationen und verifiziert Commit- sowie Root-Tree-Objektidentität;
- bindet die transitive lokale `$ref`-Closure einschließlich Cross-Namespace-Referenzen;
- löst `$ref` gemäß JSON Schema Draft 2020-12 gegen den jeweils aktiven, auch verschachtelten `$id`-Basis-URI auf und indexiert committed Schemaressourcen deterministisch nach ihren IDs;
- behandelt malformed Origin-URLs, fehlende/doppelte Schemaressourcen, Cache-Knotentypen und weitere erwartbare Randfälle typisiert mit Exit 2;
- verifiziert bestehende Archive mit `--verify` bytegenau gegen die gebundene Quelle;
- dokumentiert Provenienz, Fehlercodes und Konsumentenpflichten;
- erweitert `contracts-validate` um einen realen `heim-pc + chronik`-Emit/Verify-Smoke.

## Review-Fixes

Die erste Reviewrunde ist vollständig eingearbeitet:

1. **P1 – transitive Schemas:** Consumer-Archive enthalten die vollständige lokale `$ref`-Closure.
2. **P1 – Commit-Attestierung:** ignorierte/ungetrackte/Worktree-only Bytes können nicht als `HEAD` attestiert werden; gelesen wird aus Git-Blobs.
3. **P2 – typisierte Cachefehler:** falsche Knotentypen enden stabil mit `ManifestError`/Exit 2 statt Traceback.

Die zweite Reviewrunde ist ebenfalls an der Wurzel adressiert:

1. **P1 – Git replacement refs:** `GIT_NO_REPLACE_OBJECTS=1` plus Rohobjektprüfung für Commit und Root-Tree verhindert umgebogene Commit-Provenienz.
2. **P2 – verschachtelte `$id`-Basis:** Referenzen werden gegen den aktiven Draft-2020-12-Basis-URI aufgelöst; committed Ressourcen-IDs bilden einen deterministischen lokalen Index.
3. **P2 – malformed Origin:** unparsebare Remote-URLs werden als stabiler `SOURCE_WRONG_REPOSITORY`-Fehler behandelt.

Dafür existieren zusätzliche fokussierte Regressionen in `tests/test_contract_source_manifest_review_regressions.py`, einschließlich Git-2.54-portablem Replacement-Ref-Fixture.

## CI-Härtung

Metarepo hatte den externen Lychee-Linkcheck doppelt: einmal im allgemeinen OS-Matrix-Workflow und einmal im dedizierten `linkcheck.yml`. Die Inline-Duplikation wurde aus `ci.yml` entfernt; der dedizierte, revisionsgepinnte **harte Linkcheck bleibt unverändert bestehen**. Dadurch können externe Link-Timeouts nicht mehr vor den eigentlichen Projekt-/Python-Tests die allgemeine Matrix blockieren.

## Validierung auf aktuellem Head `dbc569fa78e738f0931e4c378f0d6d745d125d40`

- Voll-CI Ubuntu: grün, einschließlich Actionlint, Shell-Lint und `just ci`;
- Voll-CI macOS: grün, einschließlich `just ci`;
- Action-Ref-Guard: grün;
- `contracts-validate`: grün;
- dedizierter Linkcheck: nach einem Lauf mit ausschließlich zwei externen Timeouts auf unverändertem Head erfolgreich im Job-Rerun;
- alle übrigen PR-Workflows/Guards auf diesem Head grün.

## Bezug zu den Akzeptanzkriterien

| Kriterium | Stand |
| --- | --- |
| `resolver-contract` | Genau eine explizit benannte Quelle; kein ambienter Sibling-Pfad und keine Umgebungsvariable als Autorität. |
| `identity` | Repository, Commit, Quellart, Inhaltswurzel und SHA-256 je Schema sind gebunden; Commit-/Tree-/Blob-Provenienz wird gegen Git-Objekte geprüft. |
| `offline-and-ci` | Archive und Offline-Caches sind reproduzierbar erzeug- und verifizierbar; CI prüft einen realen Multi-Consumer-Fall. |
| `fail-closed` | Provenienz-, Auswahl-, `$id`-/`$ref`-, Materialisierungs- und Verify-Fehler sind typisiert. |
| `execution-surface` | Alle Eingaben sind explizite CLI-Argumente. |
| `tests` | Provenienz, Ignore-/Worktree-Drift, Replacement-Refs, verschachtelte `$id`-Basen, transitive/zyklische Refs, Escape-/Missing-Fälle, malformed Origin und Cache-Knotentypen sind abgedeckt. |

## Bewusst nicht in dieser PR

- Keine `heim-pc`-Änderung: Pin-Bump und E2E-Manifestroute werden nach dem Merge an den exakten Default-Branch-Commit gebunden.
- Keine vorschnelle Registrierung in `contracts/consumers.yaml`: ein Claim muss auf exakte Default-Branch-Evidenz zeigen.
- Kein `dirty`-Override.
- Nicht lokal gebundene externe URI-Abhängigkeiten werden nicht archiviert; dafür wäre eine eigene Provenienzstrategie nötig.

Bureau-Task: `OPERATOR-MACHINE-READABILITY-V1-T008`