### PR TITLE
fix(tests): keep Python 3.10 TOML compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
 dev = [
   "jsonschema>=4.25.1",
   "pytest>=7.0.0",
+  "tomli>=2.0.1; python_version < '3.11'",
 ]
 
 [build-system]

--- a/tests/test_agent_kit_security_dependencies.py
+++ b/tests/test_agent_kit_security_dependencies.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
-import tomllib
 from pathlib import Path
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # Python 3.10 compatibility
+    import tomli as tomllib
 
 
 ROOT = Path(__file__).resolve().parents[1]

--- a/uv.lock
+++ b/uv.lock
@@ -80,6 +80,7 @@ dependencies = [
 dev = [
     { name = "jsonschema" },
     { name = "pytest" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
 
 [package.metadata]
@@ -89,6 +90,7 @@ requires-dist = [{ name = "pyyaml", specifier = ">=6.0.1" }]
 dev = [
     { name = "jsonschema", specifier = ">=4.25.1" },
     { name = "pytest", specifier = ">=7.0.0" },
+    { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.0.1" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Problem
The root project declares Python >=3.10, but tests/test_agent_kit_security_dependencies.py imported tomllib unconditionally, so the suite failed during collection on Python 3.10.

## Change
- fall back to tomli on Python 3.10
- declare tomli only for python_version < 3.11 in the dev group
- refresh uv.lock without changing package versions

## Verification
- targeted Python 3.10 test: 2 passed
- full Python 3.10 suite with isolated uv/Node runtime: 305 passed
- git diff --check: pass