### PR TITLE
fix(renovate): allow RepoGround workflow refresh

### DIFF
--- a/automation/renovate/repoground-workflow-refresh.sh
+++ b/automation/renovate/repoground-workflow-refresh.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+origin="$(git config --get remote.origin.url || true)"
+if [[ ! "$origin" =~ ^https://([^/@]+@)?github\.com/heimgewebe/repoground(\.git)?$ ]] &&
+  [[ ! "$origin" =~ ^git@github\.com:heimgewebe/repoground(\.git)?$ ]] &&
+  [[ ! "$origin" =~ ^ssh://git@github\.com/heimgewebe/repoground(\.git)?$ ]]; then
+  echo "RepoGround workflow refresh refused: current repository is not heimgewebe/repoground" >&2
+  exit 2
+fi
+
+refresh="scripts/ci/refresh_workflow_control_plane.py"
+if [[ ! -f "$refresh" ]]; then
+  echo "RepoGround workflow refresh refused: canonical refresh script is missing" >&2
+  exit 2
+fi
+
+python3 "$refresh"

--- a/automation/renovate/runtime-config.cjs
+++ b/automation/renovate/runtime-config.cjs
@@ -23,6 +23,6 @@ module.exports = {
   platformCommit: "enabled",
   allowedCommands: [
     "^bash /home/alex/\\.local/share/renovate-fleet/current/automation/renovate/repoground-lock-coupling\\.sh$",
-    "^python3 scripts/ci/refresh_workflow_control_plane\\.py$",
+    "^bash /home/alex/\\.local/share/renovate-fleet/current/automation/renovate/repoground-workflow-refresh\\.sh$",
   ],
 };

--- a/automation/renovate/runtime-config.cjs
+++ b/automation/renovate/runtime-config.cjs
@@ -23,5 +23,6 @@ module.exports = {
   platformCommit: "enabled",
   allowedCommands: [
     "^bash /home/alex/\\.local/share/renovate-fleet/current/automation/renovate/repoground-lock-coupling\\.sh$",
+    "^python3 scripts/ci/refresh_workflow_control_plane\\.py$",
   ],
 };

--- a/tests/test_renovate_repoground_lock_coupling.py
+++ b/tests/test_renovate_repoground_lock_coupling.py
@@ -60,7 +60,7 @@ def _run(repo: Path, calls: Path, **extra_env: str) -> subprocess.CompletedProce
     )
 
 
-def test_runtime_allows_only_exact_repoground_lock_coupling_command() -> None:
+def test_runtime_keeps_exact_repoground_lock_coupling_command() -> None:
     completed = subprocess.run(
         [
             "node",
@@ -74,11 +74,12 @@ def test_runtime_allows_only_exact_repoground_lock_coupling_command() -> None:
         check=True,
     )
     patterns = json.loads(completed.stdout)
-    assert patterns == [
+    expected_pattern = (
         "^bash /home/alex/\\.local/share/renovate-fleet/current/automation/renovate/"
         "repoground-lock-coupling\\.sh$"
-    ]
-    assert __import__("re").fullmatch(patterns[0], EXPECTED_COMMAND)
+    )
+    assert expected_pattern in patterns
+    assert __import__("re").fullmatch(expected_pattern, EXPECTED_COMMAND)
 
 
 def test_requirement_update_runs_canonical_generator_then_read_only_check(tmp_path: Path) -> None:

--- a/tests/test_renovate_repoground_workflow_refresh.py
+++ b/tests/test_renovate_repoground_workflow_refresh.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WRAPPER = ROOT / "automation" / "renovate" / "repoground-workflow-refresh.sh"
+
+
+def _git(repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+
+
+def _repo(tmp_path: Path, *, origin: str = "https://github.com/heimgewebe/repoground.git") -> Path:
+    repo = tmp_path / "repoground"
+    repo.mkdir()
+    _git(repo, "init")
+    _git(repo, "config", "user.email", "test@example.invalid")
+    _git(repo, "config", "user.name", "test")
+    _git(repo, "remote", "add", "origin", origin)
+
+    refresh = repo / "scripts" / "ci" / "refresh_workflow_control_plane.py"
+    refresh.parent.mkdir(parents=True)
+    refresh.write_text(
+        "from pathlib import Path\n"
+        "import os\n"
+        "Path(os.environ['CALLS_FILE']).write_text('refresh\\n', encoding='utf-8')\n",
+        encoding="utf-8",
+    )
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", "baseline")
+    return repo
+
+
+def _run(repo: Path, calls: Path) -> subprocess.CompletedProcess[str]:
+    env = {**os.environ, "CALLS_FILE": str(calls)}
+    return subprocess.run(
+        ["bash", str(WRAPPER)],
+        cwd=repo,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def test_repoground_repository_runs_canonical_workflow_refresh(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    calls = tmp_path / "calls"
+
+    completed = _run(repo, calls)
+
+    assert completed.returncode == 0, completed.stderr
+    assert calls.read_text(encoding="utf-8") == "refresh\n"
+
+
+def test_non_repoground_repository_is_rejected_before_repository_code_runs(tmp_path: Path) -> None:
+    repo = _repo(tmp_path, origin="https://github.com/heimgewebe/audio.git")
+    calls = tmp_path / "calls"
+
+    completed = _run(repo, calls)
+
+    assert completed.returncode == 2
+    assert not calls.exists()
+    assert "not heimgewebe/repoground" in completed.stderr
+
+
+def test_missing_canonical_refresh_script_fails_closed(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    calls = tmp_path / "calls"
+    (repo / "scripts" / "ci" / "refresh_workflow_control_plane.py").unlink()
+
+    completed = _run(repo, calls)
+
+    assert completed.returncode == 2
+    assert not calls.exists()
+    assert "canonical refresh script is missing" in completed.stderr

--- a/tests/test_renovate_runtime_allowed_commands.py
+++ b/tests/test_renovate_runtime_allowed_commands.py
@@ -30,17 +30,17 @@ def _runtime_command_matches(commands: list[str]) -> dict[str, object]:
 def test_runtime_allows_only_exact_repoground_post_upgrade_commands() -> None:
     commands = [
         "bash /home/alex/.local/share/renovate-fleet/current/automation/renovate/repoground-lock-coupling.sh",
+        "bash /home/alex/.local/share/renovate-fleet/current/automation/renovate/repoground-workflow-refresh.sh",
         "python3 scripts/ci/refresh_workflow_control_plane.py",
-        "python3 scripts/ci/refresh_workflow_control_plane.py --root .",
-        "python scripts/ci/refresh_workflow_control_plane.py",
-        "python3 ./scripts/ci/refresh_workflow_control_plane.py",
-        "bash -lc 'python3 scripts/ci/refresh_workflow_control_plane.py'",
+        "bash /home/alex/.local/share/renovate-fleet/current/automation/renovate/repoground-workflow-refresh.sh --root .",
+        "bash automation/renovate/repoground-workflow-refresh.sh",
+        "bash -lc '/home/alex/.local/share/renovate-fleet/current/automation/renovate/repoground-workflow-refresh.sh'",
     ]
 
     resolved = _runtime_command_matches(commands)
 
     assert resolved["allowedCommands"] == [
         r"^bash /home/alex/\.local/share/renovate-fleet/current/automation/renovate/repoground-lock-coupling\.sh$",
-        r"^python3 scripts/ci/refresh_workflow_control_plane\.py$",
+        r"^bash /home/alex/\.local/share/renovate-fleet/current/automation/renovate/repoground-workflow-refresh\.sh$",
     ]
     assert resolved["matches"] == [True, True, False, False, False, False]

--- a/tests/test_renovate_runtime_allowed_commands.py
+++ b/tests/test_renovate_runtime_allowed_commands.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+RUNTIME_CONFIG = ROOT / "automation" / "renovate" / "runtime-config.cjs"
+
+
+def _runtime_command_matches(commands: list[str]) -> dict[str, object]:
+    script = (
+        "const config = require(process.argv[1]); "
+        "const commands = process.argv.slice(2); "
+        "const matches = commands.map((command) => "
+        "config.allowedCommands.some((pattern) => new RegExp(pattern).test(command))); "
+        "process.stdout.write(JSON.stringify({allowedCommands: config.allowedCommands, matches}));"
+    )
+    completed = subprocess.run(
+        ["node", "-e", script, str(RUNTIME_CONFIG), *commands],
+        check=True,
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+    )
+    return json.loads(completed.stdout)
+
+
+def test_runtime_allows_only_exact_repoground_post_upgrade_commands() -> None:
+    commands = [
+        "bash /home/alex/.local/share/renovate-fleet/current/automation/renovate/repoground-lock-coupling.sh",
+        "python3 scripts/ci/refresh_workflow_control_plane.py",
+        "python3 scripts/ci/refresh_workflow_control_plane.py --root .",
+        "python scripts/ci/refresh_workflow_control_plane.py",
+        "python3 ./scripts/ci/refresh_workflow_control_plane.py",
+        "bash -lc 'python3 scripts/ci/refresh_workflow_control_plane.py'",
+    ]
+
+    resolved = _runtime_command_matches(commands)
+
+    assert resolved["allowedCommands"] == [
+        r"^bash /home/alex/\.local/share/renovate-fleet/current/automation/renovate/repoground-lock-coupling\.sh$",
+        r"^python3 scripts/ci/refresh_workflow_control_plane\.py$",
+    ]
+    assert resolved["matches"] == [True, True, False, False, False, False]


### PR DESCRIPTION
## Ziel

RepoGround PR #1301 koppelt Renovate-GitHub-Actions-Updates an den bestehenden Offline-Refresh der Workflow-Control-Plane. Die selbst gehostete Renovate-Runtime darf diesen Repo-Code jedoch nicht direkt global freigeben.

## Änderung

- erlaubt ausschließlich den absolut adressierten, Fleet-installierten Wrapper `repoground-workflow-refresh.sh`;
- der Wrapper validiert vor Ausführung die Repository-Origin als `heimgewebe/repoground`;
- Fremd-Repositories und ein fehlendes kanonisches Refresh-Skript werden fail-closed abgewiesen;
- der bestehende RepoGround-Lock-Coupling-Wrapper bleibt unverändert;
- Tests beweisen sowohl den erlaubten RepoGround-Pfad als auch die enge `allowedCommands`-Grenze.

## Validierung

- vollständiger lokaler Testlauf: `314 passed`;
- Ruff auf den betroffenen Python-Tests: grün;
- GitHub-CI am exakten Head `1dc1b1e1fcae573d3a8ec3e2f2c4ab35d510f2aa`: 7/7 Workflows grün;
- P1-Review zur direkten Ausführung repo-kontrollierten Codes behoben und Thread aufgelöst.

## Integrationsvertrag

Nach dem Merge muss die exakte gemergte Metarepo-Revision in die Renovate-Fleet deployed werden. Vor dem Merge von RepoGround #1301 werden aktive Fleet-Revision, `runtime-config.cjs` und der installierte Wrapper zurückgelesen.