### PR TITLE
fix(renovate): bind RepoGround lock generation

### DIFF
--- a/automation/renovate/repoground-lock-coupling.sh
+++ b/automation/renovate/repoground-lock-coupling.sh
@@ -5,9 +5,9 @@ repo_root="$(git rev-parse --show-toplevel)"
 cd "$repo_root"
 
 origin="$(git config --get remote.origin.url || true)"
-if [[ ! "$origin" =~ ^https://([^/@]+@)?github\.com/heimgewebe/repoground(\.git)?$ ]] \
-  && [[ ! "$origin" =~ ^git@github\.com:heimgewebe/repoground(\.git)?$ ]] \
-  && [[ ! "$origin" =~ ^ssh://git@github\.com/heimgewebe/repoground(\.git)?$ ]]; then
+if [[ ! "$origin" =~ ^https://([^/@]+@)?github\.com/heimgewebe/repoground(\.git)?$ ]] &&
+  [[ ! "$origin" =~ ^git@github\.com:heimgewebe/repoground(\.git)?$ ]] &&
+  [[ ! "$origin" =~ ^ssh://git@github\.com/heimgewebe/repoground(\.git)?$ ]]; then
   echo "RepoGround lock coupling refused: current repository is not heimgewebe/repoground" >&2
   exit 2
 fi
@@ -15,7 +15,7 @@ fi
 needs_lock_refresh=false
 while IFS= read -r path; do
   case "$path" in
-    requirements*.txt|requirements/*)
+    requirements*.txt | requirements/*)
       needs_lock_refresh=true
       break
       ;;

--- a/automation/renovate/repoground-lock-coupling.sh
+++ b/automation/renovate/repoground-lock-coupling.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+origin="$(git config --get remote.origin.url || true)"
+if [[ ! "$origin" =~ ^https://([^/@]+@)?github\.com/heimgewebe/repoground(\.git)?$ ]] \
+  && [[ ! "$origin" =~ ^git@github\.com:heimgewebe/repoground(\.git)?$ ]] \
+  && [[ ! "$origin" =~ ^ssh://git@github\.com/heimgewebe/repoground(\.git)?$ ]]; then
+  echo "RepoGround lock coupling refused: current repository is not heimgewebe/repoground" >&2
+  exit 2
+fi
+
+needs_lock_refresh=false
+while IFS= read -r path; do
+  case "$path" in
+    requirements*.txt|requirements/*)
+      needs_lock_refresh=true
+      break
+      ;;
+  esac
+done < <(git diff --name-only --diff-filter=ACMRTUXB HEAD --)
+
+if [[ "$needs_lock_refresh" != true ]]; then
+  echo "RepoGround lock coupling: no Python requirement change; nothing to regenerate"
+  exit 0
+fi
+
+generator="scripts/release/compile_dependency_locks.sh"
+if [[ ! -f "$generator" ]]; then
+  echo "RepoGround lock coupling refused: canonical generator is missing" >&2
+  exit 2
+fi
+
+bash "$generator"
+bash "$generator" --check

--- a/automation/renovate/runtime-config.cjs
+++ b/automation/renovate/runtime-config.cjs
@@ -21,4 +21,7 @@ module.exports = {
   requireConfig: "optional",
   forkProcessing: "disabled",
   platformCommit: "enabled",
+  allowedCommands: [
+    "^bash /home/alex/\\.local/share/renovate-fleet/current/automation/renovate/repoground-lock-coupling\\.sh$",
+  ],
 };

--- a/tests/test_renovate_repoground_lock_coupling.py
+++ b/tests/test_renovate_repoground_lock_coupling.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WRAPPER = ROOT / "automation" / "renovate" / "repoground-lock-coupling.sh"
+RUNTIME_CONFIG = ROOT / "automation" / "renovate" / "runtime-config.cjs"
+EXPECTED_COMMAND = (
+    "bash /home/alex/.local/share/renovate-fleet/current/automation/renovate/"
+    "repoground-lock-coupling.sh"
+)
+
+
+def _git(repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+
+
+def _repo(tmp_path: Path, *, origin: str = "https://github.com/heimgewebe/repoground.git") -> Path:
+    repo = tmp_path / "repoground"
+    repo.mkdir()
+    _git(repo, "init")
+    _git(repo, "config", "user.email", "test@example.invalid")
+    _git(repo, "config", "user.name", "test")
+    _git(repo, "remote", "add", "origin", origin)
+
+    (repo / "requirements-dev.txt").write_text("ruff==0.16.3\n", encoding="utf-8")
+    (repo / "README.md").write_text("baseline\n", encoding="utf-8")
+    generator = repo / "scripts" / "release" / "compile_dependency_locks.sh"
+    generator.parent.mkdir(parents=True)
+    generator.write_text(
+        "#!/usr/bin/env bash\n"
+        "set -euo pipefail\n"
+        "printf '%s\\n' \"${1:-generate}\" >> \"${CALLS_FILE:?}\"\n"
+        "if [[ \"${FAIL_GENERATE:-0}\" == 1 && $# -eq 0 ]]; then exit 17; fi\n",
+        encoding="utf-8",
+    )
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", "baseline")
+    return repo
+
+
+def _run(repo: Path, calls: Path, **extra_env: str) -> subprocess.CompletedProcess[str]:
+    env = {**os.environ, "CALLS_FILE": str(calls), **extra_env}
+    return subprocess.run(
+        ["bash", str(WRAPPER)],
+        cwd=repo,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def test_runtime_allows_only_exact_repoground_lock_coupling_command() -> None:
+    completed = subprocess.run(
+        [
+            "node",
+            "-e",
+            "const c=require(process.argv[1]); process.stdout.write(JSON.stringify(c.allowedCommands));",
+            str(RUNTIME_CONFIG),
+        ],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    patterns = json.loads(completed.stdout)
+    assert patterns == [
+        "^bash /home/alex/\\.local/share/renovate-fleet/current/automation/renovate/"
+        "repoground-lock-coupling\\.sh$"
+    ]
+    assert __import__("re").fullmatch(patterns[0], EXPECTED_COMMAND)
+
+
+def test_requirement_update_runs_canonical_generator_then_read_only_check(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    calls = tmp_path / "calls"
+    (repo / "requirements-dev.txt").write_text("ruff==0.16.4\n", encoding="utf-8")
+    _git(repo, "add", "requirements-dev.txt")
+
+    completed = _run(repo, calls)
+
+    assert completed.returncode == 0, completed.stderr
+    assert calls.read_text(encoding="utf-8").splitlines() == ["generate", "--check"]
+
+
+def test_unrelated_update_does_not_run_lock_generator(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    calls = tmp_path / "calls"
+    (repo / "README.md").write_text("changed\n", encoding="utf-8")
+
+    completed = _run(repo, calls)
+
+    assert completed.returncode == 0, completed.stderr
+    assert not calls.exists()
+    assert "no Python requirement change" in completed.stdout
+
+
+def test_generator_failure_stops_before_read_only_check(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    calls = tmp_path / "calls"
+    (repo / "requirements-dev.txt").write_text("ruff==0.16.4\n", encoding="utf-8")
+
+    completed = _run(repo, calls, FAIL_GENERATE="1")
+
+    assert completed.returncode == 17
+    assert calls.read_text(encoding="utf-8").splitlines() == ["generate"]
+
+
+def test_non_repoground_repository_is_rejected_before_repository_code_runs(tmp_path: Path) -> None:
+    repo = _repo(tmp_path, origin="https://github.com/heimgewebe/audio.git")
+    calls = tmp_path / "calls"
+    (repo / "requirements-dev.txt").write_text("ruff==0.16.4\n", encoding="utf-8")
+
+    completed = _run(repo, calls)
+
+    assert completed.returncode == 2
+    assert not calls.exists()
+    assert "not heimgewebe/repoground" in completed.stderr


### PR DESCRIPTION
## Zweck

Schließt die reale RepoGround-Renovate-Lücke aus PR #1297: ein Dependency-Input konnte zunächst ohne den kanonisch regenerierten Hash-Lock vorgeschlagen werden.

## Änderung

- erlaubt global im self-hosted Renovate exakt einen festen RepoGround-Lock-Coupling-Befehl;
- Wrapper verweigert Nicht-RepoGround-Checkouts;
- bei Requirements-Änderungen läuft ausschließlich `scripts/release/compile_dependency_locks.sh` und danach `--check`;
- Generator- oder Reproduzierbarkeitsfehler propagieren fail-closed vor Renovates Commit;
- keine Merge-, Automerge- oder Direct-main-Autorität wird erweitert.

## Verifikation

- fokussierte Renovate-Tests: 23/23 grün;
- `ALLOW_NET=1 just validate`: lokale Validierung grün, 299/299 Python-Tests grün;
- exakte Command-Allowlist, Repo-Identität, No-op und Failure-Propagation sind regressionsgetestet.

Voraussetzung für die gekoppelte RepoGround-Seite des Bureau-Tasks `REPOGROUND-LEGACY-RECONCILIATION-V1-FU-RENOVATE-LOCK-COUPLING-20260824`.