### PR TITLE
Fail closed on ambiguous contract example schemas

### DIFF
--- a/scripts/validate-contracts.sh
+++ b/scripts/validate-contracts.sh
@@ -210,9 +210,8 @@ else
         c_dir=$(dirname "$c")
         # Check if c_dir ends with rel_dir
         if [[ -z "$rel_dir" ]]; then
-          # If rel_dir is empty (root example), prefer root schema or 'contracts/events' (historical)
-          # We check if schema is in root 'contracts' or direct subfolder 'contracts/events'
-          # Simple heuristic: shorter path wins for root examples
+          # Root examples carry no directory evidence, so every same-name
+          # schema remains a candidate and ambiguity must be handled below.
           matched_candidates+=("$c")
         else
           # Check if path contains rel_dir
@@ -227,14 +226,12 @@ else
         found=("${matched_candidates[@]}")
       fi
 
-      # If still multiple, pick shortest path
       if ((${#found[@]} == 1)); then
         final_candidate="${found[0]}"
       else
-        # Sort by length
-        sorted=$(printf '%s\n' "${found[@]}" | awk '{ print length, $0 }' | sort -n | cut -d" " -f2-)
-        # Pick first
-        final_candidate=$(echo "$sorted" | head -n1)
+        echo "::error::Ambiguous schema match for ${example}. Found multiple candidates:"
+        printf '  - %s\n' "${found[@]}"
+        exit 2
       fi
     fi
 

--- a/tests/test_contract_validator_toolchain.py
+++ b/tests/test_contract_validator_toolchain.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 import subprocess
 
@@ -43,6 +44,65 @@ def _locked_package_names(lock: dict[str, object]) -> set[str]:
     return names
 
 
+def _write_executable(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+    path.chmod(0o755)
+
+
+def _contract_validator_fixture(tmp_path: Path) -> tuple[Path, dict[str, str]]:
+    repo = tmp_path / "repo"
+    (repo / "scripts/contracts").mkdir(parents=True)
+    (repo / "contracts/examples").mkdir(parents=True)
+
+    validator = repo / "scripts/validate-contracts.sh"
+    validator.write_text(VALIDATE_SCRIPT.read_text(encoding="utf-8"), encoding="utf-8")
+    validator.chmod(0o755)
+    (repo / "scripts/contracts/ajv_validate.cjs").write_text("// test stub\n", encoding="utf-8")
+    (repo / "scripts/check-contract-json.py").write_text("# test stub\n", encoding="utf-8")
+    (repo / "scripts/contracts/validate_consumers.py").write_text("# test stub\n", encoding="utf-8")
+    (repo / "contracts/package.json").write_text("{}\n", encoding="utf-8")
+    (repo / "contracts/package-lock.json").write_text("{}\n", encoding="utf-8")
+
+    fake_bin = repo / "fake-bin"
+    _write_executable(fake_bin / "npm", "#!/usr/bin/env bash\nexit 0\n")
+    _write_executable(fake_bin / "python3", "#!/usr/bin/env bash\nexit 0\n")
+    _write_executable(fake_bin / "uv", "#!/usr/bin/env bash\nexit 0\n")
+    _write_executable(
+        fake_bin / "node",
+        """#!/usr/bin/env bash
+if [[ "${1:-}" == "-p" ]]; then
+  case "${3:-}" in
+    *ajv-formats/package.json) printf '%s\\n' '3.0.1' ;;
+    *) printf '%s\\n' '8.20.0' ;;
+  esac
+fi
+exit 0
+""",
+    )
+
+    env = os.environ.copy()
+    env["PATH"] = f"{fake_bin}:/usr/bin:/bin"
+    return repo, env
+
+
+def _write_schema(repo: Path, relative_path: str, schema_id: str) -> None:
+    schema = repo / relative_path
+    schema.parent.mkdir(parents=True, exist_ok=True)
+    schema.write_text(json.dumps({"$id": schema_id, "type": "object"}) + "\n", encoding="utf-8")
+
+
+def _run_contract_validator(repo: Path, env: dict[str, str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["bash", "scripts/validate-contracts.sh"],
+        cwd=repo,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
 def test_contract_manifest_uses_direct_pinned_ajv_runtime() -> None:
     package = _load_json(PACKAGE_JSON)
 
@@ -69,6 +129,35 @@ def test_contract_orchestrator_invokes_lock_bound_direct_runner() -> None:
     assert "npm ci --prefix" in script
     assert "npm install --prefix" not in script
     assert 'node "$AJV_RUNNER"' in script
+
+
+def test_contract_examples_fail_closed_on_ambiguous_schema_matches(tmp_path: Path) -> None:
+    repo, env = _contract_validator_fixture(tmp_path)
+    (repo / "contracts/examples/widget.example.json").write_text("{}\n", encoding="utf-8")
+    _write_schema(repo, "contracts/alpha/widget.schema.json", "urn:test:alpha:widget")
+    _write_schema(repo, "contracts/beta/widget.schema.json", "urn:test:beta:widget")
+
+    completed = _run_contract_validator(repo, env)
+
+    assert completed.returncode == 2
+    assert "Ambiguous schema match for contracts/examples/widget.example.json" in completed.stdout
+    assert "contracts/alpha/widget.schema.json" in completed.stdout
+    assert "contracts/beta/widget.schema.json" in completed.stdout
+
+
+def test_contract_examples_keep_unique_directory_disambiguation(tmp_path: Path) -> None:
+    repo, env = _contract_validator_fixture(tmp_path)
+    example = repo / "contracts/examples/alpha/widget.example.json"
+    example.parent.mkdir(parents=True)
+    example.write_text("{}\n", encoding="utf-8")
+    _write_schema(repo, "contracts/alpha/widget.schema.json", "urn:test:alpha:widget")
+    _write_schema(repo, "contracts/beta/widget.schema.json", "urn:test:beta:widget")
+
+    completed = _run_contract_validator(repo, env)
+
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+    assert "Validate Example contracts/examples/alpha/widget.example.json" in completed.stdout
+    assert "Ambiguous schema match" not in completed.stdout
 
 
 def test_direct_ajv_runner_is_valid_javascript() -> None:


### PR DESCRIPTION
## Summary
- fail closed when multiple same-name schemas remain after directory disambiguation for contract examples
- preserve successful unique directory-based schema selection
- add regression coverage for ambiguous and unambiguous cases

## Validation
- `python3 -m pytest -q tests/test_contract_validator_toolchain.py` — 7 passed
- `bash scripts/validate-contracts.sh` — passed; consumer registry valid
- `bash -n scripts/validate-contracts.sh` — passed
- `python3 -m ruff check tests/test_contract_validator_toolchain.py` — passed
- `git diff --check` — passed