### PR TITLE
fix(contracts): close post-merge source-manifest review gaps

### DIFF
--- a/scripts/contracts/emit_source_manifest.py
+++ b/scripts/contracts/emit_source_manifest.py
@@ -38,6 +38,26 @@ DEFAULT_CONTENT_ROOT = "content"
 HEX40 = re.compile(r"^[0-9a-f]{40}$")
 RELATIVE_POSIX = re.compile(r"^(?!.*(^|/)\.\.?(/|$))[A-Za-z0-9._-]+(/[A-Za-z0-9._-]+)*$")
 
+SCHEMA_VALUE_KEYWORDS = frozenset(
+    {
+        "additionalProperties",
+        "contains",
+        "contentSchema",
+        "else",
+        "if",
+        "items",
+        "not",
+        "propertyNames",
+        "then",
+        "unevaluatedItems",
+        "unevaluatedProperties",
+    }
+)
+SCHEMA_ARRAY_KEYWORDS = frozenset({"allOf", "anyOf", "oneOf", "prefixItems"})
+SCHEMA_MAP_KEYWORDS = frozenset(
+    {"$defs", "dependentSchemas", "patternProperties", "properties"}
+)
+
 
 class ManifestError(RuntimeError):
     """Stable, typed contract source manifest failure."""
@@ -57,18 +77,30 @@ class GitTreeEntry:
     object_id: str
 
 
-def _run_git(root: Path, *args: str) -> str:
-    env = os.environ.copy()
+def _git_environment() -> dict[str, str]:
+    env = {key: value for key, value in os.environ.items() if not key.startswith("GIT_")}
     env["GIT_NO_REPLACE_OBJECTS"] = "1"
+    return env
+
+
+def _run_git(root: Path, *args: str, absent_ok: bool = False) -> str:
     try:
         result = subprocess.run(
             ["git", "-C", str(root), *args],
             check=True,
             text=True,
             capture_output=True,
-            env=env,
+            env=_git_environment(),
         )
     except (OSError, subprocess.CalledProcessError, UnicodeError) as exc:
+        if (
+            absent_ok
+            and isinstance(exc, subprocess.CalledProcessError)
+            and exc.returncode == 1
+            and not (exc.stdout or "").strip()
+            and not (exc.stderr or "").strip()
+        ):
+            return ""
         stderr = getattr(exc, "stderr", "") or ""
         raise ManifestError("SOURCE_NOT_GIT", stderr.strip() or str(exc)) from exc
     return result.stdout.strip()
@@ -77,14 +109,12 @@ def _run_git(root: Path, *args: str) -> str:
 def _run_git_bytes(
     root: Path, *args: str, code: str = "SOURCE_NOT_GIT", detail: str = "Git read failed"
 ) -> bytes:
-    env = os.environ.copy()
-    env["GIT_NO_REPLACE_OBJECTS"] = "1"
     try:
         result = subprocess.run(
             ["git", "-C", str(root), *args],
             check=True,
             capture_output=True,
-            env=env,
+            env=_git_environment(),
         )
     except (OSError, subprocess.CalledProcessError) as exc:
         stderr = getattr(exc, "stderr", b"") or b""
@@ -177,7 +207,9 @@ def resolve_source(source_path: str, expected_commit: str | None) -> tuple[Path,
             f"explicit source must be the Git repository root: {root}",
         )
 
-    origin = _run_git(root, "config", "--get", "remote.origin.url")
+    origin = _run_git(
+        root, "config", "--get", "remote.origin.url", absent_ok=True
+    )
     if _repository_identity(origin) != EXPECTED_REPOSITORY:
         raise ManifestError(
             "SOURCE_WRONG_REPOSITORY",
@@ -434,7 +466,7 @@ def _resolve_uri(referrer: str, base_uri: str, value: str, keyword: str) -> str:
 def _schema_resources_and_references(
     relative: str, schema: Any, base_uri: str
 ) -> Iterable[tuple[str, str]]:
-    """Yield resource identifiers and references with their active base URI."""
+    """Yield resources and references at Draft 2020-12 schema positions."""
 
     if isinstance(schema, dict):
         active_base = base_uri
@@ -459,11 +491,18 @@ def _schema_resources_and_references(
                         "SCHEMA_REF_INVALID", f"{relative} contains a non-string $ref"
                     )
                 yield "reference", _resolve_uri(relative, active_base, value, "REF")
-            if key != "$id":
+            elif key in SCHEMA_VALUE_KEYWORDS:
                 yield from _schema_resources_and_references(relative, value, active_base)
-    elif isinstance(schema, list):
-        for value in schema:
-            yield from _schema_resources_and_references(relative, value, base_uri)
+            elif key in SCHEMA_ARRAY_KEYWORDS and isinstance(value, list):
+                for subschema in value:
+                    yield from _schema_resources_and_references(
+                        relative, subschema, active_base
+                    )
+            elif key in SCHEMA_MAP_KEYWORDS and isinstance(value, dict):
+                for name in sorted(value):
+                    yield from _schema_resources_and_references(
+                        relative, value[name], active_base
+                    )
 
 
 def _schema_identifier_index(

--- a/tests/test_contract_source_manifest_review_regressions.py
+++ b/tests/test_contract_source_manifest_review_regressions.py
@@ -165,3 +165,89 @@ def test_malformed_origin_url_is_a_typed_cli_failure(tmp_path: Path, capsys) -> 
     assert captured.out == ""
     assert captured.err.startswith("SOURCE_WRONG_REPOSITORY: ")
     assert "Traceback" not in captured.err
+
+
+def test_ambient_git_repository_overrides_do_not_change_named_source(
+    tmp_path: Path, monkeypatch
+) -> None:
+    source = _source_repo(tmp_path)
+    expected_head = _git(source, "rev-parse", "HEAD")
+    expected_bytes = _git_bytes(source, "show", f"{expected_head}:{ZONES_SCHEMA}")
+
+    ambient_parent = tmp_path / "ambient"
+    ambient_parent.mkdir()
+    ambient = _source_repo(ambient_parent)
+    (ambient / ZONES_SCHEMA).write_text(
+        '{"title":"ambient repository bytes"}\n', encoding="utf-8"
+    )
+    _git(ambient, "add", ZONES_SCHEMA)
+    _git(ambient, "commit", "-m", "change ambient repository")
+
+    monkeypatch.setenv("GIT_DIR", str(ambient / ".git"))
+    monkeypatch.setenv("GIT_WORK_TREE", str(source))
+    monkeypatch.setenv("GIT_INDEX_FILE", str(ambient / ".git" / "index"))
+
+    out_dir = tmp_path / "ambient-override-archive"
+    manifest = _emit(source, out_dir)
+
+    assert manifest["commit"] == expected_head
+    assert (out_dir / "content" / ZONES_SCHEMA).read_bytes() == expected_bytes
+    assert manifest["schemas"][ZONES_SCHEMA] == hashlib.sha256(expected_bytes).hexdigest()
+
+
+def test_annotation_and_instance_values_are_not_traversed_as_subschemas(tmp_path: Path) -> None:
+    repo = _source_repo(tmp_path)
+    schema_path = "contracts/annotations/root.schema.json"
+    _write_schema(
+        repo,
+        schema_path,
+        {
+            "type": "object",
+            "properties": {"value": {"type": "string"}},
+            "examples": [{"$ref": "not-a-schema.schema.json"}],
+            "default": {"$id": "also-not-a-schema"},
+            "const": {"$ref": "const-data.schema.json"},
+            "enum": [{"$id": "enum-data"}],
+        },
+    )
+    _git(repo, "add", "contracts")
+    _git(repo, "commit", "-m", "add annotation data with schema-like keys")
+
+    out_dir = tmp_path / "annotation-archive"
+    assert (
+        run(
+            [
+                "--source",
+                str(repo),
+                "--out-dir",
+                str(out_dir),
+                "--consumer",
+                "annotations",
+            ]
+        )
+        == 0
+    )
+    manifest = json.loads((out_dir / MANIFEST_NAME).read_text(encoding="utf-8"))
+    assert set(manifest["schemas"]) == {schema_path}
+
+
+def test_missing_origin_is_a_repository_identity_failure(tmp_path: Path, capsys) -> None:
+    repo = _source_repo(tmp_path)
+    _git(repo, "remote", "remove", "origin")
+
+    exit_code = main(
+        [
+            "--source",
+            str(repo),
+            "--out-dir",
+            str(tmp_path / "out"),
+            "--consumer",
+            "heim-pc",
+        ]
+    )
+
+    assert exit_code == 2
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err.startswith("SOURCE_WRONG_REPOSITORY: ")
+    assert "Traceback" not in captured.err

--- a/tests/test_contract_source_manifest_review_regressions.py
+++ b/tests/test_contract_source_manifest_review_regressions.py
@@ -186,6 +186,9 @@ def test_ambient_git_repository_overrides_do_not_change_named_source(
     monkeypatch.setenv("GIT_DIR", str(ambient / ".git"))
     monkeypatch.setenv("GIT_WORK_TREE", str(source))
     monkeypatch.setenv("GIT_INDEX_FILE", str(ambient / ".git" / "index"))
+    monkeypatch.setenv("GIT_CONFIG_COUNT", "1")
+    monkeypatch.setenv("GIT_CONFIG_KEY_0", "remote.origin.url")
+    monkeypatch.setenv("GIT_CONFIG_VALUE_0", "https://github.com/ambient/wrong.git")
 
     out_dir = tmp_path / "ambient-override-archive"
     manifest = _emit(source, out_dir)
@@ -198,18 +201,25 @@ def test_ambient_git_repository_overrides_do_not_change_named_source(
 def test_annotation_and_instance_values_are_not_traversed_as_subschemas(tmp_path: Path) -> None:
     repo = _source_repo(tmp_path)
     schema_path = "contracts/annotations/root.schema.json"
+    default_target = "contracts/resources/default-target.schema.json"
+    enum_target = "contracts/resources/enum-target.schema.json"
+    default_id = "https://schemas.example.invalid/default-target.schema.json"
+    enum_id = "https://schemas.example.invalid/enum-target.schema.json"
     _write_schema(
         repo,
         schema_path,
         {
             "type": "object",
             "properties": {"value": {"type": "string"}},
+            "allOf": [{"$ref": default_id}, {"$ref": enum_id}],
             "examples": [{"$ref": "not-a-schema.schema.json"}],
-            "default": {"$id": "also-not-a-schema"},
+            "default": {"$id": default_id},
             "const": {"$ref": "const-data.schema.json"},
-            "enum": [{"$id": "enum-data"}],
+            "enum": [{"$id": enum_id}],
         },
     )
+    _write_schema(repo, default_target, {"$id": default_id, "type": "string"})
+    _write_schema(repo, enum_target, {"$id": enum_id, "type": "integer"})
     _git(repo, "add", "contracts")
     _git(repo, "commit", "-m", "add annotation data with schema-like keys")
 
@@ -228,7 +238,61 @@ def test_annotation_and_instance_values_are_not_traversed_as_subschemas(tmp_path
         == 0
     )
     manifest = json.loads((out_dir / MANIFEST_NAME).read_text(encoding="utf-8"))
-    assert set(manifest["schemas"]) == {schema_path}
+    assert set(manifest["schemas"]) == {schema_path, default_target, enum_target}
+
+
+def test_all_draft_2020_12_schema_keyword_shapes_are_traversed(tmp_path: Path) -> None:
+    repo = _source_repo(tmp_path)
+    root = "contracts/keyword-coverage/root.schema.json"
+    single_keywords = (
+        "additionalProperties",
+        "contains",
+        "contentSchema",
+        "else",
+        "if",
+        "items",
+        "not",
+        "propertyNames",
+        "then",
+        "unevaluatedItems",
+        "unevaluatedProperties",
+    )
+    array_keywords = ("allOf", "anyOf", "oneOf", "prefixItems")
+    map_keywords = ("$defs", "dependentSchemas", "patternProperties", "properties")
+    targets: set[str] = set()
+
+    def reference(keyword: str) -> dict[str, str]:
+        slug = keyword.removeprefix("$").lower()
+        target = f"contracts/resources/{slug}.schema.json"
+        targets.add(target)
+        _write_schema(repo, target, {"type": "null"})
+        return {"$ref": f"../resources/{slug}.schema.json"}
+
+    schema: dict[str, object] = {
+        keyword: reference(keyword) for keyword in single_keywords
+    }
+    schema.update({keyword: [reference(keyword)] for keyword in array_keywords})
+    schema.update({keyword: {"covered": reference(keyword)} for keyword in map_keywords})
+    _write_schema(repo, root, schema)
+    _git(repo, "add", "contracts")
+    _git(repo, "commit", "-m", "cover Draft 2020-12 schema keyword shapes")
+
+    out_dir = tmp_path / "keyword-coverage-archive"
+    assert (
+        run(
+            [
+                "--source",
+                str(repo),
+                "--out-dir",
+                str(out_dir),
+                "--consumer",
+                "keyword-coverage",
+            ]
+        )
+        == 0
+    )
+    manifest = json.loads((out_dir / MANIFEST_NAME).read_text(encoding="utf-8"))
+    assert set(manifest["schemas"]) == targets | {root}
 
 
 def test_missing_origin_is_a_repository_identity_failure(tmp_path: Path, capsys) -> None:


### PR DESCRIPTION
## Ausgangslage

Die finale Codex-Review von PR #710 traf erst nach dessen Merge ein und meldete drei zusätzliche materielle Fälle gegen den gemergten Head `dbc569fa78e738f0931e4c378f0d6d745d125d40`:

1. ambient `GIT_DIR` / `GIT_WORK_TREE` / weitere `GIT_*`-Overrides können provenance-relevante Git-Aufrufe auf ein anderes Repository umlenken;
2. die Schemaressourcen-Traversierung interpretiert beliebige JSON-Werte unter Annotationen/Instanzkeywords wie `examples`, `default`, `const`, `enum` fälschlich als Subschemas;
3. ein fehlender `remote.origin.url` wird als `SOURCE_NOT_GIT` statt als Repository-Identitätsfehler klassifiziert.

## Vorgehen

Dieser PR beginnt mit drei reproduzierenden Regressionstests. Der Produktfix soll anschließend:

- Git-Subprozesse an die explizit benannte Quelle binden, indem ambient repository/config `GIT_*`-Overrides entfernt werden; `GIT_NO_REPLACE_OBJECTS=1` bleibt explizit gesetzt;
- Draft-2020-12-Ressourcen nur an schemawertigen Keywordpositionen traversieren;
- einen fehlenden Origin fail-closed als `SOURCE_WRONG_REPOSITORY` behandeln.

Bestehende Replacement-Ref-, `$id`-/`$ref`-, Commit-Blob- und Cache-Invarianten dürfen nicht abgeschwächt werden.

Bezug: heimgewebe/metarepo#710, nachgelagerte Reviewthreads `PRRT_kwDOP7-dLM6YM8DL`, `PRRT_kwDOP7-dLM6YM8DQ`, `PRRT_kwDOP7-dLM6YM8DT`.