### PR TITLE
Harden ai-context guidance validation

### DIFF
--- a/scripts/ai_context/README.md
+++ b/scripts/ai_context/README.md
@@ -7,7 +7,7 @@ Validiert `.ai-context.yml` (Repo-Root) und optional Templates unter `ai-context
 ### Was wird geprüft?
 - YAML parsebar
 - `project.name`, `project.summary`, `project.role` vorhanden und nicht leer
-- `ai_guidance.do` und `ai_guidance.dont` vorhanden und nicht leer
+- `ai_guidance.do` und `ai_guidance.dont` sind nicht leere Listen aus nicht leeren Strings
 - keine offensichtlichen Platzhalter: TODO / TBD / FIXME / lorem / ipsum
 
 ### Rollout-Logik (Patch in alle Repos einspeisen)

--- a/scripts/ai_context/validate_ai_context.py
+++ b/scripts/ai_context/validate_ai_context.py
@@ -2,8 +2,8 @@
 from __future__ import annotations
 
 import argparse
-import sys
 import re
+import sys
 from pathlib import Path
 from typing import Any, Dict, List, Tuple
 
@@ -39,22 +39,32 @@ def load_yaml(p: Path) -> Dict[str, Any]:
     return data
 
 
+def get_value(d: Dict[str, Any], path: str) -> Any:
+    cur: Any = d
+    for k in path.split("."):
+        if not isinstance(cur, dict) or k not in cur:
+            return None
+        cur = cur[k]
+    return cur
+
+
 def get_str(d: Dict[str, Any], path: str) -> str:
-    cur: Any = d
-    for k in path.split("."):
-        if not isinstance(cur, dict) or k not in cur:
-            return ""
-        cur = cur[k]
-    return cur if isinstance(cur, str) else ""
+    value = get_value(d, path)
+    return value if isinstance(value, str) else ""
 
 
-def get_list(d: Dict[str, Any], path: str) -> List[Any]:
-    cur: Any = d
-    for k in path.split("."):
-        if not isinstance(cur, dict) or k not in cur:
-            return []
-        cur = cur[k]
-    return cur if isinstance(cur, list) else []
+def validate_non_empty_string_list(d: Dict[str, Any], path: str) -> List[str]:
+    value = get_value(d, path)
+    if not isinstance(value, list):
+        return [f"{path} must be a non-empty list of non-empty strings"]
+    if not value:
+        return [f"{path} must not be empty"]
+
+    return [
+        f"{path}[{index}] must be a non-empty string"
+        for index, item in enumerate(value)
+        if not isinstance(item, str) or not item.strip()
+    ]
 
 
 def has_placeholders(obj: Any) -> bool:
@@ -84,12 +94,8 @@ def validate_one(p: Path) -> List[str]:
     if not role.strip():
         errs.append("missing project.role")
 
-    do = get_list(d, "ai_guidance.do")
-    dont = get_list(d, "ai_guidance.dont")
-    if not do:
-        errs.append("ai_guidance.do must not be empty")
-    if not dont:
-        errs.append("ai_guidance.dont must not be empty")
+    errs.extend(validate_non_empty_string_list(d, "ai_guidance.do"))
+    errs.extend(validate_non_empty_string_list(d, "ai_guidance.dont"))
 
     if has_placeholders(d):
         errs.append("contains placeholders (TODO/TBD/FIXME/lorem/ipsum)")

--- a/tests/test_ai_context_validator.py
+++ b/tests/test_ai_context_validator.py
@@ -1,0 +1,66 @@
+import json
+
+import pytest
+
+from scripts.ai_context.validate_ai_context import validate_one
+
+
+def _write_context(tmp_path, *, do=None, dont=None):
+    payload = {
+        "project": {
+            "name": "example",
+            "summary": "Example repository",
+            "role": "test",
+        },
+        "ai_guidance": {
+            "do": ["Keep changes focused"] if do is None else do,
+            "dont": ["Change unrelated files"] if dont is None else dont,
+        },
+    }
+    path = tmp_path / ".ai-context.yml"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def test_accepts_non_empty_string_guidance(tmp_path) -> None:
+    path = _write_context(
+        tmp_path,
+        do=["  Keep changes focused  "],
+        dont=["Avoid unrelated changes"],
+    )
+
+    assert validate_one(path) == []
+
+
+@pytest.mark.parametrize("field", ["do", "dont"])
+def test_rejects_empty_guidance_lists(tmp_path, field) -> None:
+    kwargs = {field: []}
+    path = _write_context(tmp_path, **kwargs)
+
+    assert f"ai_guidance.{field} must not be empty" in validate_one(path)
+
+
+@pytest.mark.parametrize("field", ["do", "dont"])
+def test_rejects_non_list_guidance(tmp_path, field) -> None:
+    kwargs = {field: "single rule"}
+    path = _write_context(tmp_path, **kwargs)
+
+    assert (
+        f"ai_guidance.{field} must be a non-empty list of non-empty strings"
+        in validate_one(path)
+    )
+
+
+@pytest.mark.parametrize("bad_value", [None, 42, {"rule": "nested"}, ["nested"]])
+def test_rejects_non_string_guidance_entries(tmp_path, bad_value) -> None:
+    path = _write_context(tmp_path, do=[bad_value])
+
+    assert "ai_guidance.do[0] must be a non-empty string" in validate_one(path)
+
+
+@pytest.mark.parametrize("field", ["do", "dont"])
+def test_rejects_blank_guidance_entries(tmp_path, field) -> None:
+    kwargs = {field: [" \t "]}
+    path = _write_context(tmp_path, **kwargs)
+
+    assert f"ai_guidance.{field}[0] must be a non-empty string" in validate_one(path)


### PR DESCRIPTION
## Summary
- require `ai_guidance.do` and `ai_guidance.dont` to be non-empty lists of non-empty strings
- report indexed, actionable errors for invalid guidance entries
- add focused regression coverage and align the validator README with the enforced contract

## Local validation
- `python3 -m pytest -q tests/test_ai_context_validator.py` — 11 passed
- `python3 scripts/ai_context/validate_ai_context.py --file .ai-context.yml --templates-dir ai-contexts` — pass
- `python3 -m ruff check scripts/ai_context/validate_ai_context.py tests/test_ai_context_validator.py` — pass
- `git diff --check` — pass

A host-wide raw `python3 -m pytest -q` is not authoritative here because the default interpreter is Python 3.10 and fails during unrelated collection on `tomllib`; `uv run` is additionally blocked by the host's read-only UV cache. Full repository validation is therefore delegated to the normal GitHub CI environment.